### PR TITLE
ci: pin trivy-action to an existing tag

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run Trivy filesystem scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scanners: vuln,secret,misconfig


### PR DESCRIPTION
`aquasecurity/trivy-action@0.28.0` does not exist — the tags carry a `v` prefix
and the lowest current one is `v0.30.0`, so the Security workflow failed at
action resolution on both the PR and `main`.

Pins `v0.36.0`, matching the sibling repos. CodeQL and Gitleaks already passed,
so this should turn the whole workflow green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)