### PR TITLE
Fix marketplace deletion and logging

### DIFF
--- a/discord-bot/src/Infrastructure/Bot/Discord/DiscordBot.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/DiscordBot.ts
@@ -41,7 +41,7 @@ export class DiscordBot implements Bot {
             try {
                 await this.botExecutor.execute(slashCommandContext)
             } catch (error: any) {
-                this.logger.error('error happened' , error);
+                this.logger.error('error happened', { error });
                 if (interaction.replied || interaction.deferred) {
                     await interaction.followUp({ content: 'There was an error while executing this command!', flags: MessageFlags.Ephemeral });
                 } else {

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/DeleteAdSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/DeleteAdSubcommand.ts
@@ -1,9 +1,10 @@
-import { inject, injectable } from 'inversify'
-import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerManager'
-import { DeleteAd } from '../../../../../Application/Write/Marketplace/DeleteAd/DeleteAd'
-import { AdId } from '../../../../../Domain/Marketplace/AdId'
-import { UnauthorizedAdDeletion } from '../../../../../Domain/Marketplace/UnauthorizedAdDeletion'
-import RecordNotFound from '../../../../../Domain/RecordNotFound'
+import { inject, injectable } from 'inversify';
+import type { SlashCommandContext } from '../../../../../Domain/Bot/SlashCommandContext';
+import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerManager';
+import { DeleteAd } from '../../../../../Application/Write/Marketplace/DeleteAd/DeleteAd';
+import { AdId } from '../../../../../Domain/Marketplace/AdId';
+import { UnauthorizedAdDeletion } from '../../../../../Domain/Marketplace/UnauthorizedAdDeletion';
+import RecordNotFound from '../../../../../Domain/RecordNotFound';
 
 @injectable()
 export class DeleteAdSubcommand {
@@ -11,7 +12,8 @@ export class DeleteAdSubcommand {
     @inject(CommandHandlerManager) private readonly commandHandlerManager: CommandHandlerManager
   ) {}
 
-  public async handle(interaction: any): Promise<void> {
+  public async handle(context: SlashCommandContext): Promise<void> {
+    const interaction = context.interaction
     const adId = AdId.fromString(interaction.options.getString('id', true))
     const userId = interaction.user.id
 


### PR DESCRIPTION
## Summary
- ensure DeleteAd subcommand expects `SlashCommandContext`
- include error object in Discord bot logs

## Testing
- `bun test` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_685fbb979ca4832eb5c7e2643812274b