### PR TITLE
docs: add the global plan sequencing all revival work

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -141,7 +141,11 @@ Plus the accumulated rot: 6 type errors, no linter, no release ever cut. See
 [`docs/known-issues.md`](docs/known-issues.md) for the itemised list (24 items)
 and [`docs/revival-plan.md`](docs/revival-plan.md) for the order to attack it in.
 
-**If you are an agent picking up a workstream**, start at
-[`docs/plans/00-overview.md`](docs/plans/00-overview.md) — it carries the shared
-context (brand assets, the real state of the data, settled decisions) that the
-four active plans assume you have read.
+**If you are an agent picking up work**, start at
+[`docs/plans/GLOBAL-PLAN.md`](docs/plans/GLOBAL-PLAN.md) — the master work queue.
+It sequences every known defect and gap into numbered work items (`M0.1`, `M4.7`,
+…) across ten milestones, says what blocks what, and traces each item back to the
+evidence for it. Then read
+[`docs/plans/00-overview.md`](docs/plans/00-overview.md) for the shared context
+(brand assets, the real state of the data, settled decisions) that every plan
+assumes you have.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,8 +10,17 @@ short version.
 | [architecture.md](architecture.md)                   | You are about to change `discord-bot/` code                                |
 | [operations.md](operations.md)                       | You need to build, release, deploy, or debug the running bot               |
 | [known-issues.md](known-issues.md)                   | You want the itemised list of what is broken or rotten, with severities    |
-| [revival-plan.md](revival-plan.md)                   | You are picking up the revival work and want a sequenced plan              |
-| [plans/](plans/00-overview.md)                       | You are an agent about to build one of the three current workstreams       |
+| [revival-plan.md](revival-plan.md)                   | You want the original narrative sequencing (superseded by the global plan) |
+| [session-log-2026-08-19.md](session-log-2026-08-19.md) | You want the record of how all of this was found, and why each call was made |
+| [plans/](plans/00-overview.md)                       | You are an agent about to build one of the workstreams                     |
+
+## ▶ Start here
+
+**[`plans/GLOBAL-PLAN.md`](plans/GLOBAL-PLAN.md) is the master work queue.** It
+sequences every finding in every document below into 92 numbered work items
+across 10 milestones, with a traceability appendix mapping each item back to its
+evidence. If you are about to do work on this repo, read that first and pick an
+item; everything else here is either evidence or per-area detail.
 
 ## Active workstreams
 
@@ -24,6 +33,9 @@ Detailed, self-contained plans written to be handed to independent agents:
 | [02 — Scheduler & lifecycle](plans/02-scheduler-and-lifecycle.md) | Job runner, ad bump/expiry, screenshot recovery |
 | [03 — Community portal](plans/03-portal.md) | Public site + admin portal |
 | [04 — Infrastructure migration](plans/04-infrastructure-migration.md) | TedRelayer → HTZ1 Portainer, CI/CD, release-please. **Repo side already built** |
+| [05 — Bot audit & hardening](plans/05-bot-audit-and-hardening.md) | Security, correctness and API findings across the whole bot |
+| [06 — Discord API modernisation](plans/06-discord-api-modernisation.md) | Deprecations, deferred replies, components, registration metadata |
+| [07 — Dependency upgrades](plans/07-dependency-upgrades.md) | Locked inventory, hygiene defects, the undici pin, Prisma 6→7 |
 
 ## The 60-second version
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -4,6 +4,25 @@ Everything here was reproduced on **2026-08-19** against commit `31f6699` and
 against the **live production deployment** on TedRelayer, not inferred from
 reading. Severity is about risk to the running community bot, not about tidiness.
 
+> **This list is not the whole picture.** A second audit pass — security,
+> correctness and Discord-API practice — produced findings that are *not*
+> numbered here, including two that belong in the 🔴 band:
+>
+> - **Mention injection (A1)** — `SellSubcommand` concatenates user-supplied text
+>   into message *content* and nothing sets `allowedMentions`, so an ad named
+>   `@everyone` makes the bot ping the server. Live exposure, today.
+> - **`/trophy rank` ranks the wrong people (B1)** — `OrmTrophyRepository` applies
+>   `take: limit` in the Prisma query *before* points are summed and sorted in JS,
+>   with no `orderBy`. "Top 10" is an arbitrary 10 profiles sorted among
+>   themselves. Affects all three rank modes and `findUserPosition`.
+>
+> Those live in [`plans/05-bot-audit-and-hardening.md`](plans/05-bot-audit-and-hardening.md)
+> (A1–A8, B1–B10, C1–C7), with the Discord-API and dependency detail in
+> [`06`](plans/06-discord-api-modernisation.md) and
+> [`07`](plans/07-dependency-upgrades.md). **Everything from all four documents is
+> sequenced together in [`plans/GLOBAL-PLAN.md`](plans/GLOBAL-PLAN.md)** — read
+> that to know what to do next.
+
 ## 🔴 High
 
 ### 0. `/marketplace sell` fails on every single use, in production, today

--- a/docs/plans/00-overview.md
+++ b/docs/plans/00-overview.md
@@ -1,8 +1,12 @@
 # Revival programme — plan index
 
-Three workstreams, drafted 2026-08-19. Each plan below is written to be handed to
-an agent working independently; read this page first for the shared context and
-the dependencies between them.
+Each plan below is written to be handed to an agent working independently; read
+this page first for the shared context and the dependencies between them.
+
+> **Sequencing lives in [`GLOBAL-PLAN.md`](GLOBAL-PLAN.md)**, not here. That file
+> is the master work queue: it folds every plan below — plus `known-issues.md`
+> and `discord-bot-feature-gap.md` — into one ordered set of numbered work items.
+> These plans hold the *design*; the global plan holds the *order*.
 
 | Plan                                                       | Owner-agent scope                              | Depends on |
 | ---------------------------------------------------------- | ---------------------------------------------- | ---------- |
@@ -10,6 +14,9 @@ the dependencies between them.
 | [02 — Scheduler & lifecycle](02-scheduler-and-lifecycle.md)| Job runner, ad bump/expiry, screenshot recovery | 01, 04     |
 | [03 — Community portal](03-portal.md)                      | Public site + admin portal                      | 02, 04     |
 | [04 — Infrastructure migration](04-infrastructure-migration.md) | TedRelayer → HTZ1, Portainer, CI/CD, releases | —      |
+| [05 — Bot audit & hardening](05-bot-audit-and-hardening.md) | Security (A1–A8), correctness (B1–B10), API (C1–C7) findings | — |
+| [06 — Discord API modernisation](06-discord-api-modernisation.md) | Deprecations, deferred replies, components, registration | 05 |
+| [07 — Dependency upgrades](07-dependency-upgrades.md) | Version inventory, hygiene defects, Prisma 6→7 | — |
 
 Plan 04's repo-side work is **already built and lint-clean** in this branch —
 workflows, composite actions, release-please config, the Portainer stack file and
@@ -25,9 +32,9 @@ the Caddy vhosts. What remains there is a credentials-and-DNS runbook.
   [`../operations.md`](../operations.md).
 - **CI does not deploy** (it targets a decommissioned host). Shipping means
   building an image and running `docker compose pull && up -d` by hand.
-- Before claiming done: `bunx prisma generate && bunx tsc --noEmit && bun test`.
-  Type checking currently fails with 6 pre-existing errors — do not add more, and
-  fix the ones your plan touches.
+- Before claiming done: `bun run typecheck && bun test` (the script runs
+  `prisma generate` for you). Both are **clean as of 2026-08-19** and `ci.yml`
+  enforces the type check, so a PR that does not compile cannot merge.
 
 ## The community
 

--- a/docs/plans/05-bot-audit-and-hardening.md
+++ b/docs/plans/05-bot-audit-and-hardening.md
@@ -1,0 +1,197 @@
+# Discord Bot — API Modernisation, Capability Lift & Security Hardening
+
+**Status:** Planned, not started. Written 2026-08-19.
+**Repo:** `GameOnPortugal/monorepo` → `discord-bot/` (the TS rewrite). Legacy reference: `old-discord-bot/` (discord.js v12, JS, Sequelize).
+> Moved into the repo on 2026-08-19 from `~/claude-plans/2026-08-19-discord-bot-upgrade.md`.
+> Sequencing is now owned by [`GLOBAL-PLAN.md`](GLOBAL-PLAN.md); read this file for the **findings**.
+
+> **This is the umbrella plan.** Two focused companion plans drill into the areas Luis flagged:
+> - **[Dependency upgrades](07-dependency-upgrades.md)** — full locked inventory, version gaps, the undici pin, Prisma 6→7, dependency hygiene defects.
+> - **[Modern Discord practices](06-discord-api-modernisation.md)** — deprecated API usage, deferred responses, components/autocomplete/modals, registration metadata, client config.
+>
+> Sections C (API modernisation) and E0 (dependency currency) below are summaries; the companion plans supersede them in detail.
+
+---
+
+## TL;DR
+
+`discord-bot/` is a clean hexagonal/CQRS TypeScript+Bun rewrite on discord.js **14.18.0** (Discord API **v10**, which is still the current gateway/REST version — so this is *not* an API-version migration). The real work is in three buckets:
+
+1. **Security & robustness** — the bot posts unsanitised user input as message content (`@everyone` injection is live), has no permission gating, no channel scoping, no rate limiting, and leaks internal error strings to users.
+2. **Interaction-API modernisation** — no `deferReply()` anywhere (3-second timeout risk on every DB-heavy command), deprecated `ephemeral:`/`fetchReply:` options, `reply(string, options)` misuse that silently makes error messages **public**, global-only command registration, and zero use of components (buttons/modals/select menus/autocomplete).
+3. **Capability gaps vs. the old bot** — `/trophy rank` is dead in the water because the **PSN crawler was never ported**, so the `trophies` table is never populated. LFG, stock alerts, `wanted` ads, and command-channel linking all exist in `old-discord-bot/` and are absent here.
+
+Recommended sequencing: **Phase 0 (bugs+security, ship fast) → Phase 1 (API modernisation) → Phase 2 (capability lift) → Phase 3 (infra/CI)**.
+
+---
+
+## Current state
+
+| Area | Detail |
+|---|---|
+| Runtime | Bun 1.2.10 (alpine image), TypeScript ESM, `strict` + `noUncheckedIndexedAccess` |
+| Library | `discord.js@14.18.0` → `discord-api-types@0.37.120`, Discord API v10 |
+| Architecture | Domain / Application (CQRS: Command+Handler) / Infrastructure / Ui, InversifyJS 7 container |
+| Persistence | Prisma 6 → MariaDB 11.7 |
+| Logging | Custom `LoggerManager` → Console + Loki (winston) |
+| Commands | `/ping`, `/screenshot create\|list\|delete`, `/trophy create\|check\|rank`, `/marketplace sell\|list\|delete` |
+| Cron | `scheduler/` (chadburn) runs `bun run:command week-screenshot-winner` Sun 23:50 |
+| Deploy | GH Actions → Docker Hub `joshlopes/game-on-portugal-bot` → CapRover |
+| Tests | Bun test, integration-only (Application handlers). No Discord-layer tests. Static analysis job is **commented out** in `.github/workflows/bot.yaml` |
+
+---
+
+## Findings
+
+### A. Security
+
+**A1 — Mention injection / mass-ping (HIGH).** `SellSubcommand.ts:57-70` builds `replyContent` by string-concatenating user-supplied `name`, `price`, `zone`, `warranty`, `description` and posts it as message **content**. Nothing sets `allowedMentions`. A member can create a listing named `@everyone` and make the bot ping the server. Same exposure in `ListAdsSubcommand.ts` (embed fields), `CreateScreenshotSubcommand.ts:53-58`.
+*Fix:* set `allowedMentions: { parse: [] }` globally on the `Client` constructor **and** per-reply; prefer embeds over raw content; escape with `escapeMarkdown()` where content is unavoidable.
+
+**A2 — No authorisation model at all.** Every command is invokable by every member in every channel, including DMs. `old-discord-bot` had `commandChannelLink` (per-channel command allowlist) and LFG ban state; neither survived. No `setDefaultMemberPermissions()`, no `setContexts()`, no role checks.
+*Fix:* add `setDefaultMemberPermissions` to admin-ish commands, `setContexts([Guild])` to guild-only ones, and reintroduce a channel-scoping table.
+
+**A3 — Internal error leakage.** `DeleteAdSubcommand.ts:59` replies `Error deleting ad: ${error.message}` — raw exception text (potentially Prisma/DB detail) to the user.
+*Fix:* generic user message + correlation id; full error to Loki only.
+
+**A4 — Unbounded attachment download.** `CreateScreenshotHandler.generateMd5FromImageUrl()` fetches the attachment URL into memory with no size cap, no content-type re-check server-side, and no timeout beyond axios defaults. Discord attachments can be very large.
+*Fix:* cap by `image.size` before fetching, enforce a max-bytes stream limit and an explicit timeout, and validate against Discord's CDN host allowlist.
+
+**A5 — Second gateway connection with the same token.** `DiscordGuildClient` lazily constructs a *whole second* `Client({intents: []})` and `login()`s it (`inversify.config.ts` binds it eagerly with `process.env.DISCORD_TOKEN ?? ''`). It is never `destroy()`ed, so the CLI process holds an open gateway session.
+*Fix:* replace with a REST-only `@discordjs/rest` client; no gateway session needed for `channels.fetch`/`messages.fetch`/`send`.
+
+**A6 — Empty-string token fallback.** `?? ''` in three places silently produces an invalid client instead of failing fast.
+*Fix:* validate env at boot with a schema (zod/typebox) and exit non-zero on missing required vars.
+
+**A7 — No supply-chain or static-analysis gate.** No Dependabot/Renovate, no CodeQL, no `bun audit`, and the static-analysis CI job is commented out — so `tsc --noEmit` never runs. (There is at least one latent type error today: `ads[position].id` in `DeleteAdSubcommand.ts:33` under `noUncheckedIndexedAccess`.)
+
+**A8 — Container runs as root**, ships `mariadb-client` in the runtime layer, and dev compose bind-mounts the whole repo `rw`. Dockerfile also has a `COPY ../ .` that only works by accident of build context.
+
+### B. Correctness bugs found while reading
+
+**B1 — Rankings are wrong (HIGH).** `OrmTrophyRepository.ts:104,137,170` apply `take: limit` in the Prisma query *before* points are computed and sorted in JS. "Top 10" is therefore *an arbitrary 10 profiles, sorted among themselves* — not the top 10. Affects all three `/trophy rank` modes and `findUserPosition` (which requests 1000 then index-searches).
+*Fix:* aggregate + order in SQL (`groupBy`/raw aggregate on points) and paginate properly.
+
+**B2 — Ephemeral flag silently dropped.** `reply(string, {flags})` is not a valid discord.js v14 signature — the second argument is ignored. `ScreenshotSlashCommand.ts:106`, `CreateScreenshotSubcommand.ts:28,34`. Those "errors" are posted **publicly**.
+
+**B3 — Double-reply crashes.** `SellSubcommand` `catch` calls `interaction.reply()` even when the try block already replied (`InteractionAlreadyReplied`). Same shape in `ScreenshotSlashCommand.handle()` and `TrophySlashCommand.handle()` — the outer catch replies after a subcommand may already have. Only `DiscordBot.ts:41-52` gets this right (`replied || deferred` check).
+
+**B4 — `DeleteScreenshotSubcommand` is missing `@injectable()`** (`src/.../Screenshot/DeleteScreenshotSubcommand.ts:604`-ish — the class declaration has the decorator omitted while its siblings have it). Bound via `.toSelf()`. Needs verifying against Inversify 7 resolution at runtime; if it throws, `/screenshot` is broken at container build.
+
+**B5 — `@multiInject(TYPES.MentionHandler)`** in `BotExecutor` has **zero bindings** in `inversify.config.ts`. Inversify throws on empty multiInject unless marked optional. Verify; either bind an empty array or mark `@optional()`.
+
+**B6 — Embed limits unguarded.** `ListAdsSubcommand` adds one field per ad with no cap (Discord max 25 fields, 1024 chars/field, 6000 chars/embed). A user with 26 listings breaks the command. `ListScreenshotSubcommand` does cap at 10 — inconsistent.
+
+**B7 — Duplicate write on sell.** `SellSubcommand` calls `CreateAd` twice (once to get an id, once to attach `message_id`). Works only because the repo `save` upserts; it should be an explicit `AttachMessageToAd` command.
+
+**B8 — Screenshot image URLs rot.** Discord CDN URLs have been signed/expiring since late 2023. `screenshots.image` stores the raw URL, so the archive dies after ~24h. Needs re-hosting (S3/R2) or storing `message_id` + refetching.
+
+**B9 — `RankSubcommand`** indexes `data.ranks[0..2]` unchecked, and `lifetime` position is hardcoded to equal `creation` (`OrmTrophyRepository.findUserPosition`, comment says "for now").
+
+**B10 — `DeleteAdSubcommand.ts:33`** `ads[position].id` — possibly-undefined access (see A7).
+
+### C. Discord API / interaction modernisation
+
+**C1 — No `deferReply()` anywhere.** Every handler must answer within 3 s. `/trophy rank` pulls up to 1000 profiles with all their trophies; `/screenshot create` downloads and MD5s an attachment *inside* the interaction window. These will intermittently fail with "The application did not respond".
+*Fix:* `deferReply({ flags: MessageFlags.Ephemeral })` first thing in every non-trivial handler, then `editReply()`.
+
+**C2 — Deprecated option shapes.** `ephemeral: true` (7 sites in Marketplace) → `flags: MessageFlags.Ephemeral`. `fetchReply: true` (2 sites) → `withResponse: true` / `interaction.fetchReply()`.
+
+**C3 — Global-only command registration.** `Routes.applicationCommands(clientId)` — up to 1 h propagation, and no dev/guild-scoped path. Errors are swallowed to `console.error` (bypassing the Logger), so a failed sync starts the bot with stale commands silently.
+*Fix:* guild-scoped registration behind `DISCORD_GUILD_ID` for dev, global for prod; fail loudly; skip the PUT when the command set hash is unchanged.
+
+**C4 — No modern component surface.** Zero buttons, select menus, modals, or autocomplete. High-value applications:
+  - `/marketplace sell` → **modal** for the long free-text fields (better UX than 7 slash options) + "Mark as sold" / "Bump" buttons on the listing.
+  - `/marketplace delete` and `/screenshot delete` → **autocomplete** on the id option (they currently ask users to paste a UUID, with a positional-index hack bolted on in `DeleteAdSubcommand`).
+  - `/trophy rank` → pagination buttons instead of `limit` capped at 10.
+  - Screenshot contest → voting via buttons instead of scraping reaction counts.
+**C5 — Missing modern registration metadata:** `setContexts()` / `setIntegrationTypes()` (user-installable apps), `setNSFW()`, localisations (`setNameLocalizations`) — the server is Portuguese and every string is English today.
+**C6 — No `Events.Error`/`ShardError` handlers, no `unhandledRejection`/`uncaughtException` handlers, no SIGTERM graceful shutdown** (client not destroyed, Prisma not disconnected). Container restarts leave sessions dangling.
+**C7 — Interaction types unhandled:** only `isChatInputCommand()`. No context-menu commands, no autocomplete routing, no component/modal routing. `SlashCommandContext.interaction` is typed `any`, which is why none of the above is type-checked.
+
+### D. Capability gaps vs `old-discord-bot/`
+
+| Capability | Old bot | New bot |
+|---|---|---|
+| PSN trophy crawler (`service/trophy/psnCrawlService.js`, 123 LOC + `trophyProfileManager.js`, 284 LOC) | ✅ | ❌ **missing — `/trophy rank` returns nothing, ever** |
+| LFG (create/cancel/rank/report/commend/ban/unban — 12 subcommands) | ✅ | ❌ (schema tables exist, unused) |
+| Marketplace `wanted` ads | ✅ | ❌ (`adType` is hardcoded `'sale'`) |
+| "Has been sold" reaper script | ✅ | ❌ |
+| Stock URL alerts | ✅ | ❌ |
+| Special channels / command-channel linking | ✅ | ❌ (tables exist, unused) |
+| Message validator (moderation: regex + commands-only channels) | ✅ | ❌ |
+| Telegram + Sentry notification | ✅ | ❌ (`SENTRY_DSN`/`TELEGRAM_ACCESS_TOKEN` still in `.env.example`, unused) |
+
+The scheduler config has `parse-psn-profiles`, `update-lfg-points` and `has-been-sold` jobs **commented out** — waiting on these ports.
+
+### E. Infra / CI
+
+**E0 — Dependency currency.** `prisma`/`@prisma/client` are pinned at `^6.6.0`; the current published release is **7.8.0** (verified 2026-08-19 against the npm registry) — a full major behind, with the Prisma 7 client-generation and query-engine changes to absorb. `discord.js@14.18.0`, `inversify@7.5.0`, `axios@^1.8.4` and `dotenv@^16.5.0` could not be checked (the sandbox's npm registry access failed with TLS errors); **re-check all of these at implementation time**. Treat the Prisma 6→7 upgrade as its own PR with the integration tests as the gate — it is the riskiest single dependency move here.
+
+- Static-analysis job commented out in `bot.yaml`; no `tsc --noEmit`, no linter config in the repo at all.
+- No healthcheck for the bot container (it `EXPOSE 3000` and sets `PORT=3000` but nothing listens).
+- No Dependabot/Renovate/CodeQL.
+- `entrypoint.sh` parses `DATABASE_URL` with `cut`/`sed` and **echoes the DB password** to stdout on every connection attempt → password lands in container logs.
+- CI copies `.env.test` over `.env`; fine, but there is no secrets-scanning gate.
+
+---
+
+## Proposed plan
+
+### Phase 0 — Correctness + security hotfix (1 PR, small, ship first)
+1. `allowedMentions: { parse: [] }` on the `Client` and on every reply that echoes user input (A1).
+2. Fix `reply(string, {flags})` → options object at 3 sites (B2).
+3. `ephemeral: true` → `flags: MessageFlags.Ephemeral` (C2).
+4. Add `replied || deferred` guards to all catch-blocks; extract a `safeReply(interaction, payload)` helper (B3).
+5. Stop leaking `error.message` to users (A3).
+6. Add `@injectable()` to `DeleteScreenshotSubcommand`; make `MentionHandler` multiInject optional (B4, B5).
+7. Fix `ads[position]` undefined access (B10).
+8. Re-enable the static-analysis CI job and add `bun run typecheck` (`tsc --noEmit`) — this is what will keep 6/7 from recurring.
+
+### Phase 1 — Interaction API modernisation (2–3 PRs)
+1. **Type the Discord layer.** Replace `interaction: any` in `SlashCommandContext` with `ChatInputCommandInteraction`; introduce discriminated `InteractionContext` covering chat-input / autocomplete / component / modal. This is the enabler for everything below.
+2. **Defer everything non-trivial** (C1) — `deferReply` + `editReply`, with the ephemeral decision moved into each handler.
+3. **Registration overhaul** (C3) — guild-scoped in dev via `DISCORD_GUILD_ID`, global in prod, hash-diffed, errors through `Logger`, fail-fast on sync failure. Add `setDefaultMemberPermissions`/`setContexts` (A2).
+4. **Lifecycle hardening** (C6) — `Events.Error`, `process.on('unhandledRejection'|'uncaughtException'|'SIGTERM')`, `client.destroy()` + `prisma.$disconnect()` on shutdown. Replace `DiscordGuildClient`'s second gateway `Client` with `@discordjs/rest` (A5).
+5. **Env validation at boot** (A6).
+6. **Components** (C4) — start with autocomplete on the two delete commands (removes the UUID-paste UX and the positional-index hack), then the sell modal, then rank pagination.
+
+### Phase 2 — Capability lift (largest chunk)
+1. **Port the PSN crawler** — this is the single highest-value item; without it `/trophy` is decorative. New `Infrastructure/Trophy/PsnProfilesCrawler` behind a `TrophySource` domain port, driven by a new console command (`parse-psn-profiles`) so `scheduler/config.ini` can re-enable its job. Respect robots/rate-limits; cache; backoff. Fix B1 (ranking SQL) as part of this.
+2. **Marketplace completeness** — `wanted` ads (`adType` already in the schema), `has-been-sold` reaper as a console command, "Mark as sold"/"Bump" buttons, embed-limit-safe pagination (B6), `AttachMessageToAd` command replacing the double-write (B7).
+3. **Screenshot durability** (B8) — re-host images to object storage on submit, or store `message_id` and refetch; decide before the archive matters.
+4. **LFG** — the biggest single feature (12 subcommands + 4 Prisma models already present). Worth its own spec; probably a follow-up plan file rather than part of this one.
+5. **Localisation** (C5) — pt-PT command names/descriptions and reply strings.
+
+### Phase 3 — Infra / CI
+1. Dependabot or Renovate + CodeQL; `bun audit` in CI.
+1b. Prisma 6 → 7 upgrade as a standalone PR, gated on the existing integration suite (E0).
+2. Non-root container user, drop `mariadb-client` from the runtime layer, fix `COPY ../ .` (A8).
+3. Stop echoing the DB password in `entrypoint.sh` (E).
+4. Add a `/health` HTTP endpoint (port 3000 is already exposed) + compose healthcheck, so CapRover can actually tell if the bot is alive.
+5. Discord-layer unit tests (currently zero) — the `InMemoryClient` seam already exists to build on.
+
+---
+
+## Decisions & rationale
+
+- **Not migrating to a newer Discord API version.** discord.js 14.18 already speaks API v10, which is current. The gain is in *unused* v10 features (components, autocomplete, contexts, integration types), not a version bump. A discord.js patch bump to the latest 14.x is still worth doing for security fixes — **verify the exact latest 14.x at implementation time** (npm was unreachable from the sandbox when this plan was written, so no version number is asserted here).
+- **Phase 0 before Phase 1** because A1 (mention injection) and B2 (public "ephemeral" errors) are live user-facing exposure and each is a few lines.
+- **Typing the Discord layer early (Phase 1.1)** because `interaction: any` is why B2/B3/B10 all got through review; fixing it converts a class of runtime bugs into compile errors — but only once `tsc --noEmit` runs in CI (Phase 0.8).
+- **PSN crawler ahead of LFG** — `/trophy rank` is already shipped and visibly broken (it returns empty rankings), whereas LFG is simply absent. Fixing a broken promise beats adding a new one.
+
+## Open questions for Luis
+
+1. Is LFG actually wanted back, or was dropping it deliberate? It's ~40% of the old bot's surface.
+2. Screenshot archive: is long-term image retention a requirement (→ object storage), or is the weekly winner announcement enough (→ ignore B8)?
+3. Portuguese localisation — worth doing, or is the server bilingual enough that English is fine?
+4. Sentry: `.env.example` still advertises `SENTRY_DSN` but nothing reads it. Reinstate, or drop the var and rely on Loki?
+
+## Operational reference
+
+- Bot source: `discord-bot/src/` (`Domain` / `Application` / `Infrastructure` / `Ui`)
+- Legacy reference implementation: `old-discord-bot/src/` (discord.js v12)
+- CI: `.github/workflows/bot.yaml` → `shared.tests.yaml` → `shared.build-image.yaml` → `shared.deploy.yaml`
+- Image: Docker Hub `joshlopes/game-on-portugal-bot`; deploy target CapRover (`CAPROVER_DISCORD_BOT_APP`)
+- Cron: `scheduler/config.ini` (chadburn), container `game-on-portugal-app-placeholder`
+- Console commands: `bun run:command <name>` → `discord-bot/bin/console.ts`

--- a/docs/plans/06-discord-api-modernisation.md
+++ b/docs/plans/06-discord-api-modernisation.md
@@ -1,0 +1,192 @@
+# Discord Bot — Modern Discord API & discord.js Practices
+
+**Status:** Planned, not started. Written 2026-08-19.
+**Scope:** `discord-bot/` in `GameOnPortugal/monorepo` — currently `discord.js@14.18.0`, Discord API **v10**.
+**Companion plans:** [dependency upgrades](07-dependency-upgrades.md) · [bot audit](05-bot-audit-and-hardening.md)
+
+> Moved into the repo on 2026-08-19 from `~/claude-plans/`. Sequencing is owned by
+> [`GLOBAL-PLAN.md`](GLOBAL-PLAN.md); read this file for the **detail**.
+
+---
+
+## TL;DR
+
+The bot is on the **current API version** (v10) — there is no version migration to do. What's missing is everything v10 gained *after* this code was written. The bot uses exactly one interaction type (`isChatInputCommand`), replies inline with plain strings and embeds, registers commands globally, and types `interaction` as `any`. It uses **none** of: deferred responses, components (buttons/select menus/modals), autocomplete, context menus, install contexts, permission gating, or localisation.
+
+The three changes with the best value-to-effort ratio, in order:
+1. **`deferReply()` everywhere** — the bot currently races Discord's 3-second interaction deadline on every DB-backed command, and loses sometimes.
+2. **Type the interaction layer** — `interaction: any` is the root cause of the deprecation bugs below; fixing it converts them into compile errors.
+3. **Autocomplete on the two delete commands** — removes the "paste a UUID" UX and the positional-index hack bolted onto it.
+
+---
+
+## ⚠️ Verification caveat
+
+My knowledge runs to **May 2026** and the npm registry was unreachable from this environment, so I could not confirm the current discord.js release or read recent changelogs. Everything below marked **[verify]** should be checked against the discord.js guide and Discord changelog before implementation. Everything about *this repo's current state* is read directly from the code and is fact.
+
+---
+
+## 1. Deprecated / wrong API usage in the code today
+
+These are concrete, located, and mostly one-line fixes. Newer 14.x releases warn or error on several of them, so they must be cleared as part of the discord.js bump.
+
+| # | Issue | Sites |
+|---|---|---|
+| P1 | **`reply(string, { flags })` is not a valid signature.** The second argument is silently ignored, so these "ephemeral" errors are posted **publicly**. | `ScreenshotSlashCommand.ts:106`, `CreateScreenshotSubcommand.ts:28,34` |
+| P2 | **`ephemeral: true` is deprecated** in favour of `flags: MessageFlags.Ephemeral`. | `DeleteAdSubcommand.ts:29,38,46,51,56,59`, `MarketplaceSlashCommand.ts:119` |
+| P3 | **`fetchReply: true` is deprecated** in favour of `withResponse: true` (which returns an `InteractionCallbackResponse`, *not* a `Message` — the call sites use `.id` off the result and will need adjusting). | `SellSubcommand.ts:81`, `CreateScreenshotSubcommand.ts:59` |
+| P4 | **No `replied`/`deferred` guard in catch blocks** → `InteractionAlreadyReplied` crashes. Only `DiscordBot.ts:41-52` does it correctly. | `SellSubcommand`, `ScreenshotSlashCommand.handle`, `TrophySlashCommand.handle` |
+| P5 | **`interaction` is typed `any`** throughout (`SlashCommandContext.ts:5`), which is *why* P1–P4 were never caught. | all handlers |
+
+**Fix pattern** — one shared helper kills P1, P2 and P4 at once:
+
+```ts
+// Domain/Bot/respond.ts
+export async function respond(
+  interaction: ChatInputCommandInteraction,
+  payload: InteractionReplyOptions,
+): Promise<void> {
+  if (interaction.deferred || interaction.replied) {
+    await interaction.followUp(payload);
+    return;
+  }
+  await interaction.reply(payload);
+}
+```
+
+---
+
+## 2. Interaction lifecycle — the 3-second deadline
+
+**There is not a single `deferReply()` call in the codebase.** Discord requires an initial response within **3 seconds**, after which the interaction token is dead and the user sees *"The application did not respond."*
+
+Current worst offenders:
+- `/screenshot create` — downloads the attachment over HTTP and MD5s it (`CreateScreenshotHandler.generateMd5FromImageUrl`) **inside** the 3s window, then does a DB lookup and write.
+- `/trophy rank` — `findUserPosition` calls `getTopMonthlyHunters(1000)` *and* `getTopSinceCreationHunters(1000)`, each loading up to 1000 profiles **with all their trophies** and sorting in JS.
+- `/marketplace delete` by position — issues a `ListUserAds` query before the delete.
+
+**Pattern to adopt:** defer first, then edit.
+
+```ts
+await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+const result = await this.commandHandlerManager.handle(command);
+await interaction.editReply({ embeds: [buildEmbed(result)] });
+```
+
+Deferring extends the window to **15 minutes**. Note the ephemeral decision moves to `deferReply` — it cannot be changed at `editReply` time, so each handler must decide up front.
+
+---
+
+## 3. Components — the biggest capability gap
+
+The bot has **zero** interactive components. Everything is a one-shot reply. This is where the modern API has moved furthest.
+
+### 3a. Components V2 **[verify]**
+Discord introduced a new component-layout system (opt-in via a message flag, roughly `MessageFlags.IsComponentsV2`) with builders along the lines of `ContainerBuilder`, `SectionBuilder`, `TextDisplayBuilder`, `SeparatorBuilder`, `MediaGalleryBuilder`, `ThumbnailBuilder`. It replaces the embed model with composable layout primitives, and is **mutually exclusive with `content`/`embeds` on the same message**.
+
+Relevance here is high — marketplace listings and screenshot submissions are exactly the "image + structured fields + actions" shape this was designed for. **Confirm the current builder names, the flag, and the stability status against the discord.js guide before designing around it**; treat the embed-based approach as the fallback.
+
+### 3b. Buttons & select menus
+- **Marketplace listing** → `Mark as sold` / `Bump` / `Delete` buttons on the listing message itself. This directly replaces the old bot's `has-been-sold` polling script with a user action.
+- **`/trophy rank`** → prev/next pagination buttons instead of the `limit` option capped at 10.
+- **Screenshot contest** → vote buttons instead of counting 🏆 reactions. The current `GetScreenshotWinnerHandler` fetches every message of the week one-by-one and reads `reactions.cache` — slow, rate-limit-prone, and it silently skips messages it can't fetch.
+
+Requires a `Events.InteractionCreate` branch for `isButton()` / `isStringSelectMenu()`, plus a `customId` routing convention (e.g. `marketplace:sold:<adId>`) and — importantly — an **authorisation check inside the component handler**, since anyone can click anyone's button.
+
+### 3c. Modals
+`/marketplace sell` currently takes **seven** slash-command options, two of them long free text. A modal (`ModalBuilder` + `TextInputBuilder`, `Paragraph` style for description) is the idiomatic shape and gives multi-line input, which slash options cannot. **[verify]** newer modal component types (label/select-in-modal) if they've landed.
+
+### 3d. Autocomplete — highest value, lowest effort
+`/marketplace delete` and `/screenshot delete` both ask the user to paste a **UUID**. `DeleteAdSubcommand.ts:24-36` works around this with a positional-index hack (`/^\d+$/` → "the Nth ad"), which is fragile and undiscoverable.
+
+Autocomplete solves it properly: `option.setAutocomplete(true)`, then handle `interaction.isAutocomplete()` and respond with up to 25 choices (`{ name: "Sony WH-1000XM5 — 180€", value: "<uuid>" }`) filtered to the invoking user's own records. Must respond within **3 seconds** and cannot be deferred, so keep the query indexed and cheap.
+
+### 3e. Context menus
+`ContextMenuCommandBuilder` — right-click a message → "Submit as screenshot", or right-click a user → "View trophy profile". Cheap to add once interaction routing is typed.
+
+---
+
+## 4. Command registration & install contexts
+
+`DiscordBot.registerSlashCommands()` (`DiscordBot.ts:60-83`) has four problems:
+
+1. **Global-only** — `Routes.applicationCommands(clientId)`. Global commands can take up to an hour to propagate; there is no fast dev loop. Add guild-scoped registration (`Routes.applicationGuildCommands(clientId, guildId)`) behind a `DISCORD_GUILD_ID` env var for development.
+2. **Errors are swallowed to `console.error`** — bypassing the injected `Logger`, and the bot then starts happily with a stale command set. Should fail loudly.
+3. **Unconditional `PUT` on every boot** — re-registers all commands on each restart. Hash the serialised command array and skip the write when unchanged.
+4. **No registration metadata:**
+   - `setDefaultMemberPermissions(...)` — nothing is permission-gated today; every member can run everything.
+   - `setContexts([InteractionContextType.Guild])` — commands are currently invokable in DMs, where `ListAdsSubcommand`'s `https://discord.com/channels/${guildId}/...` link builds with `guildId === null`.
+   - `setIntegrationTypes(...)` — declares guild-install vs user-install. Even if you only want guild installs, **declaring it explicitly is now the expected practice**. **[verify]** exact enum names.
+   - `setNameLocalizations` / `setDescriptionLocalizations` — see §7.
+
+---
+
+## 5. Client configuration
+
+`new Client({ intents: [GatewayIntentBits.Guilds] })` (`DiscordBot.ts:20`) is minimal and correct — no privileged intents needed, which is good and should stay that way. But several defaults deserve overriding:
+
+- **`allowedMentions: { parse: [] }` at the client level.** Currently unset, and `SellSubcommand` concatenates user-supplied ad text into message *content* — so a listing named `@everyone` makes the bot ping the server. This is the single most important line in this plan. Set it globally and opt in per-message where a real mention is intended (e.g. the winner announcement).
+- **Cache limits.** discord.js caches aggressively by default. For a long-lived single-guild bot, `makeCache: Options.cacheWithLimits({...})` plus `sweepers` bounds memory. `messages` and `users` are the ones that grow. **[verify]** current option names.
+- **`rest` options** — timeouts, retries, and the `REST` client's rate-limit events are worth wiring into the `Logger` for observability (see §6).
+- **Partials** — only needed if you keep the reaction-counting path (§3b); uncached reaction events arrive partial and need fetching.
+
+---
+
+## 6. Rate limits & resilience
+
+- `@discordjs/rest` handles per-route buckets and the global limit automatically, but it emits events (rate-limit hits, invalid requests) that this bot **ignores**. Wire them to the Loki logger — an invalid-request spike is how you find out you're heading for a Cloudflare ban before it happens.
+- `GetScreenshotWinnerHandler` does a **sequential fetch per screenshot per week**, each a REST round-trip, with per-item try/catch that logs and continues. As submissions grow, this will hit rate limits and silently drop candidates. Moving to button-based voting (§3b) eliminates the fetch loop entirely.
+- **No `Events.Error` / shard error handlers**, no `process.on('unhandledRejection' | 'uncaughtException')`, no **SIGTERM graceful shutdown** — the container is killed without `client.destroy()` or `prisma.$disconnect()`. On CapRover redeploys that leaves gateway sessions dangling.
+- **Sharding is not needed** — required only past ~2500 guilds. Explicitly out of scope; noting it so nobody adds it speculatively.
+
+---
+
+## 7. Localisation
+
+The community is Portuguese; every command name, description, and reply string is English. `setNameLocalizations` / `setDescriptionLocalizations` (`pt-BR`, and **[verify]** whether `pt-PT` is a supported locale — Discord's locale list is finite and I can't confirm it here) localise the command surface. Reply strings need a small i18n layer of their own; there is currently no message-catalogue abstraction at all.
+
+---
+
+## 8. Attachment URL expiry
+
+Discord CDN attachment URLs are **signed and expiring**. `screenshots.image` (`prisma/schema.prisma`) stores the raw `image.url` from the interaction, so stored URLs die within roughly a day. The re-upload at submission time (`files: [image.url]`) works, but the archive rots — and the MD5 dedupe in `CreateScreenshotHandler` re-fetches that URL, so **dedupe against older rows will fail once the URL expires**.
+
+Options: (a) re-host to object storage (S3/R2) on submit — most robust; (b) store `channel_id` + `message_id` and re-fetch the fresh URL on demand; (c) **[verify]** Discord's attachment-URL refresh endpoint, which exchanges expired URLs for fresh signed ones.
+
+---
+
+## 9. discord.js v15 horizon **[verify]**
+
+A v15 major has been in development (builders overhaul, tighter `@discordjs/core` split, removal of the deprecations in §1, higher minimum Node). **Do not block on it** — but every §1 fix is also v15 preparation, which is a good reason to do them now rather than at migration time under pressure.
+
+---
+
+## Proposed sequencing
+
+**Phase A — Deprecations & safety (small, ship first)**
+1. `allowedMentions: { parse: [] }` on the Client + on replies echoing user input. *(This one is urgent — it's live mass-ping exposure.)*
+2. Fix P1 (public "ephemeral" errors), P2, P3.
+3. Add the `respond()` helper and fix P4 everywhere.
+4. `Events.Error`, `unhandledRejection`/`uncaughtException`, SIGTERM graceful shutdown.
+
+**Phase B — Type the interaction layer (the enabler)**
+5. Replace `interaction: any` with `ChatInputCommandInteraction` in `SlashCommandContext`.
+6. Introduce a discriminated `InteractionContext` covering chat-input / autocomplete / component / modal, and branch `Events.InteractionCreate` accordingly.
+7. Extend `SlashCommandHandler` with optional `autocomplete()` / `component()` hooks; type `builder()` as `SlashCommandBuilder` instead of `any`.
+   *Requires `tsc --noEmit` in CI — see the [dependency plan](07-dependency-upgrades.md) Step 2 — or none of this is enforced.*
+
+**Phase C — Lifecycle & registration**
+8. `deferReply()` in every non-trivial handler.
+9. Registration overhaul: guild-scoped dev path, hash-diffed writes, loud failures, `setDefaultMemberPermissions` + `setContexts` + `setIntegrationTypes`.
+10. Client cache limits + sweepers; REST rate-limit events → Logger.
+
+**Phase D — New surfaces (feature work, prioritise by value)**
+11. **Autocomplete** on both delete commands. *(Best value/effort in the whole plan.)*
+12. Marketplace listing buttons (sold / bump / delete).
+13. `/marketplace sell` modal.
+14. `/trophy rank` pagination buttons.
+15. Components V2 evaluation for listings & screenshots **[verify]** — spike first, decide after.
+16. Context menus.
+17. Localisation.
+
+Phases A–C are hardening and should land before D. Within D, item 11 is the one users will notice immediately.

--- a/docs/plans/07-dependency-upgrades.md
+++ b/docs/plans/07-dependency-upgrades.md
@@ -1,0 +1,154 @@
+# Discord Bot — Dependency Upgrade Plan
+
+**Status:** Planned, not started. Written 2026-08-19.
+**Scope:** `discord-bot/` in `GameOnPortugal/monorepo`. Package manager: **Bun** (`bun.lock`, 167 transitive packages).
+**Companion plans:** [modern Discord practices](06-discord-api-modernisation.md) · [bot audit](05-bot-audit-and-hardening.md)
+
+> Moved into the repo on 2026-08-19 from `~/claude-plans/`. Sequencing is owned by
+> [`GLOBAL-PLAN.md`](GLOBAL-PLAN.md); read this file for the **detail**.
+
+---
+
+## TL;DR
+
+Nine direct runtime deps, three dev deps, one peer dep, 167 packages resolved. Two are a **full major version behind** (`prisma` 6→7, `dotenv` 16→17), one is ~10 minors behind (`axios`), and `discord.js` is on 14.18.0 which hard-pins `undici@6.21.1` — meaning **you cannot patch undici without bumping discord.js**. There are also two hygiene defects worth fixing before any bump: `reflect-metadata` is imported but undeclared, and `dotenv` is declared but never imported.
+
+**Recommended order:** hygiene → low-risk patches → discord.js → axios/dotenv → **Prisma 6→7 alone, last, with the integration suite as the gate**.
+
+---
+
+## ⚠️ Data-quality caveat — read this first
+
+The npm registry was **only intermittently reachable** from the environment this plan was written in (TLS interception; `npm`, `curl -k`, and `bun info` all failed for most packages). Latest versions below are marked:
+
+- **✅ verified** — fetched live from `registry.npmjs.org` on 2026-08-19.
+- **❓ unverified** — *not checked*. Do not treat the "latest" column as fact; it is blank.
+
+Before starting, run this to fill in the table properly:
+
+```bash
+cd discord-bot
+bun outdated            # or: npx npm-check-updates
+```
+
+Everything in the **"locked"** column is hard fact, read from `bun.lock`.
+
+---
+
+## Direct dependency inventory
+
+| Package | Declared | Locked | Latest | Gap | Notes |
+|---|---|---|---|---|---|
+| `discord.js` | `^14.18.0` | **14.18.0** | ❓ | patch/minor behind 14.x | Pins `undici@6.21.1` exactly. See "The undici problem". |
+| `@prisma/client` | `^6.6.0` | **6.6.0** | **7.8.0** ✅ | **1 major** | Biggest job by far. See "Prisma 6→7". |
+| `prisma` (dev) | `^6.6.0` | **6.6.0** | **7.8.0** ✅ | **1 major** | Must move in lockstep with `@prisma/client`. |
+| `axios` | `^1.8.4` | **1.8.4** | **1.18.1** ✅ | ~10 minors | Several 1.x security fixes landed after 1.8.4. |
+| `dotenv` | `^16.5.0` | **16.5.0** | **17.4.2** ✅ | **1 major** | **Dead dependency — never imported.** Candidate for deletion, not upgrade. |
+| `inversify` | `^7.5.0` | **7.5.0** | ❓ | ? | v7 is the current major line. Split into `@inversifyjs/*` packages. |
+| `winston` | `^3.17.0` | **3.17.0** | ❓ | ? | Only used by `LokiLogProvider`. |
+| `winston-loki` | `^6.1.3` | **6.1.3** | ❓ | ? | Drags in `snappy` + `protobufjs`. See "winston-loki weight". |
+| `dayjs` | `^1.11.13` | **1.11.13** | ❓ | ? | Single use: `OrmScreenshotRepository.findByWeek`. |
+| `uuid` | `^11.1.0` | **11.1.0** | ❓ | ? | Single use: `src/Domain/Id.ts`. |
+| `@types/bun` (dev) | `latest` | **1.2.9** | ❓ | ? | **Unpinned `latest` spec** — non-reproducible. Local Bun is 1.3.14; types are 1.2.9. |
+| `env-cmd` (dev) | `^10.1.0` | **10.1.0** | ❓ | ? | Only for `test:*` scripts. Bun can do `--env-file` natively now. |
+| `typescript` (peer) | `^5` | **5.8.3** | ❓ | ? | Should be a **dev** dep, not a peer dep — this is an app, not a library. |
+
+### Notable transitives
+
+| Package | Locked | Why it matters |
+|---|---|---|
+| `undici` | **6.21.1** | Exact-pinned by `discord.js` **and** `@discordjs/rest`. Cannot be overridden safely. |
+| `discord-api-types` | 0.37.120 | Ships the API v10 typings; bumps with discord.js. |
+| `ws` | 8.18.1 | Gateway transport via `@discordjs/ws`. |
+| `snappy` + 13 platform binaries | 7.2.2 | Native compression, pulled in **only** by `winston-loki`. |
+| `protobufjs` | 7.5.0 | Also only `winston-loki`. |
+| `esbuild` + 21 platform binaries | 0.25.2 | Via `@prisma/config` → `esbuild-register`. Disappears differently under Prisma 7. |
+| `lodash` | 4.17.21 | Fully patched version — fine. |
+| `@types/node` | 22.14.1 | Node 22 typings in a Bun project. |
+
+---
+
+## Hygiene defects to fix first (these are bugs, not upgrades)
+
+**D1 — `reflect-metadata` is a phantom dependency.** It is imported for side effects in `src/Infrastructure/DependencyInjection/inversify.config.ts:1` and `src/Infrastructure/CommandHandler/CommandHandlerManager.ts:4`, but appears **nowhere** in `package.json`. It resolves today only because Inversify happens to pull it in transitively (locked at 0.2.2). The day Inversify drops or restructures that dep, the container fails to build at boot.
+*Fix:* `bun add reflect-metadata` and pin it explicitly.
+
+**D2 — `dotenv` is declared but never imported.** No file in `src/`, `bin/`, `tests/`, or `docker/` references it. Env loading actually works by accident of **Bun auto-loading `.env`**. Two consequences: (a) the dep is dead weight, and (b) anyone who assumes Node-compatibility will find env loading silently missing.
+*Fix:* either delete `dotenv` and document the Bun-implicit behaviour, or import it explicitly at the entrypoint if Node portability matters. Don't upgrade 16→17 for a package you don't use.
+
+**D3 — `@types/bun: "latest"`.** An unpinned floating spec in `devDependencies`. Every fresh `bun install` can pull a different version; the lockfile currently says 1.2.9 while the local toolchain is Bun 1.3.14.
+*Fix:* pin to a real range matching the Bun version the Dockerfile uses (`oven/bun:1.2.10-alpine` — note that's *also* drifting from local 1.3.14).
+
+**D4 — `typescript` in `peerDependencies`.** Applications don't have peers. It should be a devDependency, especially once `tsc --noEmit` runs in CI.
+
+**D5 — Bun version drift.** Dockerfile pins `oven/bun:1.2.10-alpine`; local dev is on Bun 1.3.14. Dev and prod are on different runtimes. Pick one and pin it in both places (plus a `.bun-version` / `engines` field).
+
+---
+
+## The undici problem
+
+`discord.js@14.18.0` → `@discordjs/rest@2.4.3` → `undici@6.21.1`, pinned **exactly** (no caret) in both. undici is the HTTP stack every Discord REST call goes through.
+
+This means:
+- `bun audit` findings against undici **cannot** be resolved by a transitive bump or a `resolutions`/`overrides` entry without risking an untested pairing.
+- The only supported remedy is **bumping `discord.js` itself** to a release whose `@discordjs/rest` pins a newer undici.
+
+*Action:* make "what undici does the latest 14.x pin?" the first question of the discord.js bump, and record the answer. This is the single strongest argument for keeping discord.js current even when no feature is wanted.
+
+## winston-loki weight
+
+`winston-loki@6.1.3` is responsible for `snappy@7.2.2` (**13 prebuilt native binaries**, one per platform) and `protobufjs@7.5.0`. That's a large native attack surface and image-size cost for what is one optional log sink, gated behind `if (!isEmpty(process.env.LOKI_HOST))`.
+
+*Options to evaluate:* (a) keep it; (b) replace with a plain HTTP push to Loki's JSON endpoint via the existing `HttpClient` abstraction — `LogProviderInterface` already isolates this, so it's a contained change; (c) ship logs via stdout and let the platform collector scrape (CapRover/Docker), dropping the sink entirely.
+
+Option (b) or (c) would remove ~15 packages and all native binaries. `LokiLogProvider` also has a **copy-paste bug** worth fixing while you're in there: `labels: { job: 'tedcrypto-campaign' }` — wrong project name, so this bot's logs are mislabelled in Loki.
+
+## Prisma 6→7
+
+The largest and riskiest single upgrade. Prisma 7 is not a drop-in.
+
+Things in this repo that Prisma 7 touches directly:
+- `prisma/schema.prisma` uses `generator client { provider = "prisma-client-js" }` with explicit `binaryTargets = ["native", "darwin", "linux-musl-arm64-openssl-3.0.x", "linux-musl-openssl-3.0.x"]`. The generator model and engine/binary-target story changed in 7 — expect this block to be rewritten.
+- `PrismaClient` is constructed once as a constant value in `inversify.config.ts` and injected as `TYPES.OrmClient` into 4 repositories. Client construction/config surface changes.
+- `docker/entrypoint.sh` runs `bunx prisma migrate deploy` at container start; `docker/Dockerfile` runs `bunx prisma generate` at build time with `--production` installs. Both need re-verification.
+- The **integration test suite** (`tests/Integration/**`, 9 handler tests against a real MariaDB) is the natural gate — it exercises every repository.
+
+*Plan:* standalone PR, no other changes in it. Read the official 6→7 upgrade guide, migrate the generator block, regenerate, run `bun run test:setup && bun test` against the CI MariaDB, then verify a real `migrate deploy` in a throwaway container before merging.
+
+---
+
+## Proposed sequencing
+
+**Step 1 — Hygiene (no version changes).** D1–D5. Declare `reflect-metadata`, drop or wire `dotenv`, pin `@types/bun`, move `typescript` to dev, reconcile Bun versions. Low risk, unblocks everything else.
+
+**Step 2 — Gates before touching versions.** Re-enable the commented-out static-analysis job in `.github/workflows/bot.yaml`, add `tsc --noEmit`, add `bun audit` to CI, add Renovate or Dependabot (grouped, so this never becomes a one-off project again). **Without a typecheck in CI, no dependency bump is verifiable** — the integration tests only cover the Application layer.
+
+**Step 3 — discord.js to latest 14.x.** Should be near-mechanical, but pair it with the deprecation cleanups in the [practices plan](06-discord-api-modernisation.md) since newer 14.x releases warn loudly on `ephemeral:` and `fetchReply:`, both of which this codebase still uses. Record the resulting undici version.
+
+**Step 4 — axios 1.8.4 → latest.** Only two files touch it (`AxiosHttpClient`, `RetryAxiosHttpClient`) behind the `HttpClient` domain port, so blast radius is tiny. Review 1.9→1.18 changelogs for `paramsSerializer`/`transformRequest` behaviour changes. *Alternative worth considering:* Bun and Node both ship `fetch` — the `HttpClient` port exists precisely so axios could be dropped entirely, removing `follow-redirects`, `form-data`, `proxy-from-env`, `combined-stream`, `mime-types`, `asynckit`.
+
+**Step 5 — inversify / winston / dayjs / uuid.** Batch minor+patch. `dayjs` and `uuid` each have exactly one call site, so they're trivially verifiable — and both are replaceable with stdlib (`crypto.randomUUID()` for uuid; `Temporal`/date math for the one `startOf('week')` call) if you want to shed deps.
+
+**Step 6 — winston-loki decision.** Keep / replace with HTTP / drop. Fix the `tedcrypto-campaign` label bug regardless.
+
+**Step 7 — Prisma 6→7, alone.** As above.
+
+---
+
+## Standing policy (so this doesn't recur)
+
+1. **Renovate or Dependabot**, grouped: one PR/week for patches, separate PRs for majors, `discord.js` in its own group.
+2. **`bun audit` in CI**, failing on high/critical.
+3. **No floating specs.** `latest` and bare `^5` are banned in `package.json`.
+4. **`tsc --noEmit` on every PR** — the actual safety net for dependency bumps.
+5. Pin the Bun base image and keep local + Docker in sync.
+
+## Environment note (not repo scope, but flagged)
+
+The workstation this plan was drafted on has npm/registry configuration issues that
+affect the trustworthiness of anything installed from it — notably TLS verification
+being disabled globally, which is why some registry reads succeeded here at all.
+That is **not a `discord-bot` concern** and is deliberately not documented in this
+public repo; it is tracked separately as a machine-configuration task outside the
+repository. Anyone reproducing a dependency bump should do so on a machine with
+default (verified) TLS.

--- a/docs/plans/GLOBAL-PLAN.md
+++ b/docs/plans/GLOBAL-PLAN.md
@@ -1,0 +1,541 @@
+# The Global Plan
+
+**One ordered route from "dormant repo with three live production failures" to
+"a maintained, modern, Portuguese community platform".**
+
+Written 2026-08-19. This is the **master work queue**. Every other document in
+`docs/` is either evidence (what is broken, and how we know) or detail (how one
+area should be built). This file is the only place that says **what to do next
+and in what order**, and it is the file to update as things land.
+
+---
+
+## How to use this document
+
+- **Work item IDs are stable** (`M4.7`, `M6.3`, …). Put the ID in the PR title
+  scope or body so the ledger can be updated without archaeology.
+- **One work item = one PR**, unless the item says otherwise. Items are sized so
+  a reviewer can hold the whole change in their head.
+- **Every item names its evidence** — the issue number, plan section or code
+  location that justifies it. If the evidence turns out to be wrong, fix the
+  evidence document too, don't just skip the item.
+- **Milestones are ordered, items inside a milestone mostly are not.** Where an
+  item genuinely blocks another it says so.
+- **Nothing here is a suggestion to skip tests.** The reason this repo
+  accumulated fourteen months of invisible breakage is that the layer where all
+  the bugs live has no tests at all.
+
+### Definition of done, for every item
+
+```bash
+cd discord-bot
+bunx prisma generate          # or the typecheck script, which does it for you
+bun run typecheck             # must be clean
+bun test                      # must be green
+```
+
+Plus: a test that would have caught the bug, a Conventional-Commit PR title with
+a scope (`fix(marketplace): …`, `feat(trophy): …` — **not** `chore:`, which cuts
+no release), and a migration (`make db.diff NAME=…`) if `schema.prisma` changed,
+because the production entrypoint runs `prisma migrate deploy` on every boot.
+
+### Where the evidence lives
+
+| Document | What it holds |
+| -------- | ------------- |
+| [`../known-issues.md`](../known-issues.md) | Itemised defects **#0–#24**, reproduced against production |
+| [`../discord-bot-feature-gap.md`](../discord-bot-feature-gap.md) | Everything the old bot did that the rewrite does not — rows **G1–G25** |
+| [`05-bot-audit-and-hardening.md`](05-bot-audit-and-hardening.md) | Security **A1–A8**, correctness **B1–B10**, API **C1–C7** |
+| [`06-discord-api-modernisation.md`](06-discord-api-modernisation.md) | Deprecations **P1–P5**, interaction lifecycle, components |
+| [`07-dependency-upgrades.md`](07-dependency-upgrades.md) | Locked inventory, hygiene defects **D1–D5**, Prisma 6→7 |
+| [`01`](01-marketplace-overhaul.md) [`02`](02-scheduler-and-lifecycle.md) [`03`](03-portal.md) [`04`](04-infrastructure-migration.md) | Per-area designs and task tables, all open questions already decided |
+| [`../session-log-2026-08-19.md`](../session-log-2026-08-19.md) | How we found all of this, and the decision log |
+
+---
+
+## The situation in five lines
+
+The bot is **live** and serving a real community (4,477 trophies, 624
+screenshots, 70 ads) and has been since April 2025. In that time
+`/marketplace sell` has failed on **100%** of invocations, the scheduler has run
+**zero** jobs, every one of the 624 stored screenshot images has **404**'d,
+`/trophy rank` has been ranking an arbitrary subset of profiles against a
+leaderboard **frozen since December 2024**, and any member could make the bot
+`@everyone` the server by naming an item `@everyone`. None of it was reported,
+because the project has no feedback loop: no type gate ran, no linter existed, no
+release was ever cut, and the discord.js layer — where every single one of those
+bugs lives — has **no tests**.
+
+So the ordering principle is: **stop the bleeding → restore the signal → make
+deployment real → modernise → build.** Resist starting at M8.
+
+---
+
+## Milestone map
+
+| # | Milestone | Why now | Blocks | Rough size |
+| - | --------- | ------- | ------ | ---------- |
+| **M0** | [Stop the bleeding](#m0--stop-the-bleeding) | Users are hitting these today | — | 3 PRs, days |
+| **M1** | [Restore the signal](#m1--restore-the-signal) | Nothing after this is verifiable without it | M3, M4 | 6 PRs, ~1 week |
+| **M2** | [Infrastructure cutover](#m2--infrastructure-cutover) | CI deploys to a machine that no longer exists | M5.11, M6, M8 | Runbook, needs Luis |
+| **M3** | [Dependency currency & container hygiene](#m3--dependency-currency--container-hygiene) | 14 months stale; two majors behind | M4 | 8 PRs |
+| **M4** | [Discord API modernisation](#m4--discord-api-modernisation) | The enabler for every feature below | M5, M6, M9 | 8 PRs |
+| **M5** | [Marketplace overhaul](#m5--marketplace-overhaul) | The most-used feature, in English, half-broken | M6.5 | 11 PRs |
+| **M6** | [Jobs, lifecycle & media durability](#m6--jobs-lifecycle--media-durability) | Recovers 624 screenshots; stops ads accumulating forever | M8 | 8 PRs |
+| **M7** | [Trophies — make the leaderboard true](#m7--trophies--make-the-leaderboard-true-again) | A shipped feature that silently lies | — | 8 PRs |
+| **M8** | [Community portal](#m8--community-portal) | The public face; makes moderation possible without SSH | — | 15 PRs, largest |
+| **M9** | [Close the feature gap, retire the dead weight](#m9--close-the-feature-gap-retire-the-dead-weight) | Finish the port so `old-discord-bot/` can die | — | Open-ended |
+
+```
+M0 ──▶ M1 ──▶ M3 ──▶ M4 ──┬──▶ M5 ──▶ M6 ──▶ M8
+                          └──▶ M9
+M2 (parallel, needs Luis) ───────▶ M5.11, M6.2, M8
+M7 (parallel after M0.8) ────────────────────▶ M8.9
+```
+
+**M2 runs in parallel from day one** — it is mostly credentials and DNS, it needs
+Luis specifically, and M5/M6/M8 all eventually need the MinIO bucket it creates.
+
+---
+
+## M0 — Stop the bleeding
+
+**Goal**: nothing the community touches today is silently broken or a security
+hole. Ship as two or three small PRs; do not bundle this with refactors.
+
+**Exit criteria**: `/marketplace sell` succeeds and stores a real `message_id`;
+no user-supplied string can make the bot mention anyone; no internal error text
+reaches a user; `/trophy rank` returns the actual top N; the DB password is not
+in `docker logs`.
+
+| ID | Item | Evidence | Notes |
+| -- | ---- | -------- | ----- |
+| **M0.1** | **Fix `/marketplace sell`.** Adopt post-then-persist: defer → build embed → send to the channel → **one** `CreateAd` write holding the real message ID → `editReply`. | [#0](../known-issues.md), [01 T1](01-marketplace-overhaul.md) | The single highest-value change in this document. Do **not** fix it by making `CreateAdHandler` return the `Ad` — that keeps the partial-failure window that caused the bug. |
+| **M0.2** | **`allowedMentions: { parse: [] }`** on the `Client` constructor **and** on every reply that echoes user input. `escapeMarkdown()` where raw content is unavoidable. | A1, [06 §5](06-discord-api-modernisation.md) | Live mass-ping exposure. An ad named `@everyone` pings the server today. |
+| **M0.3** | **Fix `reply(string, { flags })`.** Not a valid discord.js v14 signature — the options object is dropped, so these "ephemeral" error messages are posted **publicly**. | B2, P1 — `ScreenshotSlashCommand.ts:106`, `CreateScreenshotSubcommand.ts:28,34` | |
+| **M0.4** | **`safeReply()` helper** in `Domain/Bot/`, plus `replied \|\| deferred` guards in every catch block. | B3, P4 | `DiscordBot.ts:41-52` already does it correctly — copy that shape. Fixes the cascading `InteractionAlreadyReplied` that hides the real error. |
+| **M0.5** | **Stop leaking `error.message` to users.** Generic message + correlation id to the user, full error to the logger. | A3 — `DeleteAdSubcommand.ts:59` | |
+| **M0.6** | **Add `@injectable()` to `DeleteScreenshotSubcommand`.** Verified missing while its four siblings have it. | B4 — `.../Screenshot/DeleteScreenshotSubcommand.ts:12` | Confirmed by inspection 2026-08-19. Bound `.toSelf()`, so verify resolution at container build. |
+| **M0.7** | **`entrypoint.sh` hygiene**: stop printing the DB password; bound the readiness loop so a bad URL fails instead of hanging forever; parse `DATABASE_URL` properly instead of positional `cut`. | [#11](../known-issues.md), [#12](../known-issues.md) | Do this **before** anyone enables `LOKI_HOST`, or the password ships to Grafana Cloud. |
+| **M0.8** | **Fix `/trophy rank` correctness.** `take: limit` is applied in the Prisma query **before** points are summed and sorted in JS, so "top 10" is an arbitrary 10 profiles sorted among themselves. Aggregate and order in SQL. | B1 — `OrmTrophyRepository.ts:104,137,170` | Verified 2026-08-19: no `orderBy` on the query, `.sort()` happens after `take`. Affects all three rank modes **and** `findUserPosition`, which pulls 1000 profiles with all their trophies to index-search. |
+| **M0.9** | **Regression tests for M0.1–M0.4** in the discord.js layer. Hand-rolled fake interaction; assert on what the subcommand *sends*. | [#14](../known-issues.md), [01 T12](01-marketplace-overhaul.md) | The first brick of the safety net. Expands into M1.2. |
+
+> **If you only do one thing**: M0.1. One-file change, failing for real users
+> every day for sixteen months, and the test you write for it is the foundation
+> of everything else.
+
+---
+
+## M1 — Restore the signal
+
+**Goal**: make it impossible for a regression of this class to go unnoticed
+again. Cheap, self-contained, and it makes every later milestone verifiable.
+
+**Exit criteria**: CI runs typecheck + lint + tests + `bun audit` + schema-drift
+check on every PR; the discord.js layer has a real test harness; a missing env
+var fails the boot loudly instead of producing a silent do-nothing bot.
+
+| ID | Item | Evidence | Notes |
+| -- | ---- | -------- | ----- |
+| **M1.1** | **ESLint + Prettier**, wired into CI, tree formatted in one commit. | [#5](../known-issues.md) | Source files carry `// eslint-disable-next-line` comments for rules no configured linter enforces. Style is 4-space *and* 2-space, semicolons *and* not, sometimes in one directory. Pick one; the formatter arbitrates. |
+| **M1.2** | **Discord-layer test harness** — a fake interaction object and a suite covering every subcommand path. | [#14](../known-issues.md), [01 T12](01-marketplace-overhaul.md) | No mocking library needed and none should be added. Both merged bugfix PRs (#1, #2) and all three live bugs are in this layer. |
+| **M1.3** | **Env validation at boot** (zod or typebox). Exit non-zero on a missing required var; delete the three `?? ''` token fallbacks. | A6 | Today an unset `DISCORD_TOKEN` silently binds `InMemoryClient` and you get a bot that does nothing. |
+| **M1.4** | **`registerSlashCommands` fails loudly** — through the injected `Logger`, not `console.error`, and fatally rather than starting with a stale command set. | [#15](../known-issues.md), C3 | |
+| **M1.5** | **Schema-drift gate**: `prisma migrate diff --exit-code` in CI, and switch test setup from `db push` to `migrate deploy` so tests take production's path. | [#1](../known-issues.md), revival plan item 17 | The drift itself is fixed; this stops it recurring. |
+| **M1.6** | **Fix `.env.example`** and regenerate the production compose file from it — dropping the Redis container and the four env vars nothing reads. | [#8](../known-issues.md) | It advertises `REDIS_DSN` / `SENTRY_DSN` / `TROPHY_WEBHOOK` / `TELEGRAM_ACCESS_TOKEN` (all unused), omits `LOKI_HOST` / `LOKI_AUTH` (both used), and gives `DATABASE_URL` a host matching no service. `Makefile` does `include .env`, so it is the first thing a contributor copies. |
+| **M1.7** | **Externalise the hardcoded Discord IDs** to config. Add `MARKETPLACE` (`📖anuncios`), and the four LFG channels while you are in there. | [#16](../known-issues.md), [G5.5](../discord-bot-feature-gap.md) | Only `SCREENSHOTS` is mapped today; any channel change means a code change, image rebuild and redeploy. **The trophy emoji IDs are verified correct — do not "fix" them.** |
+| **M1.8** | **Clear the dead ends**: `test:local` → a file that does not exist; Makefile `create-user` / `console-command` / `db-seed` targets invoking `ts-node` (not a dependency) or a seed script that is not configured; `discord-bot/README.md` is unedited `bun init` boilerplate; decide the fate of the bound-but-uncalled `RetryAxiosHttpClient`. | [#17](../known-issues.md) | Keep `RetryAxiosHttpClient` — M7.1 is what it was clearly bound in anticipation of. |
+| **M1.9** | **Supply-chain gates**: `bun audit` failing on high/critical, plus Renovate or Dependabot **grouped** (weekly patches in one PR, majors separate, `discord.js` in its own group). | A7, [07 step 2](07-dependency-upgrades.md) | Without this, M3 becomes a one-off project that has to be repeated in 2027. |
+| **M1.10** | **Permission model.** A `ManageMessages`-based admin check plus guild-only contexts. | A2, [G19/§7.3](../discord-bot-feature-gap.md), [01 decision 4](01-marketplace-overhaul.md) | Small, and it **unblocks** M5.10, M9.1 and M9.3. Keys off the guild permission, not a role ID — no config to drift. Every command is invokable by every member in every channel today, including DMs, where `ListAdsSubcommand` builds links with `guildId === null`. |
+
+---
+
+## M2 — Infrastructure cutover
+
+**Goal**: merging to `main` actually changes production. Runs in parallel with
+everything else and is the one milestone that **needs Luis specifically** —
+credentials, DNS and production access.
+
+The repo side is **already built and lint-clean**: eight workflows, the
+`portainer-deploy` composite action, release-please config, the Portainer stack
+file and the Caddy vhosts. What remains is a runbook, written out step by step in
+[`04-infrastructure-migration.md`](04-infrastructure-migration.md).
+
+**Exit criteria**: a merge to `main` builds, pushes and rolls the HTZ1 Portainer
+stack; release-please cuts a real tagged release; `media.game-on-portugal.pt`
+serves a public object.
+
+| ID | Item | Evidence |
+| -- | ---- | -------- |
+| **M2.1** | **Phase 0 — safety net.** Dump production, restore it locally, confirm 4,477 / 624 / 118 / 70 row counts. Copy `~/game-on-portugal/.env` into 1Password (**it is the only copy of the bot token, on a home server**). Verify the nightly `databack/mysql-backup` output actually restores — nobody has ever checked. | [04 phase 0](04-infrastructure-migration.md) |
+| **M2.2** | **Phase 1 — repo wiring.** Squash-only merges, branch protection requiring `CI`, create `RELEASE_PLEASE_TOKEN` / `DOCKER_*` / `PORTAINER_ACCESS_TOKEN` / `DEPLOY_SSH_*` / `TELEGRAM_*`, delete the obsolete `CAPROVER_*` and `MY_RELEASE_PLEASE_TOKEN`. | [04 phase 1](04-infrastructure-migration.md), [#2](../known-issues.md), [#6](../known-issues.md) |
+| **M2.3** | **Phase 2 — HTZ1 prep, no cutover.** Tunnel-only deploy key **appended** to `~ezweb/.ssh/authorized_keys`; create the Portainer stack with a **placeholder `DISCORD_TOKEN`** so it cannot fight the live bot; restore the dump; add only the `media.` DNS record and Caddy vhost. | [04 phase 2](04-infrastructure-migration.md) |
+| **M2.4** | **Phase 3 — cutover** (~15 min downtime). Stop the old bot **first** — two bots on one token both receive interactions. Delta dump, real token, verify `/ping`, then re-enable `deploy.yml`'s commented-out `push` trigger and prove the pipeline end to end. | [04 phase 3](04-infrastructure-migration.md) |
+| **M2.5** | **Phase 5 — decommission.** Leave the TedRelayer stack stopped-but-intact for two weeks, then remove it keeping one final dump. Update `operations.md`, `AGENT.md` and `remote-hosts.md`. | [04 phase 5](04-infrastructure-migration.md) |
+| **M2.6** | **Resolve the two open items**: confirm `DEPLOY_SSH_PORT` (remote-hosts says `2224`, the ez-web SETUP files say `22`), and decide whether the MinIO console should be reachable at all. | [04 open items](04-infrastructure-migration.md) |
+
+> Phase 4 (the `game-on-portugal.pt` apex cutover) is deliberately **not** here —
+> it belongs with the portal, as **M8.15**. Do not bundle it with M2.4.
+
+---
+
+## M3 — Dependency currency & container hygiene
+
+**Goal**: nothing more than one minor version behind, on a machine that can be
+trusted to install it, in a container that does not run as root.
+
+**Blocked by M1** — without `tsc --noEmit` and a lint gate in CI, a dependency
+bump is unverifiable, because the integration tests only cover the Application
+layer.
+
+**Exit criteria**: `bun audit` clean; no floating version specs; Prisma 7;
+container runs non-root with a working healthcheck.
+
+| ID | Item | Evidence | Notes |
+| -- | ---- | -------- | ----- |
+| **M3.1** | **Hygiene, no version changes.** Declare `reflect-metadata` (imported for side effects in two files, **absent from `package.json`** — it resolves only because Inversify happens to pull it in). Drop or explicitly wire `dotenv` (declared, never imported; env loading works by accident of Bun auto-loading `.env`). Pin `@types/bun` off `latest`. Move `typescript` out of `peerDependencies` — this is an app. Reconcile the Bun version between the Dockerfile and local dev. | D1–D5 | Verified 2026-08-19: `reflect-metadata` absent, `dotenv` present, `@types/bun: "latest"`, `peerDependencies` block present. Low risk, unblocks the rest. |
+| **M3.2** | **discord.js 14.18.0 → latest 14.x**, and **record the resulting `undici` version**. Clear the deprecations in the same PR — newer 14.x warns loudly on both. | [#7](../known-issues.md), [#13](../known-issues.md), C2, P2 (7 sites), P3 (2 sites) | `discord.js` and `@discordjs/rest` pin `undici@6.21.1` **exactly**, so an undici advisory cannot be patched by an override — bumping discord.js is the only supported remedy. That is the standing argument for keeping it current. Note `fetchReply: true` → `withResponse: true` returns an `InteractionCallbackResponse`, **not** a `Message`; the call sites read `.id` off it and need adjusting. |
+| **M3.3** | **axios 1.8.4 → latest**, *or* drop it for native `fetch`. | [07 step 4](07-dependency-upgrades.md) | Only two files touch it, both behind the `HttpClient` domain port — which exists precisely so this is a contained decision. Dropping it removes six transitive packages. |
+| **M3.4** | **Batch the rest**: inversify, winston, dayjs, uuid. | [#7](../known-issues.md), [07 step 5](07-dependency-upgrades.md) | `dayjs` and `uuid` have exactly one call site each and are both replaceable with stdlib (`crypto.randomUUID()`; date math). |
+| **M3.5** | **winston-loki decision** — keep, replace with an HTTP push through the existing `HttpClient`, or drop for stdout scraping. **Fix the label bug regardless**: `LokiLogProvider` tags this bot's logs `job: 'tedcrypto-campaign'`. | [07 step 6](07-dependency-upgrades.md) | It drags in `snappy` (13 prebuilt native binaries) and `protobufjs` for one optional, env-gated log sink. Options b/c remove ~15 packages and all native binaries. |
+| **M3.6** | **Prisma 6 → 7, alone, as its own PR.** Migrate the generator block, add the now-required `output` path, regenerate, run the integration suite, and verify a real `migrate deploy` in a throwaway container before merging. | [#7](../known-issues.md), [#13](../known-issues.md), [07 step 7](07-dependency-upgrades.md) | The riskiest single move here. `docker/entrypoint.sh` runs `migrate deploy` at boot and `docker/Dockerfile` runs `generate` at build with `--production` installs — re-verify both. |
+| **M3.7** | **`::set-output` → `$GITHUB_OUTPUT`** sweep. | [#13](../known-issues.md) | Deprecated by GitHub since 2022. |
+| **M3.8** | **Container hardening**: non-root user, drop `mariadb-client` from the runtime layer, fix the accidental `COPY ../ .`, stop bind-mounting the repo `rw` in dev compose, and add a real `/health` endpoint plus a compose healthcheck. | A8, E | The container `EXPOSE`s 3000 and sets `PORT=3000` and **nothing listens** — so no orchestrator can tell whether the bot is alive. |
+
+---
+
+## M4 — Discord API modernisation
+
+**Goal**: the interaction layer is typed, cannot time out, and can dispatch
+components. This is the enabler for M5, M6 and M9 — do not start them first.
+
+The bot is on **API v10, which is current**. There is no version migration here.
+What is missing is everything v10 gained after this code was written.
+
+**Exit criteria**: `interaction: any` no longer appears anywhere; no handler can
+miss the 3-second deadline; buttons, autocomplete and modals route safely with
+server-side authorisation.
+
+| ID | Item | Evidence | Notes |
+| -- | ---- | -------- | ----- |
+| **M4.1** | **Type the interaction layer.** `SlashCommandContext.interaction` → `ChatInputCommandInteraction`; `builder()` → `SlashCommandBuilder`; introduce a discriminated `InteractionContext` covering chat-input / autocomplete / component / modal. | P5, C7 — `SlashCommandContext.ts:5` | **The enabler.** `interaction: any` is *why* M0.3, M0.4 and the `noUncheckedIndexedAccess` bugs got through review. Typing it converts a class of runtime bugs into compile errors — but only because M1 put `tsc --noEmit` in CI. |
+| **M4.2** | **`deferReply()` in every non-trivial handler**, then `editReply()`. | C1, [06 §2](06-discord-api-modernisation.md) | **There is not a single `deferReply()` in the codebase.** Worst offenders: `/screenshot create` downloads and MD5s an attachment inside the 3s window; `/trophy rank` loads up to 1000 profiles with all their trophies; `/marketplace delete` by position runs a query first. Deferring extends the window to 15 minutes. Note the ephemeral decision moves to `deferReply` and cannot be changed later. |
+| **M4.3** | **Registration overhaul.** Guild-scoped dev path behind `DISCORD_GUILD_ID`; hash the command set and skip the `PUT` when unchanged; add `setDefaultMemberPermissions`, `setContexts([Guild])` and `setIntegrationTypes`. | C3, C5, [06 §4](06-discord-api-modernisation.md), A2 | Global-only registration means up to an hour of propagation and no dev loop. `setContexts` also fixes commands being invokable in DMs. |
+| **M4.4** | **Lifecycle hardening.** `Events.Error` and shard errors, `process.on('unhandledRejection' \| 'uncaughtException')`, and SIGTERM → `client.destroy()` + `prisma.$disconnect()`. | C6, [06 §6](06-discord-api-modernisation.md) | The container is killed today without either, leaving gateway sessions dangling on every redeploy. |
+| **M4.5** | **Replace `DiscordGuildClient`'s second gateway client** with a REST-only `@discordjs/rest` client. | A5 | It lazily constructs and `login()`s a *whole second* `Client` on the same token and never destroys it, so the CLI process holds an open gateway session. Nothing it does (`channels.fetch`, `messages.fetch`, `send`) needs a gateway. |
+| **M4.6** | **Client configuration**: `makeCache` limits + sweepers (`messages` and `users` are what grow), and wire the REST client's rate-limit and invalid-request events into the `Logger`. | [06 §5–§6](06-discord-api-modernisation.md) | An invalid-request spike is how you learn you are heading for a Cloudflare ban *before* it happens. Keep the intents minimal — `GatewayIntentBits.Guilds` only is correct and should stay that way until M9.1 genuinely needs `MessageContent`. |
+| **M4.7** | **Component routing infrastructure.** A `ButtonHandler` interface in `Domain/Bot/`, a `TYPES.ButtonHandler` multi-binding, and dispatch on `isButton()` / `isStringSelectMenu()` / `isModalSubmit()` / `isAutocomplete()` by `customId` prefix (`mkt:sold:<adId>`). | C4, [01 T6](01-marketplace-overhaul.md) | **Always re-check ownership server-side from the row — never trust the `customId`.** Anyone can click anyone's button. `BotExecutor` handles chat-input only today. |
+| **M4.8** | **Autocomplete on both delete commands**, filtered to the invoking user's own records. Delete the positional-index hack. | [06 §3d](06-discord-api-modernisation.md) | Best value-to-effort ratio in the whole modernisation. Both commands currently ask the user to **paste a UUID**, with a fragile `/^\d+$/` "the Nth ad" workaround bolted on. Must answer in 3s and cannot be deferred — keep the query indexed. |
+| **M4.9** | **Attachment ingest safety**: cap on `image.size` before fetching, a streamed max-bytes limit, an explicit timeout, and a Discord CDN host allowlist. | A4 — `CreateScreenshotHandler.generateMd5FromImageUrl()` | Currently fetches an arbitrary URL into memory with no cap and no timeout beyond axios defaults. |
+| **M4.10** | **Output-size safety**: guard embed limits (25 fields, 1024 chars/field, 6000/embed) and add a 2000-char message chunking helper. | B6, [G7.4](../discord-bot-feature-gap.md) | `ListAdsSubcommand` adds one field per ad with **no cap** — a user with 26 listings breaks the command outright. `ListScreenshotSubcommand` caps at 10. Make it consistent. |
+
+---
+
+## M5 — Marketplace overhaul
+
+**Goal**: `/marketplace` is correct, complete, Portuguese and pleasant on a
+phone, without losing the 70 ads already in the database.
+
+Full design in [`01-marketplace-overhaul.md`](01-marketplace-overhaul.md), whose
+decisions are settled. M0.1 already did its task 1; M1.2 did its task 12.
+
+**Depends on**: M4.7 (buttons), M1.10 (admin check), M2.3 (MinIO, for M5.11).
+**M5.3 must land before M5.5–M5.10.**
+
+**Exit criteria**: an ad can be created with photos, browsed, searched, edited,
+bumped and marked sold, in Portuguese, with the listing message and the row
+staying in sync.
+
+| ID | Item | Evidence |
+| -- | ---- | -------- |
+| **M5.1** | **Route ads to `📖anuncios`** via `GuildClient` instead of `interaction.reply()`. Five ads are currently sitting in `💬chat` and three elsewhere. | [#20](../known-issues.md), [G2.4](../discord-bot-feature-gap.md), [01 T2](01-marketplace-overhaul.md) |
+| **M5.2** | **Delete removes the Discord message**, tolerating an already-deleted one. The channel is accumulating listings for ads that no longer exist. | [#21](../known-issues.md), [G2.2](../discord-bot-feature-gap.md), [01 T3](01-marketplace-overhaul.md) |
+| **M5.3** | **Schema migration**: `status`, `price_cents`, `images`, `bumped_at`, `expires_at`, `sold_at`, `deleted_at`, plus indexes. Backfill `status='active'`, normalise `adType` (`'sale'` → `'sell'`, 3 values → 2 concepts), parse `price_cents` where unambiguous. | [#22](../known-issues.md), [01 T4](01-marketplace-overhaul.md) |
+| **M5.4** | **pt-PT copy pass** across every marketplace string, plus `setDescriptionLocalizations`. | [#24](../known-issues.md), [G7.11](../discord-bot-feature-gap.md), [01 T5](01-marketplace-overhaul.md) |
+| **M5.5** | **Listing embed + buttons** — `💬 Contactar` / `✅ Marcar vendido` / `🔄 Renovar`, colour-coded by type, ad ID in the footer so a row can be recovered from the message alone. | [01 T6](01-marketplace-overhaul.md) |
+| **M5.6** | **`sold` / `bump` / `edit` subcommands.** Bump rate-limited to once per ad per 72h. | [01 T7](01-marketplace-overhaul.md) |
+| **M5.7** | **`wanted` subcommand** — restores an old-bot feature; lives in `📖anuncios` alongside sales, distinguished by colour and title. | [G3](../discord-bot-feature-gap.md), [01 T8](01-marketplace-overhaul.md) |
+| **M5.8** | **`list` improvements**: ephemeral, paginated, status-aware, working links. | [01 T9](01-marketplace-overhaul.md) |
+| **M5.9** | **`search` subcommand** + `AdRepository.search()` — keyword / zone / type / condition / max price. The marketplace has no browse at all today. | [01 T10](01-marketplace-overhaul.md) |
+| **M5.10** | **Limits + admin override**: max 10 active ads per user; `ManageMessages` holders bypass ownership on `delete`/`sold`. | [G2.3](../discord-bot-feature-gap.md), [01 T11](01-marketplace-overhaul.md) |
+| **M5.11** | **Item images re-hosted to MinIO at upload**, never linked from Discord's CDN. | [01 decision 5](01-marketplace-overhaul.md) — needs M2.3 |
+
+> **Settled, do not relitigate**: the create flow keeps slash-command *options*
+> rather than a modal (modals cannot accept attachments or select menus, which
+> would make images impossible); the 28 orphaned `message_id`s are **not**
+> backfilled heuristically — they get marked expired on the first lifecycle run;
+> historical free-text `state`/`zone` rows are **mapped at display time**, never
+> rewritten.
+
+---
+
+## M6 — Jobs, lifecycle & media durability
+
+**Goal**: scheduled work actually runs, the 624-screenshot gallery has live
+images again, and ads have a real lifecycle instead of accumulating forever.
+
+Full design in [`02-scheduler-and-lifecycle.md`](02-scheduler-and-lifecycle.md).
+
+**Depends on**: M5.3 (status columns), M5.5 (buttons), M2.3 (MinIO).
+**M2 should land before M6.3**, so recovered images are written into storage that
+will still exist afterwards rather than to TedRelayer twice.
+
+**Exit criteria**: a job runs on schedule and reports its outcome; ≥90% of the
+624 screenshot rows resolve to a real message and a live image; the weekly winner
+names a real winner; ads expire rather than pile up.
+
+| ID | Item | Evidence | Notes |
+| -- | ---- | -------- | ----- |
+| **M6.1** | **In-process job runner** replacing the `scheduler/` container, keeping `bin/console.ts` as the manual entry point. | [#3](../known-issues.md), [02 T1](02-scheduler-and-lifecycle.md) | The Chadburn + supervisord + `update_container.py` indirection existed **only** to cope with CapRover's generated container names, which docker-compose does not have. It also mounts `/var/run/docker.sock` — root-equivalent host access, for a cron job, on a box also running Plex and Frigate. |
+| **M6.2** | **Fix screenshot capture at source**: store the **posted message's** ID (not `interaction.id`) and re-host the image at submit time. | [#18](../known-issues.md), [#19](../known-issues.md), [02 T2](02-scheduler-and-lifecycle.md) | Verified: stored `1511065198885212340` does not resolve; the real message is `1511065203364860014`. Same root cause as M0.1. |
+| **M6.3** | **`screenshots:relink`** recovery job — page back through `🖼screenshots`, match the `ID: #<uuid>` in each message **deterministically**, repair `message_id`, re-host the freshly-signed attachment. | [02 T3](02-scheduler-and-lifecycle.md) | Idempotent, rate-limit-aware, honest reporting of unmatched rows and unmatched messages. |
+| **M6.4** | **Unblock and harden `screenshots:winner`**: dry-run the first production run to an admin channel, handle ties explicitly, skip vanished messages quietly, restore the old bot's contest-opening banner, and **drop the `!give-xp` line** unless someone confirms the receiving bot still exists. | [#3](../known-issues.md), [G7](../discord-bot-feature-gap.md), [02 T4](02-scheduler-and-lifecycle.md) | Also verify `findByWeek`'s window matches the old bot's Monday→Sunday before trusting parity. |
+| **M6.5** | **`ads:lifecycle`** — 14 days idle → prompt → 72h → **expire, never delete**. Buttons instead of DM reactions; one DM listing all of a user's expiring ads; renewal bumps **the same row** with a new `message_id`. | [G5](../discord-bot-feature-gap.md), [02 T5](02-scheduler-and-lifecycle.md) | The old bot's version deleted the row on silence *and* on a closed DM. Keep its shape, drop the data loss. |
+| **M6.6** | **`ads:reconcile`** — walk active ads, mark rows whose message has vanished. Catches moderator deletions and M0.1's orphan case. | [02 T6](02-scheduler-and-lifecycle.md) | |
+| **M6.7** | **Retire `scheduler/`**; update compose, `AGENT.md` and `operations.md`; archive the standalone `GameOnPortugal/scheduler` repo. | [02 T7](02-scheduler-and-lifecycle.md), revival plan item 26 | |
+| **M6.8** | **Job observability** — a per-run summary to an admin channel, so a failed run is visible without SSH. | [02 T8](02-scheduler-and-lifecycle.md) | |
+
+> Every job gets: structured start/finish logs with counts, a `--dry-run` flag,
+> and a bounded work limit per run. And after deploying, **verify inside the
+> container** — trusting the repo about what is deployed is exactly how this went
+> unnoticed for sixteen months.
+
+---
+
+## M7 — Trophies — make the leaderboard true again
+
+**Goal**: `/trophy rank` reflects trophies people actually earned this month.
+
+This is the **highest-value gap in the port**, because the feature *appears* to
+work: 118 profiles and 4,477 trophies are presented as a live leaderboard that has
+not moved since **2024-12-02**. The read side was ported; the entire
+data-producing side was not.
+
+**Depends on**: M0.8 (ranking correctness) and M3.3 (whatever HTTP client wins).
+Otherwise parallel with M5/M6.
+
+**Exit criteria**: the sync job creates new trophy rows on a schedule, the
+"data frozen" caveat can be deleted from the portal and the bot, and moderation
+flags are written as well as read.
+
+| ID | Item | Evidence |
+| -- | ---- | -------- |
+| **M7.1** | **Port the PSNProfiles crawler** behind a `TrophySource` domain port — platinum rarity + completion date (incl. the blank-first-row workaround and "not earned yet" detection), profile world/country rank, paginated platinum lists. Respect robots and rate limits; cache; back off. | [#10](../known-issues.md), [G11 / §4.1](../discord-bot-feature-gap.md) |
+| **M7.2** | **Port the points engine** — the rarity→TP ladder (>30.01% = 50 TP … ≤0.6% = 2000 TP) and `TrophyAlreadyClaimedException` (one claim per profile+URL). | [§4.2](../discord-bot-feature-gap.md) |
+| **M7.3** | **`trophies:sync` job** with catch-up mode (stop early at the first already-claimed trophy, unless `--all --profile=X`) and the auto-moderation flags: no rank → `isBanned` + `isExcluded`; Discord error 10007 → `hasLeft` + `isExcluded`. | [§4.3](../discord-bot-feature-gap.md) |
+| **M7.4** | **`/trophy check` shows live world/national rank again**, and the specific message when a profile is banned or has left. | [§4.5](../discord-bot-feature-gap.md) |
+| **M7.5** | **`/trophy create` accepts both URL shapes** — bare profile and the 6-segment trophy URL. | [§4.6](../discord-bot-feature-gap.md) |
+| **M7.6** | **Rank presentation parity** — the guild's custom plat/gold/silver/bronze emojis for positions 1/2/3/rest, and pagination buttons instead of a `limit` option capped at 10. | [§4.7](../discord-bot-feature-gap.md), C4 |
+| **M7.7** | **`fix-old-trophies` backfill** as a console command, for rows with a null `completionDate`. | [§4.4](../discord-bot-feature-gap.md) |
+| **M7.8** | **Decide the trophy webhook**: reinstate `TROPHY_WEBHOOK` announcements ("Parabéns \<@user\>! Acabaste de receber N TP…") or drop the env var. | [§7.7](../discord-bot-feature-gap.md), [#8](../known-issues.md) |
+
+---
+
+## M8 — Community portal
+
+**Goal**: a public site that promotes the community and shows what it produces,
+plus an admin portal so moderation stops meaning SSH and SQL.
+
+Full design, brand direction, page list and task table in
+[`03-portal.md`](03-portal.md). Phase A can start in parallel with M5–M7; the
+Screenshots page (M8.8) is hard-blocked on M6.3.
+
+**Depends on**: M2 (hosting, MinIO), M6.3 (live images).
+
+**Exit criteria**: `game-on-portugal.pt` serves the portal; an admin can moderate
+ads, screenshots and jobs from a browser; a shared link previews with the brand.
+
+| ID | Item |
+| -- | ---- |
+| **M8.1** | Vendor the brand — guild icon + banner into the repo, trace an SVG, define design tokens. **There is no logo file in this repo today**; `webpage/assets/img/logo.png` is referenced by `index.html` and does not exist. |
+| **M8.2** | Add `portal-api` / `portal-web` to release-please config **and** manifest, and uncomment their services in `infrastructure/game-on-portugal.yaml` — in the same PR that creates the directories (release-please errors on a package path that does not exist). |
+| **M8.3** | Scaffold `portal/api` (Bun + Hono) with read-only endpoints. **The bot owns the schema**; the portal reads it and never runs migrations. |
+| **M8.4** | **Shared normalisation module** — 21 platform strings → 4 platforms + Other; legacy Portuguese conditions → the enum; zone → district; `price_cents`. Used by **both** bot and portal so a listing renders identically in Discord and on the web. Map at display time; never rewrite history. |
+| **M8.5** | Scaffold `portal/web` (Vite + React + Tailwind), mobile-first at 375 px. |
+| **M8.6** | Home page — hero, live stats, latest screenshots, newest listings, Discord CTA. |
+| **M8.7** | Marketplace pages — grid, filters, detail. |
+| **M8.8** | Screenshots gallery + Hall of Fame. **Blocked on M6.3.** Thumbnails at ingest — a phone must not download a 4 MB PNG per grid tile. |
+| **M8.9** | Trophies leaderboard, with an honest "data frozen" notice until M7 lands. |
+| **M8.10** | Discord OAuth + admin shell, gated on guild membership **and `ManageMessages`** — the same definition of "admin" the bot uses. |
+| **M8.11** | Admin CRUD + audit log. |
+| **M8.12** | Admin jobs page, wired to M6.1's runner. |
+| **M8.13** | SEO, OG cards, sitemap. |
+| **M8.14** | Deploy + CI, documented in `operations.md`. |
+| **M8.15** | **Plan 04 phase 4** — point the `game-on-portugal.pt` apex and `www` at HTZ1 (and **refresh the OVH zone**, which applies the zone, not the record), add the apex Caddy block, archive `GameOnPortugal/gameonportugal.github.io`, and delete this repo's orphaned `webpage/`. Resolves [#9](../known-issues.md). |
+
+> **Settled**: dark-first (the brand is black); the four brand face-button colours
+> are the four platform colours, assigned once and never varied; pt-PT only for
+> v1, structured for i18n; v1 **includes** the admin portal; display names only,
+> never user IDs, with an opt-out from day one.
+
+---
+
+## M9 — Close the feature gap, retire the dead weight
+
+**Goal**: everything in `old-discord-bot/` is either ported or explicitly
+dropped, so the directory can be deleted and the feature-gap document closed.
+
+**Depends on**: M1.10 (permissions) and M4 throughout.
+
+| ID | Item | Evidence | Notes |
+| -- | ---- | -------- | ----- |
+| **M9.1** | **Channel restrictions + message validator** — the `regex` and `only_commands` handlers, admin bypass, offending message deleted and DM'd back. | [G16 / §6.1](../discord-bot-feature-gap.md) | Arguably the highest-value non-LFG gap, and the enforcement layer the marketplace and screenshot channels were designed around. **Needs the `MessageContent` intent and a message-event pipeline — the rewrite has neither.** Weigh that intent against M4.6's minimal-intents position before starting. |
+| **M9.2** | **`commandchannellink`**, *or* the explicit decision to drop it in favour of the static channel config from M1.7. | [G17 / §6.2](../discord-bot-feature-gap.md) | M5.1 already hardcodes the marketplace channel. If static config is enough, **decide and delete the table** rather than leaving a third unused model. |
+| **M9.3** | **LFG** — 11 subcommands, the points model (+20 create / +10 participate / +5 commend / −10 leave / −30 miss / −20 cancel, doubled under 1h), the aggregation cron, and banned-user enforcement. **Needs its own spec document before any code.** | [G13, G14 / §5](../discord-bot-feature-gap.md) | The largest single gap, ~40% of the old bot's surface. The four Prisma models already exist and the tables are **empty** — greenfield, no migration, but also no continuity with the community's old rankings, which is worth telling users. **Open question for Luis: is LFG actually wanted back, or was dropping it deliberate?** |
+| **M9.4** | **Stock alerts + Telegram bridge** — the fan-out ladder (immediate Telegram Prime + Discord premium ping → +3 min `@everyone` free channel → +5 min Telegram everyone). | [G15 / §7.5](../discord-bot-feature-gap.md) | **Decide first whether the community still uses it.** Lowest value in the gap list; a legitimate candidate for "explicitly dropped". Note the legacy `setTimeout` implementation silently lost pending alerts on restart — a port needs durable scheduling (M6.1). |
+| **M9.5** | **Sentry vs Loki decision**, and delete whichever env vars lose. | [G22 / §7.6](../discord-bot-feature-gap.md), [#8](../known-issues.md) | Recommend: Loki only. Then `SENTRY_DSN`, `REDIS_DSN`, `TROPHY_WEBHOOK` and `TELEGRAM_ACCESS_TOKEN` all leave `.env.example` and the compose file for good. |
+| **M9.6** | **Retire `old-discord-bot/`** — move to `reference/` when the port is done so it stops looking like something that builds, then delete once M9.3/M9.4 are settled. | revival plan item 25 | It is the only spec for the scraper, LFG and stock. Do not delete it early. |
+| **M9.7** | **Privacy**: a single `public_opt_out` flag honoured by **both** the bot and the portal, a short privacy page, and a deletion request path that removes portal content too. | [03 decision 5](03-portal.md) | The community is EU-based. Cheap now, expensive to retrofit — do it with M8.7, not after. |
+
+---
+
+## Cross-cutting rules
+
+These are not milestones. They are constraints on every PR in every milestone.
+
+1. **pt-PT for all user-facing copy.** Command and subcommand *names* stay
+   English — they are already registered with Discord and English verbs are the
+   platform convention — but everything a member **reads** is Portuguese. The
+   rewrite's English is a regression, not a decision anyone made.
+2. **Soft-delete, never hard-delete.** The old bot destroyed rows on expiry,
+   which is why nothing can be reconstructed.
+3. **Never store a Discord CDN URL as the durable copy of an image.** They are
+   signed and expire within 24 hours. This is the sole cause of the empty
+   gallery.
+4. **Store the ID of the message you actually posted** — not `interaction.id`,
+   not a placeholder to be filled in later. Both live data-corruption bugs are
+   this one mistake.
+5. **Schema changes need a migration**, because `prisma migrate deploy` runs in
+   the container entrypoint and a failing migration is a failed **boot**, not a
+   failed CI job.
+6. **Nothing is reachable until it is bound** in
+   `Infrastructure/DependencyInjection/inversify.config.ts`. A handler, a
+   subcommand or a repository that is not bound there simply does not exist.
+7. **Conventional Commit PR titles with a scope.** PRs are squash-merged and the
+   title becomes the commit release-please reads. `chore:` cuts no release — the
+   repo's 30-commit `chore:` streak is precisely why nothing has ever shipped.
+8. **Verify in production, not in the repo.** The scheduler ran zero jobs for
+   sixteen months while the repo said otherwise.
+
+---
+
+## Progress ledger
+
+Update this table as items land. `—` = not started.
+
+| Milestone | Items | Done | Status |
+| --------- | ----- | ---- | ------ |
+| M0 Stop the bleeding | 9 | 0 | — |
+| M1 Restore the signal | 10 | 0 | partial: `tsc --noEmit`, CodeQL/Trivy/Gitleaks and PR-title linting are already in CI |
+| M2 Infrastructure cutover | 6 | 0 | repo side **built**; needs credentials, Portainer stack and DNS |
+| M3 Dependencies & container | 8 | 0 | — |
+| M4 Discord API modernisation | 10 | 0 | — |
+| M5 Marketplace overhaul | 11 | 0 | — |
+| M6 Jobs, lifecycle & media | 8 | 0 | — |
+| M7 Trophies | 8 | 0 | — |
+| M8 Community portal | 15 | 0 | — |
+| M9 Feature gap & dead weight | 7 | 0 | — |
+| **Total** | **92** | **0** | |
+
+Already closed before this plan was written: [#1](../known-issues.md) (schema
+drift), [#4](../known-issues.md) (6 type errors), and the repo side of
+[#2](../known-issues.md) and [#6](../known-issues.md) (CI/CD rewritten,
+release-please reconfigured).
+
+---
+
+## Open questions for Luis
+
+Four decisions this plan cannot make on its own. Everything else has been
+decided and is recorded in the per-area plans.
+
+1. **Is LFG wanted back?** (M9.3) It is ~40% of the old bot's surface and its
+   tables are empty, so it is a greenfield build, not a restoration.
+2. **Is stock alerting still used?** (M9.4) If not, delete `StockUrls` and the
+   Telegram dependency rather than porting them.
+3. **Sentry or Loki?** (M9.5) Both are currently half-configured; neither is
+   fully wired.
+4. **How long is screenshot retention a requirement?** It drives the MinIO
+   sizing in M2.3 and the thumbnail strategy in M8.8.
+
+---
+
+## Traceability
+
+Every finding in the evidence documents maps to exactly one work item. If you
+find something here without a source, or a source without an item, that is a bug
+in this document.
+
+### `known-issues.md` → work items
+
+| Issue | Item | Issue | Item |
+| ----- | ---- | ----- | ---- |
+| #0 sell fails 100% | M0.1 | #13 deprecated APIs | M3.2, M3.6, M3.7 |
+| #1 schema drift | ✅ fixed · gated by M1.5 | #14 no discord.js tests | M0.9, M1.2 |
+| #2 CI deploys nowhere | repo side ✅ · M2.2, M2.4 | #15 silent registration failures | M1.4 |
+| #3 scheduler never ran | M6.1, M6.4 | #16 hardcoded IDs | M1.7 |
+| #4 six type errors | ✅ fixed | #17 dead ends | M1.8 |
+| #5 nothing gates quality | M1.1 (lint) · rest ✅ | #18 wrong screenshot message ID | M6.2, M6.3 |
+| #6 no release ever cut | repo side ✅ · M2.2 | #19 all image URLs dead | M6.2, M6.3, M5.11 |
+| #7 stale dependencies | M3.1–M3.6 | #20 ads posted anywhere | M5.1 |
+| #8 wrong `.env.example` | M1.6, M9.5 | #21 delete leaves the message | M5.2 |
+| #9 orphaned `webpage/` | M8.15 | #22 `adType` drift | M5.3 |
+| #10 trophies frozen | M7.1–M7.3 | #23 free-text columns | M5.3, M8.4 |
+| #11 password in logs | M0.7 | #24 Portuguese dropped | M5.4, cross-cutting rule 1 |
+| #12 unbounded DB wait | M0.7 | | |
+
+### `05-bot-audit-and-hardening.md` → work items
+
+| Finding | Item | Finding | Item |
+| ------- | ---- | ------- | ---- |
+| A1 mention injection | **M0.2** | B1 rankings wrong | **M0.8** |
+| A2 no authorisation | M1.10, M4.3 | B2 ephemeral dropped | M0.3 |
+| A3 error leakage | M0.5 | B3 double-reply | M0.4 |
+| A4 unbounded download | M4.9 | B4 missing `@injectable()` | M0.6 |
+| A5 second gateway client | M4.5 | B5 empty multiInject | ✅ verified safe |
+| A6 empty-token fallback | M1.3 | B6 embed limits | M4.10 |
+| A7 no supply-chain gate | M1.9 | B7 duplicate write on sell | M0.1 |
+| A8 container runs as root | M3.8 | B8 image URLs rot | M6.2 |
+| C1 no `deferReply` | M4.2 | B9 unchecked rank indexing | M0.8, M7.6 |
+| C2 deprecated options | M3.2 | B10 `ads[position]` undefined | ✅ fixed |
+| C3 global-only registration | M4.3, M1.4 | E0 dependency currency | M3.1–M3.6 |
+| C4 no components | M4.7, M4.8, M5.5, M7.6 | E no healthcheck | M3.8 |
+| C5 missing registration metadata | M4.3, M5.4 | E `entrypoint.sh` password | M0.7 |
+| C6 no lifecycle handlers | M4.4 | D (capability gaps) | M7, M9 |
+| C7 untyped interactions | M4.1 | | |
+
+### `06-discord-api-modernisation.md` → work items
+
+P1 → M0.3 · P2/P3 → M3.2 · P4 → M0.4 · P5 → M4.1 · §2 lifecycle → M4.2 ·
+§3a Components V2 → M5.5 (spike first, embeds are the fallback) · §3b buttons →
+M5.5, M6.5, M7.6 · §3c modals → M5.6 · §3d autocomplete → M4.8 ·
+§3e context menus → **deferred**, revisit after M4.7 · §4 registration → M4.3 ·
+§5 client config → M0.2, M4.6 · §6 rate limits → M4.6, M6.3 ·
+§7 localisation → M5.4 · §8 attachment expiry → M6.2 · §9 discord.js v15 →
+covered incidentally by M0.3/M0.4/M3.2, not a milestone.
+
+### `07-dependency-upgrades.md` → work items
+
+D1 `reflect-metadata` · D2 `dotenv` · D3 `@types/bun` · D4 `typescript` peer ·
+D5 Bun drift → all **M3.1**. Step 2 gates → M1.9 + M1 generally · step 3
+discord.js → M3.2 · step 4 axios → M3.3 · step 5 batch → M3.4 · step 6
+winston-loki → M3.5 · step 7 Prisma → M3.6 · standing policy → M1.9.
+The machine-configuration note is **out of repo scope** and tracked separately.
+
+### `discord-bot-feature-gap.md` → work items
+
+| Row | Item | Row | Item |
+| --- | ---- | --- | ---- |
+| G1 ping | ✅ | G14 LFG points cron | M9.3 |
+| G2 sell | M0.1, M5.1–M5.5 | G15 stock alerts | M9.4 *(decide first)* |
+| G3 wanted ads | M5.7 | G16 channel restrictions | M9.1 |
+| G4 list / delete | M5.2, M5.8, M5.10 | G17 command→channel link | M9.2 |
+| G5 has-been-sold cron | M6.5 | G18 command prefix | ✅ obsolete by design |
+| G6 screenshot CRUD | M6.2 | G19 permission checks | M1.10 |
+| G7 weekly winner | M6.4 | G20 DM wizards | superseded — preview/confirm lands with M5.6 |
+| G8 link PSN profile | M7.5 | G21 message chunking | M4.10 |
+| G9 check profile | M7.4 | G22 Sentry | M9.5 |
+| G10 ranks | M0.8, M7.6 | G23 Telegram bridge | M9.4 |
+| G11 PSN crawler | **M7.1** | G24 trophy webhook | M7.8 |
+| G12 fix-old-trophies | M7.7 | G25 Redis / Keyv | ✅ dropped — M1.6 removes the container |
+| G13 LFG subsystem | M9.3 | | |

--- a/docs/session-log-2026-08-19.md
+++ b/docs/session-log-2026-08-19.md
@@ -1,0 +1,186 @@
+# Game On Portugal — revival session log (2026-08-19)
+
+> Moved into the repo from `~/claude-plans/2026-08-19-gameonportugal-revival.md`.
+> This is the **durable record** of the session that produced `docs/` and
+> `docs/plans/` — what was explored, what was decided and why. It is history, not
+> a work queue: the work queue is [`plans/GLOBAL-PLAN.md`](plans/GLOBAL-PLAN.md).
+
+**Status**: planning complete; CI/CD pipeline + infra scaffolding built; two
+production bugs fixed. 2026-08-19.
+
+## TL;DR
+
+The GameOnPortugal monorepo went dormant on 2025-06-30 but the Discord bot never
+stopped running — it is live on TedRelayer with 4,477 trophies, 624 screenshots
+and 70 ads of real community data, and members still use it. Fourteen months of
+absence hid three production failures that nobody noticed, because the project
+has no feedback loop of any kind. This session documented the whole system from
+scratch (`AGENT.md` + `docs/`), audited it against production, and wrote four
+agent-ready plans: marketplace overhaul, scheduler/lifecycle, a new community
+portal, and the migration off the home server. The CI/CD pipeline and infrastructure definitions are built and validated; what
+remains there is credentials, a Portainer stack and a DNS cutover.
+
+## What was done (2026-08-19)
+
+1. **Full exploration and documentation.** Created `AGENT.md` (symlinked to
+   `CLAUDE.md`) and `docs/`: `state-of-the-project.md`, `architecture.md`,
+   `operations.md`, `known-issues.md`, `revival-plan.md`. Everything verified
+   against the running system rather than inferred.
+2. **Production audit** over SSH to TedRelayer — containers, logs, database,
+   Discord API. Found and quantified three live bugs.
+3. **Four plans** in `docs/plans/`, written to be handed to independent agents:
+   `00-overview.md` (shared context), `01-marketplace-overhaul.md`,
+   `02-scheduler-and-lifecycle.md`, `03-portal.md`, `04-infrastructure-migration.md`.
+   Every open question has been **decided** and recorded in each plan.
+4. **Replaced the whole CI/CD pipeline** with the ez-web house pattern: deleted
+   the nine CapRover-era workflows, added `ci · docker-build · deploy ·
+   release-please · pr-title · labeler · security · workflow-failed`, the
+   `portainer-deploy` composite action, the `game-on-portugal` Portainer stack
+   (bot + MariaDB + **new MinIO** + backup), the Caddy vhosts, and
+   `infrastructure/SETUP.md`. `actionlint` clean.
+5. **Fixed issues #1 and #4** so CI can actually go green: relaxed
+   `Ad.state/price/zone` to nullable (no migration needed — the DB was already
+   nullable, only `schema.prisma` disagreed) and fixed the two real type errors
+   in `DeleteAdSubcommand.ts`. `bun run typecheck` clean, 32/32 tests pass,
+   `prisma migrate diff` reports no drift.
+6. **Updated `~/.claude/projects/-Users-joshlopes/memory/remote-hosts.md`** with
+   the Game On Portugal deployment specifics.
+
+Nothing committed — the work sits in the worktree
+`/Users/joshlopes/work/gameonportugal/.worktrees/new-task-82ca7140` on branch
+`luis/new-task-82ca7140`. Source changes are limited to the three files in item 5
+plus `package.json` (a `version` field, required by release-please's `node` type,
+and a `typecheck` script).
+
+## Findings worth not relearning
+
+**The deployment moved and the repo never found out.** Superman (CapRover) was
+decommissioned 2026-06-30; the stack was hand-migrated to TedRelayer as plain
+docker-compose at `~/game-on-portugal/`, and nobody updated the repo — so
+**merging to `main` did nothing**. The workflows have now been rewritten to
+target HTZ1, but until plan 04 is executed production still only changes via
+`docker compose pull && up -d` over SSH.
+
+**`/marketplace sell` fails on every use.** `CreateAdHandler.handle()` returns
+`void`; `SellSubcommand` awaits it and reads `ad.id` → `TypeError`. The ad saves
+with `message_id = ''`, the listing posts, then the catch replies a second time
+and throws `InteractionAlreadyReplied`. 28 of 33 post-rewrite ads are orphaned
+from their Discord message. Failure rate 100%, unreported for over a year.
+
+**The scheduler has never run a job.** Its deployed image was pushed 2025-04-19
+14:27; the commit enabling the weekly screenshot winner landed 2025-04-20 09:56.
+Seventeen hours, never rebuilt. Every job in the container's `config.ini` is
+commented out.
+
+**And fixing that alone wouldn't help** — `CreateScreenshotSubcommand` stores
+`interaction.id` as `message_id` instead of the posted message's ID, so the
+winner job fetches a non-existent message for every screenshot and always
+concludes "no winner". Recoverable: the real messages exist, carry `plat`
+reactions, and embed the screenshot UUID in their content.
+
+**All 624 screenshot images are dead** (HTTP 404). The bot stored Discord's
+signed CDN URLs, which expire in 24h. Recoverable from the messages, but any
+future design must re-host at ingest.
+
+**Trophies are frozen at 2024-12-02** because the psnprofiles.com scraper was
+never ported from the old bot. `/trophy rank` shows a two-year-old leaderboard as
+if it were current.
+
+**The rewrite dropped Portuguese.** The old bot spoke pt-PT throughout; every
+string in the TypeScript rewrite is English, in a Portuguese community.
+
+**The brand exists, but not in the repo.** The real logo is the Discord guild
+icon: a flaming gamepad-skull, white on black, four coloured face buttons.
+Palette sampled: bg `#060302`, fg `#FFFFFF`, red `#EA3223`, blue `#4199E7`,
+mint `#8AFBCC`, yellow `#FFFD54`. `webpage/assets/img/` contains only Bootstrap
+template leftovers — `logo.png` is referenced by `index.html` and does not exist.
+
+**The data is messy** because two bots with different conventions wrote to the
+same tables: `adType` has three values for two concepts, `plataform` has 21
+strings for ~7 platforms, `zone`/`price`/`state` are unvalidated free text.
+
+**LFG tables are empty** — porting LFG is greenfield, no migration needed.
+
+## Decisions taken (2026-08-19, at my request — "make decisions for me")
+
+1. **Host: HTZ1**, Portainer stack `game-on-portugal`, deployed by GitHub Actions
+   over the SSH tunnel, same as brawl-teams / builders-and-builds. Not the
+   static-first path — the migration is happening anyway, so building twice is
+   waste.
+2. **Media: a new in-stack MinIO**, bucket `gop-media`, public-read, at
+   `media.game-on-portugal.pt`. Separate from insight-report-studio's MinIO.
+3. **Releases: release-please per component**, on merge, with Conventional
+   Commits enforced on PR titles (`pr-title.yml`) — the actual root cause of
+   "never released", since PRs are squash-merged and `chore:` cuts nothing.
+4. **Runners: `ubuntu-latest`.** The repo is public, so hosted runners and code
+   scanning are free; no dependency on ARC access this org may not have.
+5. **Scheduler: delete it**, run jobs in-process in the bot — also removes a
+   `/var/run/docker.sock` mount from the host running Plex and Frigate.
+6. **Ad lifecycle**: 14 days idle → prompt → 72h → expire (never delete).
+7. **Privacy**: display names only, never user IDs, opt-out from day one.
+8. **Language**: pt-PT for all user-facing copy, English command names.
+9. **Redis: dropped.** The rewritten bot never reads `REDIS_DSN`.
+10. **No heuristic backfill** of the 28 orphaned ad `message_id`s.
+
+## Next / open
+
+Suggested order is **04 → 01 → 02 → 03**, with 03's design work parallelisable.
+Plan 01 is safe to build before 04 lands (it touches no infrastructure).
+
+What still needs me specifically (all in plan 04's runbook):
+
+- **Repo secrets/variables**: `RELEASE_PLEASE_TOKEN` (PAT — `GITHUB_TOKEN` PRs
+  don't trigger downstream workflows), `DOCKER_*`, `PORTAINER_ACCESS_TOKEN`,
+  `DEPLOY_SSH_KEY`/`KNOWN_HOSTS`, `TELEGRAM_*`. Delete the `CAPROVER_*` ones.
+- **HTZ1**: append a tunnel-only deploy key to `~ezweb/.ssh/authorized_keys`
+  (append, never rewrite), create the Portainer stack, restore the DB dump.
+- **DNS**: `game-on-portugal.pt` apex + `media` → 195.201.192.35 in the OVH zone,
+  and refresh the zone. Apex only once the portal exists.
+- **Confirm `DEPLOY_SSH_PORT`** — remote-hosts says 2224, the ez-web SETUP files
+  say 22.
+- Repo settings: squash-only merges, branch protection requiring `CI`.
+
+Also outstanding from the earlier audit: back up `~/game-on-portugal/.env` (only
+copy of the bot token and DB credentials, on a home server), verify the
+`databack/mysql-backup` job actually restores, and stop `entrypoint.sh` printing
+the DB root password as its first log line.
+
+## Operational reference
+
+- **Repo**: `github.com/GameOnPortugal/monorepo`, branch `main`. Worktree for this
+  work: `.worktrees/new-task-82ca7140`, branch `luis/new-task-82ca7140`.
+- **Production**: `ssh -p 2224 tedcrypto@192.168.0.184` (TedRelayer),
+  `~/game-on-portugal/` — containers `game-on-portugal-{app,scheduler,db,redis,db-backup}`.
+- **Credentials**: `~/game-on-portugal/.env` on that host, mode 0600. **No other
+  copy exists.**
+- **DB**: MariaDB 11.5.2, schema `discord-bot`. Query without exposing the
+  password: `set -a; . ~/game-on-portugal/.env; set +a; docker exec
+  game-on-portugal-db mariadb -uroot -p"$MYSQL_ROOT_PASSWORD" discord-bot -e '…'`
+- **Images**: Docker Hub `joshlopes/game-on-portugal-{bot,scheduler}`.
+- **Discord**: guild `818108848492773377`, bot `GameOnPortugalBot#9387`.
+  Channels — `📖anuncios` `818447274266591243`, `🖼screenshots`
+  `827646847483904040`, `💬chat` `818447297444052993`.
+- **Brand assets**: guild icon hash `b5d2486a6181a2a5ecb3a4cfbc4b9a0d`, banner
+  `ffa308a0fad1a858794921dec051bad5`, both on `cdn.discordapp.com`.
+- **Local dev**: Node ≥18.18 required (use nvm 24.x — system Node 18.16 fails
+  Prisma's preinstall). Always `bunx prisma generate` before type checking.
+
+## Decisions log
+
+- **Documented in-repo rather than only here** — the plans are agent-facing work
+  specs tightly coupled to the code, so they live in `docs/plans/`; this file is
+  the durable overview and pointer.
+- **pt-PT for all user-facing copy**, command names stay English. The community
+  writes Portuguese and the old bot spoke it; the rewrite's English is a
+  regression, not a decision anyone made.
+- **Soft-delete over hard-delete** everywhere. The old bot destroyed rows on
+  expiry, which is why nothing can be reconstructed.
+- **Never store a Discord CDN URL as the durable copy of an image.** Cause of the
+  dead gallery.
+- **Post the message first, then persist once** with the real message ID —
+  rather than the two-phase write that produced both current bugs.
+- **The four brand button colours become the four platform colours** (PlayStation,
+  Xbox, Nintendo, PC) across the portal — brand-native and instantly legible.
+- **Recommended killing the scheduler container** rather than repairing it: its
+  `update_container.py` indirection existed only to cope with CapRover's
+  generated container names, which docker-compose does not have.


### PR DESCRIPTION
## Why

Planning for this repo was spread across seven documents in two places — four in `docs/plans/`, three in a local `~/claude-plans/` directory **nothing in the repo could see** — plus `known-issues.md` (#0–#24) and `discord-bot-feature-gap.md` (G1–G25). Between them they described the work well, but nowhere said what to do first, and half of it was invisible to anyone who wasn't on Luis's laptop.

## What this does

**Moves the orphaned plans into the repo**

| From `~/claude-plans/` | To |
| --- | --- |
| `2026-08-19-discord-bot-upgrade.md` | `docs/plans/05-bot-audit-and-hardening.md` |
| `2026-08-19-discord-bot-discord-practices.md` | `docs/plans/06-discord-api-modernisation.md` |
| `2026-08-19-discord-bot-dependencies.md` | `docs/plans/07-dependency-upgrades.md` |
| `2026-08-19-gameonportugal-revival.md` | `docs/session-log-2026-08-19.md` |

Cross-links rewritten, provenance banners added, and pointer stubs left behind so the old paths still lead somewhere. The dependency plan's closing note described the workstation's npm/TLS configuration and named an employer registry — **scrubbed**, since this repo is public and that finding is machine configuration, not repo scope. It stays tracked outside the repo.

**Adds `docs/plans/GLOBAL-PLAN.md`** — the master work queue, and the point of this PR.

One ordered route from *"dormant repo with three live production failures"* to *"maintained platform"*: **92 numbered work items across ten milestones**.

| | Milestone | Why now |
| - | --------- | ------- |
| M0 | Stop the bleeding | Users are hitting these today |
| M1 | Restore the signal | Nothing after this is verifiable without it |
| M2 | Infrastructure cutover | CI deploys to a machine that no longer exists |
| M3 | Dependency currency & container hygiene | 14 months stale, two majors behind |
| M4 | Discord API modernisation | The enabler for every feature below |
| M5 | Marketplace overhaul | Most-used feature, in English, half-broken |
| M6 | Jobs, lifecycle & media durability | Recovers 624 screenshots |
| M7 | Trophies — make the leaderboard true | A shipped feature that silently lies |
| M8 | Community portal | Moderation without SSH |
| M9 | Close the feature gap, retire the dead weight | So `old-discord-bot/` can die |

Each item carries stable ID, evidence pointer, blockers and a definition of done. A **traceability appendix** maps every finding in all four evidence documents to exactly one item — if something has no item, or an item has no source, that's a documented bug in the plan.

**Flags two findings missing from `known-issues.md`**, both belonging in its 🔴 band and both verified against the code in this session:

- **A1 — mention injection.** `SellSubcommand` concatenates user-supplied text into message *content* and nothing sets `allowedMentions`. An ad named `@everyone` makes the bot ping the server. Live exposure.
- **B1 — `/trophy rank` ranks the wrong people.** `OrmTrophyRepository` applies `take: limit` in the Prisma query *before* points are summed and `.sort()`ed in JS, with no `orderBy`. "Top 10" is an arbitrary 10 profiles sorted among themselves. All three rank modes plus `findUserPosition`.

**Housekeeping**: `AGENT.md`, `docs/README.md` and `plans/00-overview.md` now point at the global plan, and 00-overview's stale claim that the type check fails with six errors is corrected — it's clean, and `ci.yml` enforces it.

## Scope

Documentation only. No source, schema or workflow changes — `git diff --stat` touches nothing outside `AGENT.md` and `docs/`.

## Open questions carried into the plan

Four decisions the plan deliberately does not make: whether LFG is wanted back (~40% of the old bot's surface, tables empty), whether stock alerting is still used, Sentry vs Loki, and how long screenshot retention needs to be (it drives MinIO sizing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)