### PR TITLE
docs: settle the open product decisions and drop LFG

### DIFF
--- a/docs/discord-bot-feature-gap.md
+++ b/docs/discord-bot-feature-gap.md
@@ -15,7 +15,15 @@ Method: full read of `old-discord-bot/src` (commands, subcommands, services, uti
 
 ## 1. Summary
 
-Legend: ✅ ported · 🟡 partially ported (behaviour differs / degraded) · ❌ missing entirely
+Legend: ✅ ported · 🟡 partially ported (behaviour differs / degraded) · ❌ missing entirely ·
+🚫 **decided not to port** (2026-08-19 — see [the decisions in the global plan](plans/GLOBAL-PLAN.md#decisions-taken))
+
+> **Six of these rows are now closed by decision rather than by work.** LFG (13,
+> 14), stock alerts and the Telegram bridge (15, 23), command→channel links (17)
+> and the trophy webhook (24) will not be ported. Channel restrictions (16) will
+> be reimplemented on Discord AutoMod rather than ported. The reasoning for each
+> is in the global plan; the detail sections below are kept because they remain
+> the only written record of what the old bot did.
 
 | # | Feature | Legacy entry point | New bot | Status |
 |---|---------|--------------------|---------|--------|
@@ -31,18 +39,18 @@ Legend: ✅ ported · 🟡 partially ported (behaviour differs / degraded) · �
 | 10 | Trophy — ranks (monthly/creation/lifetime/user) | `commands/trophy/trophy.js` (`rank`) | `/trophy rank` | 🟡 |
 | 11 | Trophy — PSNProfiles crawler + points engine | `service/trophy/psnCrawlService.js`, `trophyManager.js`, `scripts/parse-psn-profile.js` | — | ❌ |
 | 12 | Trophy — backfill missing completion dates | `scripts/fix-old-trophies.js` | — | ❌ |
-| 13 | LFG — whole subsystem (11 subcommands) | `commands/lfg/lfg.js` + `subcommands/lfg/*` | — | ❌ |
-| 14 | LFG — points recalculation cron | `scripts/lfg-update-points.js` | — | ❌ |
-| 15 | Stock alerts (Discord + Telegram) | `commands/stock/stock.js` | — | ❌ |
-| 16 | Channel restrictions (`setchannel`) + message validator | `commands/channel/setChannel.js`, `util/MessageValidator.js` | — | ❌ |
-| 17 | Command→channel routing (`commandchannellink`) | `commands/channel/commandChannelLink.js` | — | ❌ |
+| 13 | LFG — whole subsystem (11 subcommands) | `commands/lfg/lfg.js` + `subcommands/lfg/*` | — | 🚫 §5 |
+| 14 | LFG — points recalculation cron | `scripts/lfg-update-points.js` | — | 🚫 §5 |
+| 15 | Stock alerts (Discord + Telegram) | `commands/stock/stock.js` | — | 🚫 §7.5 |
+| 16 | Channel restrictions (`setchannel`) + message validator | `commands/channel/setChannel.js`, `util/MessageValidator.js` | — | 🚫 §6.1 — replaced by AutoMod |
+| 17 | Command→channel routing (`commandchannellink`) | `commands/channel/commandChannelLink.js` | — | 🚫 §6.2 |
 | 18 | Configurable command prefix | `commands/prefix.js`, `util/prefixUtil.js` | — | ❌ (obsolete by design, see §7.1) |
 | 19 | Admin / moderator permission checks | `util/permissionsUtil.js` | — | ❌ |
 | 20 | DM conversational wizards + interaction lock | `util/messageCreatorUtil.js` | — | ❌ (superseded, see §7.2) |
 | 21 | 2000-char message chunking | `util/messageCreatorUtil.js` `sendMessage` | — | ❌ |
 | 22 | Sentry error reporting | `src/index.js` | — | ❌ (Loki logging instead) |
-| 23 | Telegram bridge | `service/stock/stockUrlManager.js` | — | ❌ |
-| 24 | Trophy webhook announcements | `scripts/parse-psn-profile.js` (`TROPHY_WEBHOOK`) | — | ❌ |
+| 23 | Telegram bridge | `service/stock/stockUrlManager.js` | — | 🚫 §7.5 |
+| 24 | Trophy webhook announcements | `scripts/parse-psn-profile.js` (`TROPHY_WEBHOOK`) | — | 🚫 §7.7 — replaced by a channel post |
 | 25 | Redis / Keyv caching | `util/prefixUtil.js`, `MessageValidator.js`, `commandChannelLinkManager.js` | — | ❌ |
 
 ---
@@ -167,7 +175,17 @@ Legacy rendered ranks with the guild's custom trophy emojis (plat/gold/silver/br
 
 ---
 
-## 5. LFG (Looking For Group) — ❌ entirely missing
+## 5. LFG (Looking For Group) — 🚫 will not be ported
+
+> **Decided 2026-08-19: Luis is not interested in moving LFG.** This was the
+> largest single item in the revival plan — roughly 40% of the old bot's command
+> surface — and it is now closed. The four Prisma models (`LFGProfile`,
+> `LFGGame`, `LFGParticipation`, `LFGEvent`) and their tables are **empty**, so
+> there is no data to preserve; they get dropped with M9.6. Nothing below is
+> scheduled work. It is kept as the only written record of what the old
+> subsystem did, in case the decision is ever revisited — note that if it is,
+> this is a greenfield build with **no continuity** with the community's old
+> rankings, which is worth telling members explicitly.
 
 The largest missing subsystem. Legacy: `commands/lfg/lfg.js` + 11 subcommands +
 `service/lfg/{lfgEventManager,lfgGamesManager,lfgProfileManager}.js`. Prisma already has
@@ -219,9 +237,9 @@ which currently only knows `SCREENSHOTS`.
 
 ---
 
-## 6. Moderation / channel configuration — ❌ entirely missing
+## 6. Moderation / channel configuration — 🚫 reimplemented, not ported
 
-### 6.1 `setchannel` + message validator
+### 6.1 `setchannel` + message validator — replaced by Discord AutoMod
 `commands/channel/setChannel.js` (admin/mod only) attached restrictions to a channel, stored in
 `SpecialChannel`, with `info` / `delete <id>` / `delete all` management. Enforcement lived in the
 `message` event via `util/MessageValidator.js`:
@@ -233,12 +251,36 @@ which currently only knows `SCREENSHOTS`.
 - offending message is deleted and DM'd back to the author with a "fala com o ModMail" note;
 - restrictions cached in Keyv, invalidated on every `setchannel` write.
 
-This is the enforcement layer for the marketplace/screenshot channels — arguably the highest-value
-non-LFG gap. Note it needs the `MessageContent` gateway intent; the new `DiscordBot` only requests
-`GatewayIntentBits.Guilds` and only handles `InteractionCreate`, so there is currently **no message
-event pipeline at all**.
+This is the enforcement layer the marketplace and screenshot channels were designed around, and it
+is worth having. **It is not worth having this way.** A straight port needs the `MessageContent`
+privileged intent, a gateway message-event pipeline the rewrite does not have at all (it requests
+only `GatewayIntentBits.Guilds` and handles only `InteractionCreate`), and a per-message round trip
+through the bot — in order to do something Discord has since built in.
 
-### 6.2 `commandchannellink`
+**Decided 2026-08-19 — reimplement on Discord AutoMod instead** (work item M9.1):
+
+- the **`regex`** handler maps directly onto an AutoMod rule with a regex trigger, applied through
+  `@discordjs/rest`, with the rule definitions checked into this repo so the configuration is
+  reviewable rather than living only in the Discord UI;
+- **`only_commands`** is not a moderation problem at all — it is a channel permission overwrite
+  (deny `SendMessages`, allow `UseApplicationCommands`). No code, and it cannot be raced;
+- admin bypass comes free — AutoMod rules take `exempt_roles`.
+
+What this buys beyond simplicity: AutoMod **blocks the message instead of deleting it after the
+fact**, so nothing is ever briefly visible, and it keeps enforcing while the bot is down or
+redeploying — which the old validator did not. What it costs: the custom "fala com o ModMail" DM
+becomes AutoMod's standard block notice. That is an acceptable trade.
+
+The `specialchannels` table holds **0 rows**, so nothing is being migrated. The model is dropped
+with M9.6.
+
+### 6.2 `commandchannellink` — 🚫 dropped
+
+> **Decided 2026-08-19.** The `commandchannellinks` table holds **0 rows** and the static channel
+> configuration from M1.7 covers every real use — M5.1 already routes ads to `📖anuncios` that way.
+> A configurable indirection nobody configured is worse than a constant. The model is dropped with
+> M9.6 rather than left lying around inviting someone to wire it up.
+
 Mapped a command name to a target channel so all content generated by that command was posted
 there (`CommandChannelLink` table, Keyv-cached, `info`/`delete`/`delete all`). Used by sell, wanted,
 screenshot and LFG create. Without it the rewrite always answers in the invoking channel (§2.4, §3).
@@ -266,7 +308,12 @@ exists in the rewrite, so every admin-gated behaviour (§2.3, §5, §6) is block
 `MessageCreatorUtil.sendMessage` split output at 1800 chars to respect Discord's 2000-char limit.
 Relevant for long ad/screenshot/rank listings.
 
-### 7.5 Stock alerts + Telegram bridge — ❌ missing
+### 7.5 Stock alerts + Telegram bridge — 🚫 dropped
+
+> **Decided 2026-08-19.** `stockurls` holds **0 rows** — the feature has not been used once in the
+> sixteen months the rewrite has been live. This also removes the only reason for the bot to carry a
+> Telegram dependency, and `TELEGRAM_ACCESS_TOKEN` leaves `.env.example` with it. Had it been kept,
+> it would have needed rebuilding rather than porting anyway: see the `setTimeout` note below.
 `|stock create|verify|alert <url>` (`commands/stock/stock.js`, `service/stock/stockUrlManager.js`):
 - store/validate stock URLs (`StockUrls.is_validated`, validated out-of-band);
 - `alert` fan-out ladder: immediate Telegram *Alertas Prime* + Discord premium channel ping
@@ -279,17 +326,29 @@ Needs `node-telegram-bot-api` (or equivalent), `TELEGRAM_ACCESS_TOKEN` (still pr
 
 ### 7.6 Sentry — ❌ missing
 `old-discord-bot/src/index.js` initialised `@sentry/node` (+ tracing). The rewrite ships Winston +
-Loki (`LokiLogProvider`) instead. `SENTRY_DSN` is still in `.env.example` but unused — either wire
-Sentry back up or drop the var.
+Loki (`LokiLogProvider`) instead. **Decided 2026-08-19: Loki, and `SENTRY_DSN` is dropped.** One
+pipeline for one signal, and Loki is the one already half-wired with a Grafana Cloud stack behind
+it. Two caveats for whoever finishes the wiring: `LokiLogProvider` currently tags this bot's logs
+`job: 'tedcrypto-campaign'` (fix in M3.5), and **`LOKI_HOST` must not be enabled until M0.7 lands**
+— the entrypoint prints the database password on its first line, and turning Loki on first ships
+that password to Grafana Cloud.
 
-### 7.7 Trophy webhook — ❌ missing
+### 7.7 Trophy webhook — 🚫 dropped, but the announcement is kept
+
 `TROPHY_WEBHOOK` (discord-webhook-node) announced each newly-credited trophy. Still in
 `.env.example`, unused.
+
+> **Decided 2026-08-19.** The announcement is worth restoring; the webhook is not. It should be
+> posted by the bot itself through `GuildClient`, to a channel named in the M1.7 channel config.
+> Same message to the member, one fewer secret to manage, one fewer thing that breaks silently when
+> someone regenerates a webhook URL — and the post gets the bot's identity and embed styling rather
+> than an anonymous webhook avatar. Tracked as **M7.8**; `TROPHY_WEBHOOK` is deleted.
 
 ### 7.8 Redis / Keyv caching — ❌ missing
 Legacy cached channel restrictions, command→channel links, the prefix and interaction locks
 (`REDIS_DSN`, still in `.env.example`, unused; the old `docker-compose.yml` ran a Redis container,
-the new one does not). Only needed if §6 comes back.
+the new one does not). §6 is not coming back in a form that needs it — AutoMod holds its own rules
+and channel permissions are enforced by Discord — so `REDIS_DSN` is dropped with the rest.
 
 ### 7.9 Scheduled jobs
 `scheduler/config.ini` currently runs exactly one job:

--- a/docs/plans/GLOBAL-PLAN.md
+++ b/docs/plans/GLOBAL-PLAN.md
@@ -84,7 +84,7 @@ deployment real → modernise → build.** Resist starting at M8.
 | **M6** | [Jobs, lifecycle & media durability](#m6--jobs-lifecycle--media-durability) | Recovers 624 screenshots; stops ads accumulating forever | M8 | 8 PRs |
 | **M7** | [Trophies — make the leaderboard true](#m7--trophies--make-the-leaderboard-true-again) | A shipped feature that silently lies | — | 8 PRs |
 | **M8** | [Community portal](#m8--community-portal) | The public face; makes moderation possible without SSH | — | 15 PRs, largest |
-| **M9** | [Close the feature gap, retire the dead weight](#m9--close-the-feature-gap-retire-the-dead-weight) | Finish the port so `old-discord-bot/` can die | — | Open-ended |
+| **M9** | [Close the feature gap, retire the dead weight](#m9--close-the-feature-gap-retire-the-dead-weight) | Finish the port so `old-discord-bot/` can die | — | 3 PRs — **LFG and stock alerts dropped, see decisions** |
 
 ```
 M0 ──▶ M1 ──▶ M3 ──▶ M4 ──┬──▶ M5 ──▶ M6 ──▶ M8
@@ -327,7 +327,7 @@ flags are written as well as read.
 | **M7.5** | **`/trophy create` accepts both URL shapes** — bare profile and the 6-segment trophy URL. | [§4.6](../discord-bot-feature-gap.md) |
 | **M7.6** | **Rank presentation parity** — the guild's custom plat/gold/silver/bronze emojis for positions 1/2/3/rest, and pagination buttons instead of a `limit` option capped at 10. | [§4.7](../discord-bot-feature-gap.md), C4 |
 | **M7.7** | **`fix-old-trophies` backfill** as a console command, for rows with a null `completionDate`. | [§4.4](../discord-bot-feature-gap.md) |
-| **M7.8** | **Decide the trophy webhook**: reinstate `TROPHY_WEBHOOK` announcements ("Parabéns \<@user\>! Acabaste de receber N TP…") or drop the env var. | [§7.7](../discord-bot-feature-gap.md), [#8](../known-issues.md) |
+| **M7.8** | **Trophy announcements through the bot, not a webhook.** Post "Parabéns \<@user\>! Acabaste de receber N TP…" via `GuildClient` to a channel from the M1.7 config; delete `TROPHY_WEBHOOK`. **Decided** — see [Decisions taken](#decisions-taken). | [§7.7](../discord-bot-feature-gap.md), [#8](../known-issues.md) |
 
 ---
 
@@ -375,16 +375,22 @@ ads, screenshots and jobs from a browser; a shared link previews with the brand.
 **Goal**: everything in `old-discord-bot/` is either ported or explicitly
 dropped, so the directory can be deleted and the feature-gap document closed.
 
+**This milestone shrank by roughly two thirds on 2026-08-19.** LFG (M9.3) and
+stock alerting (M9.4) are dropped outright, `commandchannellink` (M9.2) with
+them, and channel moderation (M9.1) is reimplemented on Discord AutoMod instead
+of ported. See [Decisions taken](#decisions-taken) for the reasoning behind each.
+What remains is deletion work plus the privacy flag.
+
 **Depends on**: M1.10 (permissions) and M4 throughout.
 
 | ID | Item | Evidence | Notes |
 | -- | ---- | -------- | ----- |
-| **M9.1** | **Channel restrictions + message validator** — the `regex` and `only_commands` handlers, admin bypass, offending message deleted and DM'd back. | [G16 / §6.1](../discord-bot-feature-gap.md) | Arguably the highest-value non-LFG gap, and the enforcement layer the marketplace and screenshot channels were designed around. **Needs the `MessageContent` intent and a message-event pipeline — the rewrite has neither.** Weigh that intent against M4.6's minimal-intents position before starting. |
-| **M9.2** | **`commandchannellink`**, *or* the explicit decision to drop it in favour of the static channel config from M1.7. | [G17 / §6.2](../discord-bot-feature-gap.md) | M5.1 already hardcodes the marketplace channel. If static config is enough, **decide and delete the table** rather than leaving a third unused model. |
-| **M9.3** | **LFG** — 11 subcommands, the points model (+20 create / +10 participate / +5 commend / −10 leave / −30 miss / −20 cancel, doubled under 1h), the aggregation cron, and banned-user enforcement. **Needs its own spec document before any code.** | [G13, G14 / §5](../discord-bot-feature-gap.md) | The largest single gap, ~40% of the old bot's surface. The four Prisma models already exist and the tables are **empty** — greenfield, no migration, but also no continuity with the community's old rankings, which is worth telling users. **Open question for Luis: is LFG actually wanted back, or was dropping it deliberate?** |
-| **M9.4** | **Stock alerts + Telegram bridge** — the fan-out ladder (immediate Telegram Prime + Discord premium ping → +3 min `@everyone` free channel → +5 min Telegram everyone). | [G15 / §7.5](../discord-bot-feature-gap.md) | **Decide first whether the community still uses it.** Lowest value in the gap list; a legitimate candidate for "explicitly dropped". Note the legacy `setTimeout` implementation silently lost pending alerts on restart — a port needs durable scheduling (M6.1). |
-| **M9.5** | **Sentry vs Loki decision**, and delete whichever env vars lose. | [G22 / §7.6](../discord-bot-feature-gap.md), [#8](../known-issues.md) | Recommend: Loki only. Then `SENTRY_DSN`, `REDIS_DSN`, `TROPHY_WEBHOOK` and `TELEGRAM_ACCESS_TOKEN` all leave `.env.example` and the compose file for good. |
-| **M9.6** | **Retire `old-discord-bot/`** — move to `reference/` when the port is done so it stops looking like something that builds, then delete once M9.3/M9.4 are settled. | revival plan item 25 | It is the only spec for the scraper, LFG and stock. Do not delete it early. |
+| **M9.1** | **Channel rules — reimplemented as Discord AutoMod, not a message pipeline.** Define the guild's AutoMod rules (keyword/regex blocking) as checked-in JSON applied through `@discordjs/rest`, and express "commands only" channels as channel *permissions* (deny `SendMessages`, allow `UseApplicationCommands`) rather than deleting messages after the fact. | [G16 / §6.1](../discord-bot-feature-gap.md) | **Redesigned — see decision 4.** The straight port needed the `MessageContent` privileged intent and a message-event pipeline the rewrite does not have, and it contradicted M4.6's minimal-intents position. AutoMod does the same job server-side, with no intent, no gateway traffic, no bot latency, and it keeps enforcing while the bot is down. The `specialchannels` table is **empty** — drop the model with M9.6. |
+| **M9.2** | ~~`commandchannellink`~~ — **dropped.** Delete the `CommandChannelLink` model and its table. | [G17 / §6.2](../discord-bot-feature-gap.md) | **Decided.** The table is **empty**; M1.7's static channel config covers every real use. Keeping a third unused model would only invite someone to wire it up later. |
+| **M9.3** | ~~**LFG**~~ — **dropped, will not be ported.** Delete the four LFG models (`LfgProfile`, `LfgGame`, `LfgEvent`, `LfgParticipation`) and their tables. | [G13, G14 / §5](../discord-bot-feature-gap.md) | **Decided by Luis, 2026-08-19: he is not interested in moving LFG.** This closes the single largest item in the plan (~40% of the old bot's surface) and removes the one work item that needed its own spec document. All four tables are **empty**, so there is no data to preserve and no migration risk. |
+| **M9.4** | ~~**Stock alerts + Telegram bridge**~~ — **dropped.** Delete the `StockUrls` model and its table, and the `TELEGRAM_ACCESS_TOKEN` env var. | [G15 / §7.5](../discord-bot-feature-gap.md) | **Decided.** `stockurls` holds **0 rows** — the feature has not been used once since the rewrite went live in April 2025. The legacy implementation also lost every pending alert on restart (bare `setTimeout`), so a port would have been a rewrite, not a port. |
+| **M9.5** | **Loki, not Sentry.** Delete `SENTRY_DSN`, `REDIS_DSN`, `TROPHY_WEBHOOK` and `TELEGRAM_ACCESS_TOKEN` from `.env.example` and the compose files. | [G22 / §7.6](../discord-bot-feature-gap.md), [#8](../known-issues.md) | **Decided.** Loki is already half-wired and there is an existing Grafana Cloud stack to ship to; Sentry would be a second vendor for the same signal. Do **not** enable `LOKI_HOST` until M0.7 lands — the entrypoint prints the database password on the first line, and enabling Loki first ships it to Grafana Cloud. Fix the `job: 'tedcrypto-campaign'` label bug in M3.5. |
+| **M9.6** | **Retire `old-discord-bot/`** — move to `reference/` once M7 has taken what it needs from the scraper, then delete. Drop the six now-dead Prisma models in one migration (4 LFG + `StockUrls` + `CommandChannelLink` + `SpecialChannel`). | revival plan item 25 | With M9.1–M9.4 settled, the only thing `old-discord-bot/` is still the sole specification for is the **PSNProfiles scraper and points ladder** (M7.1, M7.2). Once those are ported it can go. |
 | **M9.7** | **Privacy**: a single `public_opt_out` flag honoured by **both** the bot and the portal, a short privacy page, and a deletion request path that removes portal content too. | [03 decision 5](03-portal.md) | The community is EU-based. Cheap now, expensive to retrofit — do it with M8.7, not after. |
 
 ---
@@ -427,15 +433,15 @@ Update this table as items land. `—` = not started.
 | --------- | ----- | ---- | ------ |
 | M0 Stop the bleeding | 9 | 0 | — |
 | M1 Restore the signal | 10 | 0 | partial: `tsc --noEmit`, CodeQL/Trivy/Gitleaks and PR-title linting are already in CI |
-| M2 Infrastructure cutover | 6 | 0 | repo side **built**; needs credentials, Portainer stack and DNS |
+| M2 Infrastructure cutover | 6 | 5 | **cut over 2026-08-19** — production is HTZ1, Portainer stack 46. M2.5 (decommission TedRelayer) due 2026-09-02 |
 | M3 Dependencies & container | 8 | 0 | — |
 | M4 Discord API modernisation | 10 | 0 | — |
 | M5 Marketplace overhaul | 11 | 0 | — |
 | M6 Jobs, lifecycle & media | 8 | 0 | — |
 | M7 Trophies | 8 | 0 | — |
 | M8 Community portal | 15 | 0 | — |
-| M9 Feature gap & dead weight | 7 | 0 | — |
-| **Total** | **92** | **0** | |
+| M9 Feature gap & dead weight | 7 | 3 | M9.2/M9.3/M9.4 **decided as dropped**; M9.1 redesigned onto AutoMod |
+| **Total** | **92** | **8** | |
 
 Already closed before this plan was written: [#1](../known-issues.md) (schema
 drift), [#4](../known-issues.md) (6 type errors), and the repo side of
@@ -444,21 +450,55 @@ release-please reconfigured).
 
 ---
 
-## Open questions for Luis
+## Decisions taken
 
-Four decisions this plan cannot make on its own. Everything else has been
-decided and is recorded in the per-area plans.
+The four questions this plan could not answer on its own were settled on
+**2026-08-19**. They are recorded here rather than in a side document because
+each one deletes work from the milestones above.
 
-1. **Is LFG wanted back?** (M9.3) It is ~40% of the old bot's surface and its
-   tables are empty, so it is a greenfield build, not a restoration.
-2. **Is stock alerting still used?** (M9.4) If not, delete `StockUrls` and the
-   Telegram dependency rather than porting them.
-3. **Sentry or Loki?** (M9.5) Both are currently half-configured; neither is
-   fully wired.
-4. **How long is screenshot retention a requirement?** It drives the MinIO
-   sizing in M2.3 and the thumbnail strategy in M8.8.
+**1. LFG is not coming back.** Luis: *not interested in moving LFG.* This was the
+largest single item in the plan and the only one that needed its own spec before
+any code could be written. The four tables are empty, so there is nothing to
+preserve; the models get dropped with M9.6. Worth telling the community
+explicitly, because the old rankings are gone and will not be reconstructed.
 
----
+**2. Stock alerting is dropped.** Not a judgement call in the end — `stockurls`
+holds **0 rows**, so the feature has been dead for the entire life of the
+rewrite. Dropping it also removes the last reason to keep a Telegram dependency
+in the bot.
+
+**3. Loki, not Sentry.** One log pipeline, one vendor, and Loki is the one
+already half-wired. `SENTRY_DSN` leaves with `REDIS_DSN`, `TROPHY_WEBHOOK` and
+`TELEGRAM_ACCESS_TOKEN`.
+
+**4. Channel moderation is reimplemented, not ported.** The old bot read every
+message through a `regex` / `only_commands` validator backed by the
+`specialchannels` table. Reproducing that means the `MessageContent` privileged
+intent, a gateway message pipeline the rewrite does not have, and per-message bot
+latency — to do something **Discord now does natively**. AutoMod rules cover the
+regex case server-side, and a channel permission overwrite (deny `SendMessages`,
+allow `UseApplicationCommands`) covers "commands only" with no code at all. Both
+keep working when the bot is down, which the old validator did not. The rule
+definitions still belong in the repo so the configuration is reviewable.
+
+**5. Screenshots are kept indefinitely.** 624 images at a few MB each is single-
+digit gigabytes against 394 GB free on HTZ1; a retention policy would cost more
+in argument than in disk. No expiry for v1. What *does* matter is generating a
+thumbnail at ingest (M8.8) so a phone does not download a 4 MB PNG per grid
+tile. Revisit only if the bucket passes 50 GB.
+
+### Two smaller calls made in passing
+
+**M7.8 — the trophy webhook is not reinstated.** Trophy announcements should go
+through the bot's own `GuildClient` to a channel named in the M1.7 config, not
+through a `TROPHY_WEBHOOK` URL. Same message, one fewer secret, one fewer thing
+that breaks silently when someone regenerates the webhook, and the announcement
+gets the bot's identity and embed styling for free.
+
+**`RELEASE_PLEASE_TOKEN` is still unset.** `release-please.yml` falls back to
+`GITHUB_TOKEN`, which works — it cut the 1.0.0 release PR — but PRs opened with
+that token do not trigger downstream workflows, so the release PR itself gets no
+CI run. Minting a fine-grained PAT needs a browser; it is left for Luis.
 
 ## Traceability
 
@@ -526,16 +566,16 @@ The machine-configuration note is **out of repo scope** and tracked separately.
 
 | Row | Item | Row | Item |
 | --- | ---- | --- | ---- |
-| G1 ping | ✅ | G14 LFG points cron | M9.3 |
-| G2 sell | M0.1, M5.1–M5.5 | G15 stock alerts | M9.4 *(decide first)* |
-| G3 wanted ads | M5.7 | G16 channel restrictions | M9.1 |
-| G4 list / delete | M5.2, M5.8, M5.10 | G17 command→channel link | M9.2 |
+| G1 ping | ✅ | G14 LFG points cron | M9.3 — **dropped** |
+| G2 sell | M0.1, M5.1–M5.5 | G15 stock alerts | M9.4 — **dropped** |
+| G3 wanted ads | M5.7 | G16 channel restrictions | M9.1 — **AutoMod** |
+| G4 list / delete | M5.2, M5.8, M5.10 | G17 command→channel link | M9.2 — **dropped** |
 | G5 has-been-sold cron | M6.5 | G18 command prefix | ✅ obsolete by design |
 | G6 screenshot CRUD | M6.2 | G19 permission checks | M1.10 |
 | G7 weekly winner | M6.4 | G20 DM wizards | superseded — preview/confirm lands with M5.6 |
 | G8 link PSN profile | M7.5 | G21 message chunking | M4.10 |
 | G9 check profile | M7.4 | G22 Sentry | M9.5 |
-| G10 ranks | M0.8, M7.6 | G23 Telegram bridge | M9.4 |
-| G11 PSN crawler | **M7.1** | G24 trophy webhook | M7.8 |
+| G10 ranks | M0.8, M7.6 | G23 Telegram bridge | M9.4 — **dropped** |
+| G11 PSN crawler | **M7.1** | G24 trophy webhook | M7.8 — **dropped for a channel post** |
 | G12 fix-old-trophies | M7.7 | G25 Redis / Keyv | ✅ dropped — M1.6 removes the container |
-| G13 LFG subsystem | M9.3 | | |
+| G13 LFG subsystem | M9.3 — **dropped** | | |


### PR DESCRIPTION
Closes the four open questions in `docs/plans/GLOBAL-PLAN.md` and two smaller calls that were blocking items behind them. Every decision here **removes** work — M9 shrinks by roughly two thirds.

## Decisions

| # | Decision | Why |
| - | -------- | --- |
| **1** | **LFG will not be ported** (M9.3) | Luis is not interested in moving LFG. It was ~40% of the old bot's command surface and the only item needing its own spec document. All four tables are **empty**, so there is nothing to preserve. |
| **2** | **Stock alerts + Telegram bridge dropped** (M9.4) | `stockurls` holds **0 rows** — dead for the entire 16 months the rewrite has been live. Removes the last reason to carry a Telegram dependency. |
| **3** | **Loki, not Sentry** (M9.5) | One pipeline for one signal, and Loki is the one already half-wired. `SENTRY_DSN`, `REDIS_DSN`, `TROPHY_WEBHOOK` and `TELEGRAM_ACCESS_TOKEN` all leave `.env.example`. |
| **4** | **Channel moderation reimplemented on AutoMod** (M9.1) | See below — this is the one that changes shape rather than disappearing. |
| **5** | **Screenshots kept indefinitely** | 624 images is single-digit GB against 394 GB free. The real requirement is a thumbnail at ingest (M8.8), not a retention policy. |

Plus two smaller ones: **`commandchannellink` dropped** (M9.2 — 0 rows, superseded by M1.7's static config), and **trophy announcements move off the webhook** (M7.8 — posted by the bot via `GuildClient` to a configured channel instead).

## The one worth reading: AutoMod instead of a message pipeline

The old bot enforced channel rules by reading **every message** through a `regex` / `only_commands` validator backed by the `specialchannels` table. Porting that needs:

- the **`MessageContent` privileged intent**, which directly contradicts M4.6's minimal-intents position;
- a gateway message-event pipeline the rewrite does not have at all (it requests only `GatewayIntentBits.Guilds` and handles only `InteractionCreate`);
- a per-message round trip through the bot.

All to do something **Discord now does natively**. So M9.1 becomes: express the regex rules as Discord **AutoMod** rules applied through `@discordjs/rest`, with the definitions checked into this repo so they stay reviewable; and express "commands only" as a channel permission overwrite (deny `SendMessages`, allow `UseApplicationCommands`) — which is no code at all. Admin bypass comes free via `exempt_roles`.

It is also strictly better behaviour: AutoMod **blocks** the message rather than deleting it after it has been seen, and it keeps enforcing while the bot is down or redeploying. The cost is losing the custom "fala com o ModMail" DM in favour of AutoMod's standard block notice.

## Not picked up in this PR

Nothing here is implemented — these are decisions recorded so the work items can be executed (or deleted) without relitigating them. The **deletion** of the six now-dead Prisma models (4 LFG + `StockUrls` + `CommandChannelLink` + `SpecialChannel`) is deliberately left to **M9.6**, together with retiring `old-discord-bot/`, because that directory is still the only written specification for the PSNProfiles scraper and points ladder that M7.1/M7.2 need.

Also recorded: **`RELEASE_PLEASE_TOKEN` is still unset** — minting a fine-grained PAT needs a browser, so `release-please.yml` continues to fall back to `GITHUB_TOKEN`. That works (it cut the 1.0.0 release PR) but means the release PR itself gets no CI run.

And a hazard worth not tripping over: **do not enable `LOKI_HOST` before M0.7 lands** — the entrypoint prints the database password on its first line, so turning Loki on first ships that password to Grafana Cloud.