### PR TITLE
Improve ad deletion UX

### DIFF
--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/DeleteAdSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/DeleteAdSubcommand.ts
@@ -2,9 +2,12 @@ import { inject, injectable } from 'inversify';
 import type { SlashCommandContext } from '../../../../../Domain/Bot/SlashCommandContext';
 import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerManager';
 import { DeleteAd } from '../../../../../Application/Write/Marketplace/DeleteAd/DeleteAd';
+import { ListUserAds } from '../../../../../Application/Query/Marketplace/ListUserAds/ListUserAds';
 import { AdId } from '../../../../../Domain/Marketplace/AdId';
 import { UnauthorizedAdDeletion } from '../../../../../Domain/Marketplace/UnauthorizedAdDeletion';
 import RecordNotFound from '../../../../../Domain/RecordNotFound';
+import { InvalidId } from '../../../../../Domain/InvalidId';
+import type { Ad } from '../../../../../Domain/Marketplace/Ad';
 
 @injectable()
 export class DeleteAdSubcommand {
@@ -14,25 +17,46 @@ export class DeleteAdSubcommand {
 
   public async handle(context: SlashCommandContext): Promise<void> {
     const interaction = context.interaction
-    const adId = AdId.fromString(interaction.options.getString('id', true))
+    const identifier = interaction.options.getString('id', true)
     const userId = interaction.user.id
+
+    let adId: AdId
+    try {
+      if (/^\d+$/.test(identifier)) {
+        const position = parseInt(identifier, 10) - 1
+        const ads: Ad[] = await this.commandHandlerManager.handle(new ListUserAds(userId))
+        if (position < 0 || position >= ads.length) {
+          await interaction.reply({ content: 'Invalid ad position', ephemeral: true })
+          return
+        }
+        adId = ads[position].id
+      } else {
+        adId = AdId.fromString(identifier)
+      }
+    } catch (error) {
+      if (error instanceof InvalidId) {
+        await interaction.reply({ content: 'Invalid Ad ID', ephemeral: true })
+        return
+      }
+      throw error
+    }
 
     try {
       await this.commandHandlerManager.handle(new DeleteAd(adId, userId))
       await interaction.reply({ content: 'Ad deleted successfully', ephemeral: true })
     } catch (error) {
       if (error instanceof UnauthorizedAdDeletion) {
-        await interaction.reply({ 
+        await interaction.reply({
           content: 'You are not authorized to delete this ad',
-          ephemeral: true 
+          ephemeral: true
         })
       } else if (error instanceof RecordNotFound) {
-        await interaction.reply({ 
+        await interaction.reply({
           content: 'Ad not found',
-          ephemeral: true 
+          ephemeral: true
         })
       } else {
-        throw error
+        await interaction.reply({ content: `Error deleting ad: ${error.message}`, ephemeral: true })
       }
     }
   }

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/ListAdsSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/ListAdsSubcommand.ts
@@ -64,6 +64,7 @@ export class ListAdsSubcommand {
                         `💰 Price: ${ad.price}`,
                         `📍 Location: ${ad.zone}`,
                         `🚚 Dispatch: ${ad.dispatch}`,
+                        `🆔 ID: ${ad.id.toString()}`,
                         ad.warranty ? `⚡ Warranty: ${ad.warranty}` : null,
                         ad.description ? `📝 ${ad.description}` : null,
                         `\n[View Listing](https://discord.com/channels/${context.interaction.guildId}/${ad.channelId}/${ad.messageId})`


### PR DESCRIPTION
## Summary
- show ad IDs in marketplace listings
- allow deleting ads by position in listing
- provide clear error messages for invalid ID, position and unexpected errors

## Testing
- `bun test` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_6862489082d4832ebf78345a250d6057