### PR TITLE
ci(bot): add lint, schema-drift and supply-chain gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,23 @@ jobs:
         working-directory: discord-bot
         run: bunx tsc --noEmit
 
+      # Schema-drift gate: fails if prisma/schema.prisma no longer produces the
+      # same shape as replaying prisma/migrations. Uses the CI MariaDB (defined
+      # below and reused by the Test step) as scratch space for a shadow
+      # database — brought up empty here, diffed, and handed off to the Test
+      # step which applies the real migrations on top.
+      - name: Check schema drift
+        working-directory: discord-bot
+        run: |
+          docker compose -f docker-compose.ci.yml up -d mariadb
+          timeout 120 bash -c 'until docker compose -f docker-compose.ci.yml exec -T mariadb mariadb-admin ping -uroot -prootpassword --silent 2>/dev/null; do sleep 2; done'
+          docker compose -f docker-compose.ci.yml exec -T mariadb mariadb -uroot -prootpassword -e "CREATE DATABASE IF NOT EXISTS discord_bot_shadow"
+          bunx prisma migrate diff \
+            --from-migrations prisma/migrations \
+            --to-schema-datamodel prisma/schema.prisma \
+            --shadow-database-url "mysql://root:rootpassword@127.0.0.1:3306/discord_bot_shadow" \
+            --exit-code
+
       # Integration tests need MariaDB. Run them inside the CI compose network so
       # the DB is reachable at `mariadb:3306` — no host port-mapping assumptions.
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,13 +129,19 @@ jobs:
         working-directory: discord-bot
         run: bun run format:check
 
-      # Supply-chain gate: fails on high/critical advisories in the resolved
-      # dependency tree. Expected to be red until the M3 dependency-upgrade
-      # work lands — see the PR description for the known advisories this
-      # surfaces on day one.
+      # Supply-chain gate: reports high/critical advisories in the resolved
+      # dependency tree on every run. Deliberately non-blocking
+      # (continue-on-error) today: there are 26 known pre-existing advisories
+      # (2 critical, 24 high) in axios, protobufjs (via winston-loki), lodash
+      # and ws/undici (both via discord.js). Clearing them is M3.2-M3.5 —
+      # undici is pinned exactly by discord.js/@discordjs/rest, so that
+      # advisory can't be patched with an override; bumping discord.js
+      # (M3.2) is the only supported remedy. The PR that clears the last of
+      # these MUST flip continue-on-error back off, or this gate is theatre.
       - name: Audit dependencies
         working-directory: discord-bot
         run: bun run audit
+        continue-on-error: true
 
   # Single required status check — green when every triggered job is.
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         run: docker compose -f docker-compose.ci.yml down -v
 
   quality:
-    name: Bot — lint & format
+    name: Bot — lint, format & audit
     needs: changes
     if: ${{ needs.changes.outputs.bot == 'true' }}
     runs-on: ubuntu-latest
@@ -128,6 +128,14 @@ jobs:
       - name: Format check
         working-directory: discord-bot
         run: bun run format:check
+
+      # Supply-chain gate: fails on high/critical advisories in the resolved
+      # dependency tree. Expected to be red until the M3 dependency-upgrade
+      # work lands — see the PR description for the known advisories this
+      # surfaces on day one.
+      - name: Audit dependencies
+        working-directory: discord-bot
+        run: bun run audit
 
   # Single required status check — green when every triggered job is.
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,10 +83,39 @@ jobs:
         working-directory: discord-bot
         run: docker compose -f docker-compose.ci.yml down -v
 
+  quality:
+    name: Bot — lint & format
+    needs: changes
+    if: ${{ needs.changes.outputs.bot == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2"
+
+      # Prisma's preinstall hook requires Node >= 18.18.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        working-directory: discord-bot
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        working-directory: discord-bot
+        run: bun run lint
+
+      - name: Format check
+        working-directory: discord-bot
+        run: bun run format:check
+
   # Single required status check — green when every triggered job is.
   ci:
     name: CI
-    needs: [bot]
+    needs: [bot, quality]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/discord-bot/.prettierignore
+++ b/discord-bot/.prettierignore
@@ -1,0 +1,14 @@
+node_modules
+dist
+prisma/generated
+coverage
+bun.lock
+
+# Infra config, not part of the JS/TS style unification this tooling exists
+# for — leave docker-compose formatting to whoever owns that file.
+*.yml
+*.yaml
+
+# release-please owns this file end to end and rewrites it on every
+# release — reformatting it here just means fighting release-please forever.
+CHANGELOG.md

--- a/discord-bot/.prettierrc.json
+++ b/discord-bot/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+    "tabWidth": 4,
+    "useTabs": false,
+    "semi": true,
+    "singleQuote": true,
+    "trailingComma": "all",
+    "printWidth": 100,
+    "arrowParens": "always"
+}

--- a/discord-bot/bin/console.ts
+++ b/discord-bot/bin/console.ts
@@ -1,41 +1,42 @@
-import { myContainer } from '../src/Infrastructure/DependencyInjection/inversify.config'
-import { type ConsoleCommand } from '../src/Domain/Console/ConsoleCommand'
-import { TYPES } from '../src/Infrastructure/DependencyInjection/types'
-import type Logger from '../src/Application/Logger/Logger'
-import WeekScreenshotWinner from "../src/Ui/Cli/WeekScreenshotWinner.ts";
+import { myContainer } from '../src/Infrastructure/DependencyInjection/inversify.config';
+import { type ConsoleCommand } from '../src/Domain/Console/ConsoleCommand';
+import { TYPES } from '../src/Infrastructure/DependencyInjection/types';
+import type Logger from '../src/Application/Logger/Logger';
+import WeekScreenshotWinner from '../src/Ui/Cli/WeekScreenshotWinner.ts';
 
-const logger = myContainer.get<Logger>(TYPES.Logger)
-const consoleCommands: Record<string, ConsoleCommand> = {}
-consoleCommands[WeekScreenshotWinner.commandName.toString()] = myContainer.get<WeekScreenshotWinner>(WeekScreenshotWinner)
+const logger = myContainer.get<Logger>(TYPES.Logger);
+const consoleCommands: Record<string, ConsoleCommand> = {};
+consoleCommands[WeekScreenshotWinner.commandName.toString()] =
+    myContainer.get<WeekScreenshotWinner>(WeekScreenshotWinner);
 
-async function run (): Promise<void> {
-  const args = process.argv.slice(2)
-  if (args.length === 0) {
-    throw new Error('Missing command to run! Run "help" to see the available commands')
-  }
+async function run(): Promise<void> {
+    const args = process.argv.slice(2);
+    if (args.length === 0) {
+        throw new Error('Missing command to run! Run "help" to see the available commands');
+    }
 
-  const commandArgs = args.slice(1)
-  const action = args[0]
+    const commandArgs = args.slice(1);
+    const action = args[0];
 
-  if (!action || action === 'help') {
-    console.log('Available commands:')
-    console.log(Object.keys(consoleCommands).join('\n'))
-    return
-  }
+    if (!action || action === 'help') {
+        console.log('Available commands:');
+        console.log(Object.keys(consoleCommands).join('\n'));
+        return;
+    }
 
-  if (!(action in consoleCommands)) {
-    throw new Error(`Unknown action: ${action}`)
-  }
+    if (!(action in consoleCommands)) {
+        throw new Error(`Unknown action: ${action}`);
+    }
 
-  await consoleCommands[action]?.run(commandArgs)
+    await consoleCommands[action]?.run(commandArgs);
 }
 
 run()
-  .then(() => {
-    logger.info('Done!')
-    process.exit(0)
-  })
-  .catch((error: any) => {
-    logger.error(`Error: ${error.message}`, { error })
-    process.exit(1)
-  })
+    .then(() => {
+        logger.info('Done!');
+        process.exit(0);
+    })
+    .catch((error: any) => {
+        logger.error(`Error: ${error.message}`, { error });
+        process.exit(1);
+    });

--- a/discord-bot/bun.lock
+++ b/discord-bot/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "discord-bot-ts",
@@ -15,9 +16,14 @@
         "winston-loki": "^6.1.3",
       },
       "devDependencies": {
+        "@eslint/js": "^9",
         "@types/bun": "latest",
         "env-cmd": "^10.1.0",
+        "eslint": "^9",
+        "eslint-config-prettier": "^9",
+        "prettier": "^3",
         "prisma": "^6.6.0",
+        "typescript-eslint": "^8",
       },
       "peerDependencies": {
         "typescript": "^5",
@@ -90,6 +96,34 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.2", "", { "os": "win32", "cpu": "x64" }, "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA=="],
+
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.10.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+
+    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.6", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.3.0", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA=="],
+
+    "@eslint/js": ["@eslint/js@9.39.5", "", {}, "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
+
+    "@humanfs/types": ["@humanfs/types@0.15.0", "", {}, "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
     "@inversifyjs/common": ["@inversifyjs/common@1.5.0", "", {}, "sha512-Qj5BELk11AfI2rgZEAaLPmOftmQRLLmoCXgAjmaF0IngQN5vHomVT5ML7DZ3+CA5fgGcEVMcGbUDAun+Rz+oNg=="],
 
@@ -169,13 +203,47 @@
 
     "@types/bun": ["@types/bun@1.2.9", "", { "dependencies": { "bun-types": "1.2.9" } }, "sha512-epShhLGQYc4Bv/aceHbmBhOz1XgUnuTZgcxjxk+WXwNyDXavv5QHD1QEFV0FwbTSQtNq6g4ZcV6y0vZakTjswg=="],
 
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
     "@types/node": ["@types/node@22.14.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw=="],
 
     "@types/triple-beam": ["@types/triple-beam@1.3.5", "", {}, "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.67.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.67.0", "@typescript-eslint/type-utils": "8.67.0", "@typescript-eslint/utils": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.67.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.67.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.67.0", "@typescript-eslint/types": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.67.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.67.0", "@typescript-eslint/types": "^8.67.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0" } }, "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.67.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0", "@typescript-eslint/utils": "8.67.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.67.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.67.0", "@typescript-eslint/tsconfig-utils": "8.67.0", "@typescript-eslint/types": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.67.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.67.0", "@typescript-eslint/types": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA=="],
+
     "@vladfrangu/async_event_emitter": ["@vladfrangu/async_event_emitter@2.4.6", "", {}, "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA=="],
+
+    "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
@@ -185,17 +253,25 @@
 
     "axios": ["axios@1.8.4", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.0", "proxy-from-env": "^1.1.0" } }, "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw=="],
 
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "brace-expansion": ["brace-expansion@1.1.18", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw=="],
+
     "btoa": ["btoa@1.2.1", "", { "bin": { "btoa": "bin/btoa.js" } }, "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="],
 
     "bun-types": ["bun-types@1.2.9", "", { "dependencies": { "@types/node": "*", "@types/ws": "*" } }, "sha512-dk/kOEfQbajENN/D6FyiSgOKEuUi9PWfqKQJEgwKrCMWbjS/S6tEXp178mWvWAcUSYm9ArDlWHZKO3T/4cLXiw=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
     "color": ["color@3.2.1", "", { "dependencies": { "color-convert": "^1.9.3", "color-string": "^1.6.0" } }, "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA=="],
 
-    "color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
-    "color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
 
@@ -205,11 +281,15 @@
 
     "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "dayjs": ["dayjs@1.11.13", "", {}, "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="],
 
     "debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
@@ -237,9 +317,43 @@
 
     "esbuild-register": ["esbuild-register@3.6.0", "", { "dependencies": { "debug": "^4.3.4" }, "peerDependencies": { "esbuild": ">=0.12 <1" } }, "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg=="],
 
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@9.39.5", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.6", "@eslint/js": "9.39.5", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw=="],
+
+    "eslint-config-prettier": ["eslint-config-prettier@9.1.2", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ=="],
+
+    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
     "fecha": ["fecha@4.2.3", "", {}, "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.4", "", {}, "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q=="],
 
     "fn.name": ["fn.name@1.1.0", "", {}, "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="],
 
@@ -255,7 +369,13 @@
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -263,19 +383,45 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "inversify": ["inversify@7.5.0", "", { "dependencies": { "@inversifyjs/common": "1.5.0", "@inversifyjs/container": "1.9.0", "@inversifyjs/core": "5.1.0" }, "peerDependencies": { "reflect-metadata": "~0.2.2" } }, "sha512-HYVDGApOdkCf5v3k1M/1tY+jAG/QjWYRnU3o+7Vlb5BvNyP0iOL/PQvz4YV7SYX7W79LALbAxi755E84cDDb+Q=="],
 
     "is-arrayish": ["is-arrayish@0.3.2", "", {}, "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="],
 
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
     "kuler": ["kuler@2.0.0", "", {}, "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="],
 
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
     "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
     "lodash.snakecase": ["lodash.snakecase@4.1.1", "", {}, "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="],
 
@@ -291,11 +437,31 @@
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "one-time": ["one-time@1.0.0", "", { "dependencies": { "fn.name": "1.x.x" } }, "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g=="],
 
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
 
     "prisma": ["prisma@6.6.0", "", { "dependencies": { "@prisma/config": "6.6.0", "@prisma/engines": "6.6.0" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "typescript": ">=5.1.0" }, "optionalPeers": ["typescript"], "bin": { "prisma": "build/index.js" } }, "sha512-SYCUykz+1cnl6Ugd8VUvtTQq5+j1Q7C0CtzKPjQ8JyA2ALh0EEJkMCS+KgdnvKW1lrxjtjCyJSHOOT236mENYg=="],
 
@@ -303,13 +469,19 @@
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -323,19 +495,33 @@
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
     "text-hex": ["text-hex@1.0.0", "", {}, "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="],
 
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
     "triple-beam": ["triple-beam@1.4.1", "", {}, "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg=="],
+
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
     "ts-mixer": ["ts-mixer@6.0.4", "", {}, "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "typescript-eslint": ["typescript-eslint@8.67.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.67.0", "@typescript-eslint/parser": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0", "@typescript-eslint/utils": "8.67.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg=="],
 
     "undici": ["undici@6.21.1", "", {}, "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "url-polyfill": ["url-polyfill@1.1.13", "", {}, "sha512-tXzkojrv2SujumYthZ/WjF7jaSfNhSXlYMpE5AYdL2I3D7DCeo+mch8KtW2rUuKjDg+3VXODXHVgipt8yGY/eQ=="],
 
@@ -351,12 +537,42 @@
 
     "winston-transport": ["winston-transport@4.9.0", "", { "dependencies": { "logform": "^2.7.0", "readable-stream": "^3.6.2", "triple-beam": "^1.3.0" } }, "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A=="],
 
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
     "ws": ["ws@8.18.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "@discordjs/rest/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
 
     "@discordjs/ws/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
 
-    "color-string/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@eslint/config-array/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@eslint/eslintrc/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.6", "", {}, "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw=="],
+
+    "@typescript-eslint/parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@typescript-eslint/project-service/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@typescript-eslint/type-utils/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@typescript-eslint/typescript-estree/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
+
+    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "color/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
+
+    "color/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
   }
 }

--- a/discord-bot/eslint.config.js
+++ b/discord-bot/eslint.config.js
@@ -1,0 +1,31 @@
+// @ts-check
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import eslintConfigPrettier from 'eslint-config-prettier';
+
+export default tseslint.config(
+    {
+        ignores: ['node_modules/**', 'dist/**', 'prisma/generated/**', 'coverage/**'],
+    },
+    eslint.configs.recommended,
+    ...tseslint.configs.recommended,
+    {
+        linterOptions: {
+            // Catches `eslint-disable` comments for rules that aren't actually
+            // enabled — several were left over from a linter this repo never had.
+            reportUnusedDisableDirectives: 'error',
+        },
+        rules: {
+            // Pragmatic, not maximalist: don't force a refactor of the existing
+            // codebase, just keep new code honest.
+            '@typescript-eslint/no-explicit-any': 'warn',
+            '@typescript-eslint/no-unused-vars': 'warn',
+            '@typescript-eslint/no-empty-object-type': 'warn',
+            '@typescript-eslint/no-empty-interface': 'off',
+            '@typescript-eslint/no-floating-promises': 'off',
+            'no-empty': 'warn',
+            'no-case-declarations': 'off',
+        },
+    },
+    eslintConfigPrettier,
+);

--- a/discord-bot/package.json
+++ b/discord-bot/package.json
@@ -1,48 +1,48 @@
 {
-  "name": "discord-bot-ts",
-  "version": "1.0.0",
-  "module": "index.ts",
-  "type": "module",
-  "scripts": {
-    "dev": "bun run --watch src/index.ts",
-    "start": "bun run src/index.ts",
-    "prisma:generate": "bunx prisma generate",
-    "dev:db:drop": "bunx prisma migrate reset --force",
-    "dev:db:push": "bunx prisma db push",
-    "dev:setup": "bun run dev:db:drop && bun run dev:db:push",
-    "test:local": "env-cmd -f .env.local bun test",
-    "test:db:drop": "env-cmd -f .env.test bunx prisma migrate reset --force --skip-generate",
-    "test:db:push": "env-cmd -f .env.test bunx prisma db push --skip-generate",
-    "test:setup": "bun run test:db:drop && bun run test:db:push",
-    "run:command": "bun bin/console.ts",
-    "typecheck": "bunx prisma generate && bunx tsc --noEmit",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
-    "format": "prettier --write .",
-    "format:check": "prettier --check ."
-  },
-  "dependencies": {
-    "@prisma/client": "^6.6.0",
-    "axios": "^1.8.4",
-    "dayjs": "^1.11.13",
-    "discord.js": "^14.18.0",
-    "dotenv": "^16.5.0",
-    "inversify": "^7.5.0",
-    "uuid": "^11.1.0",
-    "winston": "^3.17.0",
-    "winston-loki": "^6.1.3"
-  },
-  "devDependencies": {
-    "@eslint/js": "^9",
-    "@types/bun": "latest",
-    "env-cmd": "^10.1.0",
-    "eslint": "^9",
-    "eslint-config-prettier": "^9",
-    "prettier": "^3",
-    "prisma": "^6.6.0",
-    "typescript-eslint": "^8"
-  },
-  "peerDependencies": {
-    "typescript": "^5"
-  }
+    "name": "discord-bot-ts",
+    "version": "1.0.0",
+    "module": "index.ts",
+    "type": "module",
+    "scripts": {
+        "dev": "bun run --watch src/index.ts",
+        "start": "bun run src/index.ts",
+        "prisma:generate": "bunx prisma generate",
+        "dev:db:drop": "bunx prisma migrate reset --force",
+        "dev:db:push": "bunx prisma db push",
+        "dev:setup": "bun run dev:db:drop && bun run dev:db:push",
+        "test:local": "env-cmd -f .env.local bun test",
+        "test:db:drop": "env-cmd -f .env.test bunx prisma migrate reset --force --skip-generate",
+        "test:db:push": "env-cmd -f .env.test bunx prisma db push --skip-generate",
+        "test:setup": "bun run test:db:drop && bun run test:db:push",
+        "run:command": "bun bin/console.ts",
+        "typecheck": "bunx prisma generate && bunx tsc --noEmit",
+        "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
+        "format": "prettier --write .",
+        "format:check": "prettier --check ."
+    },
+    "dependencies": {
+        "@prisma/client": "^6.6.0",
+        "axios": "^1.8.4",
+        "dayjs": "^1.11.13",
+        "discord.js": "^14.18.0",
+        "dotenv": "^16.5.0",
+        "inversify": "^7.5.0",
+        "uuid": "^11.1.0",
+        "winston": "^3.17.0",
+        "winston-loki": "^6.1.3"
+    },
+    "devDependencies": {
+        "@eslint/js": "^9",
+        "@types/bun": "latest",
+        "env-cmd": "^10.1.0",
+        "eslint": "^9",
+        "eslint-config-prettier": "^9",
+        "prettier": "^3",
+        "prisma": "^6.6.0",
+        "typescript-eslint": "^8"
+    },
+    "peerDependencies": {
+        "typescript": "^5"
+    }
 }

--- a/discord-bot/package.json
+++ b/discord-bot/package.json
@@ -12,14 +12,15 @@
         "dev:setup": "bun run dev:db:drop && bun run dev:db:push",
         "test:local": "env-cmd -f .env.local bun test",
         "test:db:drop": "env-cmd -f .env.test bunx prisma migrate reset --force --skip-generate",
-        "test:db:push": "env-cmd -f .env.test bunx prisma db push --skip-generate",
-        "test:setup": "bun run test:db:drop && bun run test:db:push",
+        "test:db:migrate": "env-cmd -f .env.test bunx prisma migrate deploy",
+        "test:setup": "bun run test:db:drop && bun run test:db:migrate",
         "run:command": "bun bin/console.ts",
         "typecheck": "bunx prisma generate && bunx tsc --noEmit",
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",
         "format": "prettier --write .",
-        "format:check": "prettier --check ."
+        "format:check": "prettier --check .",
+        "db:drift": "prisma migrate diff --from-migrations prisma/migrations --to-schema-datamodel prisma/schema.prisma --shadow-database-url \"$SHADOW_DATABASE_URL\" --exit-code"
     },
     "dependencies": {
         "@prisma/client": "^6.6.0",

--- a/discord-bot/package.json
+++ b/discord-bot/package.json
@@ -15,7 +15,11 @@
     "test:db:push": "env-cmd -f .env.test bunx prisma db push --skip-generate",
     "test:setup": "bun run test:db:drop && bun run test:db:push",
     "run:command": "bun bin/console.ts",
-    "typecheck": "bunx prisma generate && bunx tsc --noEmit"
+    "typecheck": "bunx prisma generate && bunx tsc --noEmit",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@prisma/client": "^6.6.0",
@@ -29,9 +33,14 @@
     "winston-loki": "^6.1.3"
   },
   "devDependencies": {
+    "@eslint/js": "^9",
     "@types/bun": "latest",
     "env-cmd": "^10.1.0",
-    "prisma": "^6.6.0"
+    "eslint": "^9",
+    "eslint-config-prettier": "^9",
+    "prettier": "^3",
+    "prisma": "^6.6.0",
+    "typescript-eslint": "^8"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/discord-bot/package.json
+++ b/discord-bot/package.json
@@ -20,7 +20,8 @@
         "lint:fix": "eslint . --fix",
         "format": "prettier --write .",
         "format:check": "prettier --check .",
-        "db:drift": "prisma migrate diff --from-migrations prisma/migrations --to-schema-datamodel prisma/schema.prisma --shadow-database-url \"$SHADOW_DATABASE_URL\" --exit-code"
+        "db:drift": "prisma migrate diff --from-migrations prisma/migrations --to-schema-datamodel prisma/schema.prisma --shadow-database-url \"$SHADOW_DATABASE_URL\" --exit-code",
+        "audit": "bun audit --audit-level=high"
     },
     "dependencies": {
         "@prisma/client": "^6.6.0",

--- a/discord-bot/prisma/README.md
+++ b/discord-bot/prisma/README.md
@@ -71,18 +71,18 @@ Then use it to interact with your models:
 ```typescript
 // Create a new ad
 const ad = await prisma.ad.create({
-  data: {
-    name: 'PlayStation 5',
-    price: '499€',
-    // ...other fields
-  }
+    data: {
+        name: 'PlayStation 5',
+        price: '499€',
+        // ...other fields
+    },
 });
 
 // Query ads
 const ads = await prisma.ad.findMany({
-  where: {
-    state: 'active'
-  }
+    where: {
+        state: 'active',
+    },
 });
 ```
 
@@ -95,9 +95,9 @@ import { AdService } from '../models/ad';
 
 // Create a new ad
 const ad = await AdService.create({
-  name: 'PlayStation 5',
-  price: '499€',
-  // ...other fields
+    name: 'PlayStation 5',
+    price: '499€',
+    // ...other fields
 });
 
 // List active ads

--- a/discord-bot/src/Application/Event/EventDispatcher/Event.ts
+++ b/discord-bot/src/Application/Event/EventDispatcher/Event.ts
@@ -1,4 +1,2 @@
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export default interface Event {
-
-}
+export default interface Event {}

--- a/discord-bot/src/Application/Event/EventDispatcher/Event.ts
+++ b/discord-bot/src/Application/Event/EventDispatcher/Event.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export default interface Event {}

--- a/discord-bot/src/Application/Event/EventDispatcher/EventDispatcher.ts
+++ b/discord-bot/src/Application/Event/EventDispatcher/EventDispatcher.ts
@@ -1,33 +1,38 @@
-import type EventHandler from './EventHandler'
-import { inject, injectable, multiInject } from 'inversify'
-import { TYPES } from '../../../Infrastructure/DependencyInjection/types'
-import type Event from './Event'
-import Logger from '../../Logger/Logger'
+import type EventHandler from './EventHandler';
+import { inject, injectable, multiInject } from 'inversify';
+import { TYPES } from '../../../Infrastructure/DependencyInjection/types';
+import type Event from './Event';
+import Logger from '../../Logger/Logger';
 
 @injectable()
 export default class EventDispatcher {
-  constructor (
-    @multiInject(TYPES.EventHandler) private readonly handlers: Array<EventHandler<Event>> = new Array<EventHandler<Event>>(),
-    @inject(TYPES.Logger) private readonly logger: Logger
-  ) {
-  }
+    constructor(
+        @multiInject(TYPES.EventHandler)
+        private readonly handlers: Array<EventHandler<Event>> = new Array<EventHandler<Event>>(),
+        @inject(TYPES.Logger) private readonly logger: Logger,
+    ) {}
 
-  public async dispatch (event: Event): Promise<void> {
-    for (const handler of this.handlers) {
-      if (handler.supports(event)) {
-        this.logger.info(`Handling event ${event.constructor.name} with handler ${handler.constructor.name}`)
-        try {
-          await handler.handle(event)
-        } catch (error: any) {
-          this.logger.error(`Error occurred while handling event ${event.constructor.name} with handler ${handler.constructor.name}`, {
-            error_message: error.message,
-            event_name: event.constructor.name,
-            handler_name: handler.constructor.name,
-            error,
-            event
-          })
+    public async dispatch(event: Event): Promise<void> {
+        for (const handler of this.handlers) {
+            if (handler.supports(event)) {
+                this.logger.info(
+                    `Handling event ${event.constructor.name} with handler ${handler.constructor.name}`,
+                );
+                try {
+                    await handler.handle(event);
+                } catch (error: any) {
+                    this.logger.error(
+                        `Error occurred while handling event ${event.constructor.name} with handler ${handler.constructor.name}`,
+                        {
+                            error_message: error.message,
+                            event_name: event.constructor.name,
+                            handler_name: handler.constructor.name,
+                            error,
+                            event,
+                        },
+                    );
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/discord-bot/src/Application/Event/EventDispatcher/EventHandler.ts
+++ b/discord-bot/src/Application/Event/EventDispatcher/EventHandler.ts
@@ -1,7 +1,7 @@
-import type Event from './Event'
+import type Event from './Event';
 
 export default interface EventHandler<E> {
-  handle: (event: E) => Promise<void>
+    handle: (event: E) => Promise<void>;
 
-  supports: (event: Event) => boolean
+    supports: (event: Event) => boolean;
 }

--- a/discord-bot/src/Application/Logger/LogProviderInterface.ts
+++ b/discord-bot/src/Application/Logger/LogProviderInterface.ts
@@ -1,7 +1,7 @@
 export default interface LogProviderInterface {
-  info: (message: string, context?: Record<string, any>) => void
-  error: (message: string, context?: Record<string, any>) => void
-  log: (message: string, context?: Record<string, any>) => void
-  warn: (message: string, context?: Record<string, any>) => void
-  debug: (message: string, context?: Record<string, any>) => void
+    info: (message: string, context?: Record<string, any>) => void;
+    error: (message: string, context?: Record<string, any>) => void;
+    log: (message: string, context?: Record<string, any>) => void;
+    warn: (message: string, context?: Record<string, any>) => void;
+    debug: (message: string, context?: Record<string, any>) => void;
 }

--- a/discord-bot/src/Application/Logger/Logger.ts
+++ b/discord-bot/src/Application/Logger/Logger.ts
@@ -1,53 +1,53 @@
-import type LogProviderInterface from './LogProviderInterface'
+import type LogProviderInterface from './LogProviderInterface';
 
 export default class Logger implements LogProviderInterface {
-  constructor (
-    private readonly providers: LogProviderInterface[] = [],
-    private readonly context?: Record<string, any>
-  ) {}
+    constructor(
+        private readonly providers: LogProviderInterface[] = [],
+        private readonly context?: Record<string, any>,
+    ) {}
 
-  info (message: string, context?: Record<string, any>): void {
-    this.providers.forEach(provider => {
-      provider.info(message, {
-        ...this.context,
-        ...context
-      })
-    })
-  }
+    info(message: string, context?: Record<string, any>): void {
+        this.providers.forEach((provider) => {
+            provider.info(message, {
+                ...this.context,
+                ...context,
+            });
+        });
+    }
 
-  error (message: string, context?: Record<string, any>): void {
-    this.providers.forEach(provider => {
-      provider.error(message, {
-        ...this.context,
-        ...context
-      })
-    })
-  }
+    error(message: string, context?: Record<string, any>): void {
+        this.providers.forEach((provider) => {
+            provider.error(message, {
+                ...this.context,
+                ...context,
+            });
+        });
+    }
 
-  debug (message: string, context?: Record<string, any>): void {
-    this.providers.forEach(provider => {
-      provider.debug(message, {
-        ...this.context,
-        ...context
-      })
-    })
-  }
+    debug(message: string, context?: Record<string, any>): void {
+        this.providers.forEach((provider) => {
+            provider.debug(message, {
+                ...this.context,
+                ...context,
+            });
+        });
+    }
 
-  log (message: string, context?: Record<string, any>): void {
-    this.providers.forEach(provider => {
-      provider.log(message, {
-        ...this.context,
-        ...context
-      })
-    })
-  }
+    log(message: string, context?: Record<string, any>): void {
+        this.providers.forEach((provider) => {
+            provider.log(message, {
+                ...this.context,
+                ...context,
+            });
+        });
+    }
 
-  warn (message: string, context?: Record<string, any>): void {
-    this.providers.forEach(provider => {
-      provider.warn(message, {
-        ...this.context,
-        ...context
-      })
-    })
-  }
+    warn(message: string, context?: Record<string, any>): void {
+        this.providers.forEach((provider) => {
+            provider.warn(message, {
+                ...this.context,
+                ...context,
+            });
+        });
+    }
 }

--- a/discord-bot/src/Application/Logger/LoggerManager.ts
+++ b/discord-bot/src/Application/Logger/LoggerManager.ts
@@ -1,19 +1,16 @@
-import type LogProviderInterface from './LogProviderInterface'
-import { injectable } from 'inversify'
-import Logger from './Logger'
+import type LogProviderInterface from './LogProviderInterface';
+import { injectable } from 'inversify';
+import Logger from './Logger';
 
 @injectable()
 export default class LoggerManager {
-  private readonly providers: LogProviderInterface[] = []
+    private readonly providers: LogProviderInterface[] = [];
 
-  addProvider (provider: LogProviderInterface): void {
-    this.providers.push(provider)
-  }
+    addProvider(provider: LogProviderInterface): void {
+        this.providers.push(provider);
+    }
 
-  createLogger (context?: Record<string, string>): Logger {
-    return new Logger(
-      this.providers,
-      context
-    )
-  }
+    createLogger(context?: Record<string, string>): Logger {
+        return new Logger(this.providers, context);
+    }
 }

--- a/discord-bot/src/Application/Query/Marketplace/ListUserAds/ListUserAds.ts
+++ b/discord-bot/src/Application/Query/Marketplace/ListUserAds/ListUserAds.ts
@@ -1,5 +1,3 @@
 export class ListUserAds {
-    constructor(
-        public readonly userId: string
-    ) {}
+    constructor(public readonly userId: string) {}
 }

--- a/discord-bot/src/Application/Query/Marketplace/ListUserAds/ListUserAdsHandler.ts
+++ b/discord-bot/src/Application/Query/Marketplace/ListUserAds/ListUserAdsHandler.ts
@@ -1,15 +1,15 @@
-import { inject, injectable } from "inversify";
-import { TYPES } from "../../../../Infrastructure/DependencyInjection/types";
-import type { AdRepository } from "../../../../Domain/Marketplace/AdRepository";
-import { ListUserAds } from "./ListUserAds";
-import type Logger from "../../../Logger/Logger";
-import type {Ad} from "../../../../Domain/Marketplace/Ad.ts";
+import { inject, injectable } from 'inversify';
+import { TYPES } from '../../../../Infrastructure/DependencyInjection/types';
+import type { AdRepository } from '../../../../Domain/Marketplace/AdRepository';
+import { ListUserAds } from './ListUserAds';
+import type Logger from '../../../Logger/Logger';
+import type { Ad } from '../../../../Domain/Marketplace/Ad.ts';
 
 @injectable()
 export class ListUserAdsHandler {
     constructor(
         @inject(TYPES.Logger) private readonly logger: Logger,
-        @inject(TYPES.AdRepository) private readonly adRepository: AdRepository
+        @inject(TYPES.AdRepository) private readonly adRepository: AdRepository,
     ) {}
 
     public async handle(query: ListUserAds): Promise<Ad[]> {

--- a/discord-bot/src/Application/Query/Ping/Ping.ts
+++ b/discord-bot/src/Application/Query/Ping/Ping.ts
@@ -1,4 +1,3 @@
-import type Command from "../../../Domain/Command/Command.ts";
+import type Command from '../../../Domain/Command/Command.ts';
 
-export class Ping implements Command {
-}
+export class Ping implements Command {}

--- a/discord-bot/src/Application/Query/Ping/PingHandler.ts
+++ b/discord-bot/src/Application/Query/Ping/PingHandler.ts
@@ -1,6 +1,6 @@
-import {injectable} from "inversify";
-import type {Ping} from "./Ping.ts";
-import type CommandHandler from "../../../Domain/Command/CommandHandler.ts";
+import { injectable } from 'inversify';
+import type { Ping } from './Ping.ts';
+import type CommandHandler from '../../../Domain/Command/CommandHandler.ts';
 
 @injectable()
 export class PingHandler implements CommandHandler<Ping> {

--- a/discord-bot/src/Application/Query/Screenshot/GetScreenshotWinner/GetScreenshotWinner.ts
+++ b/discord-bot/src/Application/Query/Screenshot/GetScreenshotWinner/GetScreenshotWinner.ts
@@ -1,5 +1,3 @@
 export class GetScreenshotWinner {
-  constructor(
-      public readonly week: Date
-  ) {}
+    constructor(public readonly week: Date) {}
 }

--- a/discord-bot/src/Application/Query/Screenshot/GetScreenshotWinner/GetScreenshotWinnerHandler.ts
+++ b/discord-bot/src/Application/Query/Screenshot/GetScreenshotWinner/GetScreenshotWinnerHandler.ts
@@ -1,77 +1,83 @@
-import {inject, injectable} from 'inversify';
-import {TYPES} from '../../../../Infrastructure/DependencyInjection/types';
+import { inject, injectable } from 'inversify';
+import { TYPES } from '../../../../Infrastructure/DependencyInjection/types';
 import type Logger from '../../../Logger/Logger';
-import type {ScreenshotRepository} from '../../../../Domain/Screenshot/ScreenshotRepository';
-import {GetScreenshotWinner} from './GetScreenshotWinner';
-import {Screenshot} from '../../../../Domain/Screenshot/Screenshot';
-import type {GuildClient} from "../../../../Domain/Community/GuildClient.ts";
-import {CustomEmoji} from "../../../../Domain/Community/CustomEmoji.ts";
-import {CommunityChannels} from "../../../../Domain/Community/CommunityChannels.ts";
+import type { ScreenshotRepository } from '../../../../Domain/Screenshot/ScreenshotRepository';
+import { GetScreenshotWinner } from './GetScreenshotWinner';
+import { Screenshot } from '../../../../Domain/Screenshot/Screenshot';
+import type { GuildClient } from '../../../../Domain/Community/GuildClient.ts';
+import { CustomEmoji } from '../../../../Domain/Community/CustomEmoji.ts';
+import { CommunityChannels } from '../../../../Domain/Community/CommunityChannels.ts';
 
 interface ScreenshotWinner {
-  screenshot: Screenshot;
-  reactionCount: number;
-  messageUrl: string;
+    screenshot: Screenshot;
+    reactionCount: number;
+    messageUrl: string;
 }
 
 @injectable()
 export class GetScreenshotWinnerHandler {
-  constructor(
-    @inject(TYPES.Logger) private readonly logger: Logger,
-    @inject(TYPES.ScreenshotRepository) private readonly screenshotRepository: ScreenshotRepository,
-    @inject(TYPES.GuildClient) private readonly guildClient: GuildClient
-  ) {}
+    constructor(
+        @inject(TYPES.Logger) private readonly logger: Logger,
+        @inject(TYPES.ScreenshotRepository)
+        private readonly screenshotRepository: ScreenshotRepository,
+        @inject(TYPES.GuildClient) private readonly guildClient: GuildClient,
+    ) {}
 
-  public async handle(command: GetScreenshotWinner): Promise<ScreenshotWinner|null> {
-    const screenshots = await this.screenshotRepository.findByWeek(command.week);
-    
-    if (screenshots.length === 0) {
-      this.logger.info('No screenshots found for this week');
-      return null;
-    }
+    public async handle(command: GetScreenshotWinner): Promise<ScreenshotWinner | null> {
+        const screenshots = await this.screenshotRepository.findByWeek(command.week);
 
-    this.logger.info('Found screenshots for this week', { count: screenshots.length });
-
-    let winner: ScreenshotWinner|null = null;
-    for (const screenshot of screenshots) {
-      try {
-        if (screenshot.messageId === null) {
-          this.logger.error('Message ID is null for screenshot', { screenshotId: screenshot.id });
-          continue;
+        if (screenshots.length === 0) {
+            this.logger.info('No screenshots found for this week');
+            return null;
         }
 
-        const reactionCount = await this.guildClient.getTotalReactionsByEmoji(
-            CommunityChannels.SCREENSHOTS,
-            screenshot.messageId,
-            CustomEmoji.TROPHY_PLAT
-        );
+        this.logger.info('Found screenshots for this week', { count: screenshots.length });
 
-        if (!winner || reactionCount > winner.reactionCount) {
-          winner = {
-            screenshot,
-            reactionCount,
-            messageUrl: await this.guildClient.getMessageUrl(CommunityChannels.SCREENSHOTS, screenshot.messageId)
-          };
+        let winner: ScreenshotWinner | null = null;
+        for (const screenshot of screenshots) {
+            try {
+                if (screenshot.messageId === null) {
+                    this.logger.error('Message ID is null for screenshot', {
+                        screenshotId: screenshot.id,
+                    });
+                    continue;
+                }
+
+                const reactionCount = await this.guildClient.getTotalReactionsByEmoji(
+                    CommunityChannels.SCREENSHOTS,
+                    screenshot.messageId,
+                    CustomEmoji.TROPHY_PLAT,
+                );
+
+                if (!winner || reactionCount > winner.reactionCount) {
+                    winner = {
+                        screenshot,
+                        reactionCount,
+                        messageUrl: await this.guildClient.getMessageUrl(
+                            CommunityChannels.SCREENSHOTS,
+                            screenshot.messageId,
+                        ),
+                    };
+                }
+            } catch (error: any) {
+                this.logger.error('Error processing screenshot', {
+                    screenshotId: screenshot.id,
+                    error: error.message,
+                });
+            }
         }
-      } catch (error: any) {
-        this.logger.error('Error processing screenshot', { 
-          screenshotId: screenshot.id,
-          error: error.message 
+
+        if (!winner) {
+            this.logger.info('No winner found');
+            return null;
+        }
+
+        this.logger.info('Found winner', {
+            screenshotId: winner.screenshot.id,
+            authorId: winner.screenshot.authorId,
+            reactionCount: winner.reactionCount,
         });
-      }
+
+        return winner;
     }
-
-    if (!winner) {
-      this.logger.info('No winner found');
-      return null;
-    }
-
-    this.logger.info('Found winner', { 
-      screenshotId: winner.screenshot.id,
-      authorId: winner.screenshot.authorId,
-      reactionCount: winner.reactionCount
-    });
-
-    return winner;
-  }
 }

--- a/discord-bot/src/Application/Query/Screenshot/GetScreenshots/GetScreenshots.ts
+++ b/discord-bot/src/Application/Query/Screenshot/GetScreenshots/GetScreenshots.ts
@@ -1,7 +1,5 @@
-import type Command from "../../../../Domain/Command/Command.ts";
+import type Command from '../../../../Domain/Command/Command.ts';
 
 export class GetScreenshots implements Command {
-  constructor(
-    public readonly userId: string | null = null
-  ) {}
+    constructor(public readonly userId: string | null = null) {}
 }

--- a/discord-bot/src/Application/Query/Screenshot/GetScreenshots/GetScreenshotsHandler.ts
+++ b/discord-bot/src/Application/Query/Screenshot/GetScreenshots/GetScreenshotsHandler.ts
@@ -1,17 +1,18 @@
-import { inject, injectable } from "inversify";
-import type CommandHandler from "../../../../Domain/Command/CommandHandler";
-import { GetScreenshots } from "./GetScreenshots";
-import type { ScreenshotRepository } from "../../../../Domain/Screenshot/ScreenshotRepository";
-import { TYPES } from "../../../../Infrastructure/DependencyInjection/types";
-import type { Screenshot } from "../../../../Domain/Screenshot/Screenshot";
+import { inject, injectable } from 'inversify';
+import type CommandHandler from '../../../../Domain/Command/CommandHandler';
+import { GetScreenshots } from './GetScreenshots';
+import type { ScreenshotRepository } from '../../../../Domain/Screenshot/ScreenshotRepository';
+import { TYPES } from '../../../../Infrastructure/DependencyInjection/types';
+import type { Screenshot } from '../../../../Domain/Screenshot/Screenshot';
 
 @injectable()
 export class GetScreenshotsHandler implements CommandHandler<GetScreenshots> {
-  constructor(
-    @inject(TYPES.ScreenshotRepository) private readonly screenshotRepository: ScreenshotRepository,
-  ) {}
+    constructor(
+        @inject(TYPES.ScreenshotRepository)
+        private readonly screenshotRepository: ScreenshotRepository,
+    ) {}
 
-  async handle(command: GetScreenshots): Promise<Screenshot[]> {
-    return await this.screenshotRepository.findBy(command.userId);
-  }
+    async handle(command: GetScreenshots): Promise<Screenshot[]> {
+        return await this.screenshotRepository.findBy(command.userId);
+    }
 }

--- a/discord-bot/src/Application/Query/Trophy/GetProfile/GetProfile.ts
+++ b/discord-bot/src/Application/Query/Trophy/GetProfile/GetProfile.ts
@@ -1,7 +1,5 @@
-import type Command from "../../../../Domain/Command/Command";
+import type Command from '../../../../Domain/Command/Command';
 
 export class GetProfile implements Command {
-    constructor(
-        public readonly userId: string
-    ) {}
+    constructor(public readonly userId: string) {}
 }

--- a/discord-bot/src/Application/Query/Trophy/GetProfile/GetProfileHandler.ts
+++ b/discord-bot/src/Application/Query/Trophy/GetProfile/GetProfileHandler.ts
@@ -1,17 +1,18 @@
-import { inject, injectable } from "inversify";
-import type CommandHandler from "../../../../Domain/Command/CommandHandler";
-import { GetProfile } from "./GetProfile";
-import type { TrophyProfileRepository } from "../../../../Domain/Trophy/TrophyProfileRepository";
-import { TYPES } from "../../../../Infrastructure/DependencyInjection/types";
-import type Logger from "../../../Logger/Logger";
-import type { TrophyProfile } from "../../../../Domain/Trophy/TrophyProfile";
-import { ProfileNotFound } from "./ProfileNotFound";
+import { inject, injectable } from 'inversify';
+import type CommandHandler from '../../../../Domain/Command/CommandHandler';
+import { GetProfile } from './GetProfile';
+import type { TrophyProfileRepository } from '../../../../Domain/Trophy/TrophyProfileRepository';
+import { TYPES } from '../../../../Infrastructure/DependencyInjection/types';
+import type Logger from '../../../Logger/Logger';
+import type { TrophyProfile } from '../../../../Domain/Trophy/TrophyProfile';
+import { ProfileNotFound } from './ProfileNotFound';
 
 @injectable()
 export class GetProfileHandler implements CommandHandler<GetProfile> {
     constructor(
-        @inject(TYPES.TrophyProfileRepository) private readonly trophyProfileRepository: TrophyProfileRepository,
-        @inject(TYPES.Logger) private readonly logger: Logger
+        @inject(TYPES.TrophyProfileRepository)
+        private readonly trophyProfileRepository: TrophyProfileRepository,
+        @inject(TYPES.Logger) private readonly logger: Logger,
     ) {}
 
     async handle(command: GetProfile): Promise<TrophyProfile> {
@@ -19,7 +20,7 @@ export class GetProfileHandler implements CommandHandler<GetProfile> {
 
         if (profile === null) {
             this.logger.warn('Trophy profile not found', {
-                userId: command.userId
+                userId: command.userId,
             });
 
             throw new ProfileNotFound(command.userId);
@@ -27,7 +28,7 @@ export class GetProfileHandler implements CommandHandler<GetProfile> {
 
         this.logger.info('Trophy profile retrieved successfully', {
             userId: command.userId,
-            psnProfile: profile.psnProfile
+            psnProfile: profile.psnProfile,
         });
 
         return profile;

--- a/discord-bot/src/Application/Query/Trophy/GetRank/GetRank.ts
+++ b/discord-bot/src/Application/Query/Trophy/GetRank/GetRank.ts
@@ -1,4 +1,4 @@
-import type Command from "../../../../Domain/Command/Command";
+import type Command from '../../../../Domain/Command/Command';
 
 export type RankType = 'monthly' | 'creation' | 'lifetime' | 'user';
 export type MonthOption = 'current' | 'last' | number; // 1-12 for specific months

--- a/discord-bot/src/Application/Query/Trophy/GetRank/GetRankHandler.ts
+++ b/discord-bot/src/Application/Query/Trophy/GetRank/GetRankHandler.ts
@@ -1,17 +1,17 @@
-import {inject, injectable} from "inversify";
-import type CommandHandler from "../../../../Domain/Command/CommandHandler";
-import {TYPES} from "../../../../Infrastructure/DependencyInjection/types";
-import type Logger from "../../../Logger/Logger";
-import {GetRank, type MonthOption} from "./GetRank";
-import type {TrophyRepository} from "../../../../Domain/Trophy/TrophyRepository";
-import type {TrophyRankData} from "../../../../Domain/Trophy/TrophyRankData";
-import type {UserPosition} from "../../../../Domain/Trophy/UserPosition";
+import { inject, injectable } from 'inversify';
+import type CommandHandler from '../../../../Domain/Command/CommandHandler';
+import { TYPES } from '../../../../Infrastructure/DependencyInjection/types';
+import type Logger from '../../../Logger/Logger';
+import { GetRank, type MonthOption } from './GetRank';
+import type { TrophyRepository } from '../../../../Domain/Trophy/TrophyRepository';
+import type { TrophyRankData } from '../../../../Domain/Trophy/TrophyRankData';
+import type { UserPosition } from '../../../../Domain/Trophy/UserPosition';
 
 @injectable()
 export class GetRankHandler implements CommandHandler<GetRank> {
     constructor(
         @inject(TYPES.Logger) private readonly logger: Logger,
-        @inject(TYPES.TrophyRepository) private readonly trophyRepository: TrophyRepository
+        @inject(TYPES.TrophyRepository) private readonly trophyRepository: TrophyRepository,
     ) {}
 
     public async handle(command: GetRank): Promise<TrophyRankData[] | UserPosition> {
@@ -20,15 +20,18 @@ export class GetRankHandler implements CommandHandler<GetRank> {
             userId: command.targetUserId,
             limit: command.limit,
             month: command.month,
-            year: command.year
+            year: command.year,
         });
 
         if (command.type === 'user') {
             return await this.getUserPositions(command.targetUserId, command.limit);
         }
 
-        const date = command.type === 'monthly' ? this.getDateForMonth(command.month, command.year) : new Date();
-        
+        const date =
+            command.type === 'monthly'
+                ? this.getDateForMonth(command.month, command.year)
+                : new Date();
+
         switch (command.type) {
             case 'monthly':
                 return await this.trophyRepository.getTopMonthlyHunters(command.limit, date);

--- a/discord-bot/src/Application/Shared/DateUtils.ts
+++ b/discord-bot/src/Application/Shared/DateUtils.ts
@@ -1,9 +1,9 @@
-export function isLastDayOfMonth (date: Date): boolean {
-  const nextDay = new Date(date)
-  nextDay.setDate(date.getDate() + 1)
-  return nextDay.getDate() === 1
+export function isLastDayOfMonth(date: Date): boolean {
+    const nextDay = new Date(date);
+    nextDay.setDate(date.getDate() + 1);
+    return nextDay.getDate() === 1;
 }
 
-export function isMonday (date: Date): boolean {
-  return date.getDay() === 1
+export function isMonday(date: Date): boolean {
+    return date.getDay() === 1;
 }

--- a/discord-bot/src/Application/Shared/StringTools.ts
+++ b/discord-bot/src/Application/Shared/StringTools.ts
@@ -1,3 +1,3 @@
-export function isEmpty (value: string | undefined | null): boolean {
-  return value === undefined || value === null || value === ''
+export function isEmpty(value: string | undefined | null): boolean {
+    return value === undefined || value === null || value === '';
 }

--- a/discord-bot/src/Application/Shared/sleep.ts
+++ b/discord-bot/src/Application/Shared/sleep.ts
@@ -1,3 +1,3 @@
-export async function sleep (ms: number): Promise<void> {
-  await new Promise(resolve => setTimeout(resolve, ms))
+export async function sleep(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/discord-bot/src/Application/Write/Marketplace/CreateAd/CreateAd.ts
+++ b/discord-bot/src/Application/Write/Marketplace/CreateAd/CreateAd.ts
@@ -1,19 +1,19 @@
-import { AdId } from '../../../../Domain/Marketplace/AdId'
-import type Command from "../../../../Domain/Command/Command.ts";
+import { AdId } from '../../../../Domain/Marketplace/AdId';
+import type Command from '../../../../Domain/Command/Command.ts';
 
 export class CreateAd implements Command {
-  constructor(
-    public readonly id: AdId,
-    public readonly name: string,
-    public readonly authorId: string,
-    public readonly channelId: string,
-    public readonly messageId: string,
-    public readonly state: string,
-    public readonly price: string,
-    public readonly zone: string,
-    public readonly dispatch: string,
-    public readonly warranty: string,
-    public readonly description: string,
-    public readonly adType: string
-  ) {}
+    constructor(
+        public readonly id: AdId,
+        public readonly name: string,
+        public readonly authorId: string,
+        public readonly channelId: string,
+        public readonly messageId: string,
+        public readonly state: string,
+        public readonly price: string,
+        public readonly zone: string,
+        public readonly dispatch: string,
+        public readonly warranty: string,
+        public readonly description: string,
+        public readonly adType: string,
+    ) {}
 }

--- a/discord-bot/src/Application/Write/Marketplace/CreateAd/CreateAdHandler.ts
+++ b/discord-bot/src/Application/Write/Marketplace/CreateAd/CreateAdHandler.ts
@@ -1,44 +1,44 @@
-import { inject, injectable } from 'inversify'
-import type CommandHandler from '../../../../Domain/Command/CommandHandler'
-import { CreateAd } from './CreateAd'
-import { Ad } from '../../../../Domain/Marketplace/Ad'
-import type { AdRepository } from '../../../../Domain/Marketplace/AdRepository'
-import { TYPES } from '../../../../Infrastructure/DependencyInjection/types'
-import type Logger from '../../../Logger/Logger'
+import { inject, injectable } from 'inversify';
+import type CommandHandler from '../../../../Domain/Command/CommandHandler';
+import { CreateAd } from './CreateAd';
+import { Ad } from '../../../../Domain/Marketplace/Ad';
+import type { AdRepository } from '../../../../Domain/Marketplace/AdRepository';
+import { TYPES } from '../../../../Infrastructure/DependencyInjection/types';
+import type Logger from '../../../Logger/Logger';
 
 @injectable()
 export class CreateAdHandler implements CommandHandler<CreateAd> {
-  constructor(
-    @inject(TYPES.AdRepository) private readonly adRepository: AdRepository,
-    @inject(TYPES.Logger) private readonly logger: Logger
-  ) {}
+    constructor(
+        @inject(TYPES.AdRepository) private readonly adRepository: AdRepository,
+        @inject(TYPES.Logger) private readonly logger: Logger,
+    ) {}
 
-  async handle(command: CreateAd): Promise<void> {
-    // Create a new Ad entity
-    const ad = new Ad(
-      command.id,
-      command.name,
-      command.authorId,
-      command.channelId,
-      command.messageId,
-      command.state,
-      command.price,
-      command.zone,
-      command.dispatch,
-      command.warranty,
-      command.description,
-      command.adType,
-      new Date(),
-      new Date()
-    )
+    async handle(command: CreateAd): Promise<void> {
+        // Create a new Ad entity
+        const ad = new Ad(
+            command.id,
+            command.name,
+            command.authorId,
+            command.channelId,
+            command.messageId,
+            command.state,
+            command.price,
+            command.zone,
+            command.dispatch,
+            command.warranty,
+            command.description,
+            command.adType,
+            new Date(),
+            new Date(),
+        );
 
-    // Save the ad using the repository
-    await this.adRepository.save(ad)
+        // Save the ad using the repository
+        await this.adRepository.save(ad);
 
-    this.logger.info('Ad created successfully', {
-      id: ad.id.toString(),
-      name: command.name,
-      authorId: command.authorId
-    })
-  }
+        this.logger.info('Ad created successfully', {
+            id: ad.id.toString(),
+            name: command.name,
+            authorId: command.authorId,
+        });
+    }
 }

--- a/discord-bot/src/Application/Write/Marketplace/DeleteAd/DeleteAd.ts
+++ b/discord-bot/src/Application/Write/Marketplace/DeleteAd/DeleteAd.ts
@@ -1,9 +1,9 @@
-import { AdId } from '../../../../Domain/Marketplace/AdId'
-import type Command from "../../../../Domain/Command/Command.ts";
+import { AdId } from '../../../../Domain/Marketplace/AdId';
+import type Command from '../../../../Domain/Command/Command.ts';
 
 export class DeleteAd implements Command {
-  constructor(
-    public readonly id: AdId,
-    public readonly userId: string
-  ) {}
+    constructor(
+        public readonly id: AdId,
+        public readonly userId: string,
+    ) {}
 }

--- a/discord-bot/src/Application/Write/Marketplace/DeleteAd/DeleteAdHandler.ts
+++ b/discord-bot/src/Application/Write/Marketplace/DeleteAd/DeleteAdHandler.ts
@@ -1,32 +1,34 @@
-import { inject, injectable } from 'inversify'
-import type CommandHandler from '../../../../Domain/Command/CommandHandler'
-import { DeleteAd } from './DeleteAd'
-import type { AdRepository } from '../../../../Domain/Marketplace/AdRepository'
-import { TYPES } from '../../../../Infrastructure/DependencyInjection/types'
-import type Logger from '../../../Logger/Logger'
-import { UnauthorizedAdDeletion } from '../../../../Domain/Marketplace/UnauthorizedAdDeletion'
+import { inject, injectable } from 'inversify';
+import type CommandHandler from '../../../../Domain/Command/CommandHandler';
+import { DeleteAd } from './DeleteAd';
+import type { AdRepository } from '../../../../Domain/Marketplace/AdRepository';
+import { TYPES } from '../../../../Infrastructure/DependencyInjection/types';
+import type Logger from '../../../Logger/Logger';
+import { UnauthorizedAdDeletion } from '../../../../Domain/Marketplace/UnauthorizedAdDeletion';
 
 @injectable()
 export class DeleteAdHandler implements CommandHandler<DeleteAd> {
-  constructor(
-    @inject(TYPES.AdRepository) private readonly adRepository: AdRepository,
-    @inject(TYPES.Logger) private readonly logger: Logger
-  ) {}
+    constructor(
+        @inject(TYPES.AdRepository) private readonly adRepository: AdRepository,
+        @inject(TYPES.Logger) private readonly logger: Logger,
+    ) {}
 
-  async handle(command: DeleteAd): Promise<void> {
-    const ad = await this.adRepository.get(command.id)
+    async handle(command: DeleteAd): Promise<void> {
+        const ad = await this.adRepository.get(command.id);
 
-    // Verify that the user owns the ad
-    if (ad.authorId !== command.userId) {
-      throw new UnauthorizedAdDeletion(`User ${command.userId} is not authorized to delete ad ${command.id.toString()}`)
+        // Verify that the user owns the ad
+        if (ad.authorId !== command.userId) {
+            throw new UnauthorizedAdDeletion(
+                `User ${command.userId} is not authorized to delete ad ${command.id.toString()}`,
+            );
+        }
+
+        // Delete the ad
+        await this.adRepository.delete(command.id);
+
+        this.logger.info('Ad deleted successfully', {
+            id: command.id.toString(),
+            userId: command.userId,
+        });
     }
-
-    // Delete the ad
-    await this.adRepository.delete(command.id)
-
-    this.logger.info('Ad deleted successfully', {
-      id: command.id.toString(),
-      userId: command.userId
-    })
-  }
 }

--- a/discord-bot/src/Application/Write/Screenshot/CreateScreenshot/CreateScreenshot.ts
+++ b/discord-bot/src/Application/Write/Screenshot/CreateScreenshot/CreateScreenshot.ts
@@ -1,14 +1,14 @@
-import type Command from "../../../../Domain/Command/Command.ts";
-import type {ScreenshotId} from "../../../../Domain/Screenshot/ScreenshotId.ts";
+import type Command from '../../../../Domain/Command/Command.ts';
+import type { ScreenshotId } from '../../../../Domain/Screenshot/ScreenshotId.ts';
 
 export class CreateScreenshot implements Command {
-  constructor(
-      public readonly id: ScreenshotId,
-    public readonly name: string,
-    public readonly authorId: string | null,
-    public readonly channelId: string | null,
-    public readonly messageId: string | null,
-    public readonly platform: string,
-    public readonly image: string,
-  ) {}
+    constructor(
+        public readonly id: ScreenshotId,
+        public readonly name: string,
+        public readonly authorId: string | null,
+        public readonly channelId: string | null,
+        public readonly messageId: string | null,
+        public readonly platform: string,
+        public readonly image: string,
+    ) {}
 }

--- a/discord-bot/src/Application/Write/Screenshot/CreateScreenshot/CreateScreenshotHandler.ts
+++ b/discord-bot/src/Application/Write/Screenshot/CreateScreenshot/CreateScreenshotHandler.ts
@@ -1,58 +1,59 @@
-import { inject, injectable } from "inversify";
-import type CommandHandler from "../../../../Domain/Command/CommandHandler";
-import { CreateScreenshot } from "./CreateScreenshot";
-import { Screenshot } from "../../../../Domain/Screenshot/Screenshot";
-import type {ScreenshotRepository} from "../../../../Domain/Screenshot/ScreenshotRepository";
-import { TYPES } from "../../../../Infrastructure/DependencyInjection/types";
-import type Logger from "../../../Logger/Logger";
-import type {HttpClient} from "../../../../Domain/Http/HttpClient.ts";
+import { inject, injectable } from 'inversify';
+import type CommandHandler from '../../../../Domain/Command/CommandHandler';
+import { CreateScreenshot } from './CreateScreenshot';
+import { Screenshot } from '../../../../Domain/Screenshot/Screenshot';
+import type { ScreenshotRepository } from '../../../../Domain/Screenshot/ScreenshotRepository';
+import { TYPES } from '../../../../Infrastructure/DependencyInjection/types';
+import type Logger from '../../../Logger/Logger';
+import type { HttpClient } from '../../../../Domain/Http/HttpClient.ts';
 import crypto from 'crypto';
-import { ScreenshotAlreadyExist } from "./ScreenshotAlreadyExist";
+import { ScreenshotAlreadyExist } from './ScreenshotAlreadyExist';
 
 @injectable()
 export class CreateScreenshotHandler implements CommandHandler<CreateScreenshot> {
-  constructor(
-    @inject(TYPES.ScreenshotRepository) private readonly screenshotRepository: ScreenshotRepository,
-    @inject(TYPES.Logger) private readonly logger: Logger,
-    @inject(TYPES.HttpClient) private readonly httpClient: HttpClient
-  ) {}
+    constructor(
+        @inject(TYPES.ScreenshotRepository)
+        private readonly screenshotRepository: ScreenshotRepository,
+        @inject(TYPES.Logger) private readonly logger: Logger,
+        @inject(TYPES.HttpClient) private readonly httpClient: HttpClient,
+    ) {}
 
-  async handle(command: CreateScreenshot): Promise<Screenshot> {
-    const md5 = await this.generateMd5FromImageUrl(command.image);
+    async handle(command: CreateScreenshot): Promise<Screenshot> {
+        const md5 = await this.generateMd5FromImageUrl(command.image);
 
-    if (await this.screenshotRepository.findByMd5(md5) !== null) {
-      throw new ScreenshotAlreadyExist(`Screenshot with MD5 hash ${md5} already exists`);
+        if ((await this.screenshotRepository.findByMd5(md5)) !== null) {
+            throw new ScreenshotAlreadyExist(`Screenshot with MD5 hash ${md5} already exists`);
+        }
+
+        // Create a new Screenshot entity
+        const screenshot = new Screenshot(
+            command.id,
+            command.name,
+            command.authorId,
+            command.channelId,
+            command.messageId,
+            command.platform,
+            command.image,
+            md5,
+            new Date(),
+            new Date(),
+        );
+
+        // Save the screenshot using the repository
+        await this.screenshotRepository.save(screenshot);
+
+        this.logger.info('Screenshot created successfully', {
+            id: screenshot.id.toString(),
+            name: command.name,
+            authorId: command.authorId,
+        });
+
+        return screenshot;
     }
 
-    // Create a new Screenshot entity
-    const screenshot = new Screenshot(
-        command.id,
-        command.name,
-        command.authorId,
-        command.channelId,
-        command.messageId,
-        command.platform,
-        command.image,
-        md5,
-        new Date(),
-        new Date()
-    );
+    private async generateMd5FromImageUrl(imageUrl: string): Promise<string> {
+        const imageData = await this.httpClient.get(imageUrl);
 
-    // Save the screenshot using the repository
-    await this.screenshotRepository.save(screenshot);
-
-    this.logger.info('Screenshot created successfully', {
-      id: screenshot.id.toString(),
-      name: command.name,
-      authorId: command.authorId
-    });
-
-    return screenshot;
-  }
-
-  private async generateMd5FromImageUrl(imageUrl: string): Promise<string> {
-    const imageData = await this.httpClient.get(imageUrl);
-
-    return crypto.createHash('md5').update(Buffer.from(imageData)).digest('hex');
-  }
+        return crypto.createHash('md5').update(Buffer.from(imageData)).digest('hex');
+    }
 }

--- a/discord-bot/src/Application/Write/Screenshot/CreateScreenshot/ScreenshotAlreadyExist.ts
+++ b/discord-bot/src/Application/Write/Screenshot/CreateScreenshot/ScreenshotAlreadyExist.ts
@@ -1,6 +1,6 @@
 export class ScreenshotAlreadyExist extends Error {
-    constructor (message: string) {
-        super(message)
-        this.name = 'ScreenshotAlreadyExist'
+    constructor(message: string) {
+        super(message);
+        this.name = 'ScreenshotAlreadyExist';
     }
 }

--- a/discord-bot/src/Application/Write/Screenshot/DeleteScreenshot/DeleteScreenshot.ts
+++ b/discord-bot/src/Application/Write/Screenshot/DeleteScreenshot/DeleteScreenshot.ts
@@ -1,9 +1,9 @@
-import type Command from "../../../../Domain/Command/Command.ts";
-import type { ScreenshotId } from "../../../../Domain/Screenshot/ScreenshotId.ts";
+import type Command from '../../../../Domain/Command/Command.ts';
+import type { ScreenshotId } from '../../../../Domain/Screenshot/ScreenshotId.ts';
 
 export class DeleteScreenshot implements Command {
-  constructor(
-    public readonly id: ScreenshotId,
-    public readonly userId: string,
-  ) {}
+    constructor(
+        public readonly id: ScreenshotId,
+        public readonly userId: string,
+    ) {}
 }

--- a/discord-bot/src/Application/Write/Screenshot/DeleteScreenshot/DeleteScreenshotHandler.ts
+++ b/discord-bot/src/Application/Write/Screenshot/DeleteScreenshot/DeleteScreenshotHandler.ts
@@ -1,36 +1,37 @@
-import { inject, injectable } from "inversify";
-import type CommandHandler from "../../../../Domain/Command/CommandHandler";
-import { DeleteScreenshot } from "./DeleteScreenshot";
-import type { ScreenshotRepository } from "../../../../Domain/Screenshot/ScreenshotRepository";
-import { TYPES } from "../../../../Infrastructure/DependencyInjection/types";
-import type Logger from "../../../Logger/Logger";
-import { NotAuthorized } from "./NotAuthorized";
+import { inject, injectable } from 'inversify';
+import type CommandHandler from '../../../../Domain/Command/CommandHandler';
+import { DeleteScreenshot } from './DeleteScreenshot';
+import type { ScreenshotRepository } from '../../../../Domain/Screenshot/ScreenshotRepository';
+import { TYPES } from '../../../../Infrastructure/DependencyInjection/types';
+import type Logger from '../../../Logger/Logger';
+import { NotAuthorized } from './NotAuthorized';
 
 @injectable()
 export class DeleteScreenshotHandler implements CommandHandler<DeleteScreenshot> {
-  constructor(
-    @inject(TYPES.ScreenshotRepository) private readonly screenshotRepository: ScreenshotRepository,
-    @inject(TYPES.Logger) private readonly logger: Logger
-  ) {}
+    constructor(
+        @inject(TYPES.ScreenshotRepository)
+        private readonly screenshotRepository: ScreenshotRepository,
+        @inject(TYPES.Logger) private readonly logger: Logger,
+    ) {}
 
-  async handle(command: DeleteScreenshot): Promise<void> {
-    const screenshot = await this.screenshotRepository.get(command.id);
+    async handle(command: DeleteScreenshot): Promise<void> {
+        const screenshot = await this.screenshotRepository.get(command.id);
 
-    if (screenshot.authorId !== command.userId) {
-      this.logger.warn('Unauthorized delete attempt', {
-        screenshotId: command.id.toString(),
-        userId: command.userId,
-        authorId: screenshot.authorId
-      });
+        if (screenshot.authorId !== command.userId) {
+            this.logger.warn('Unauthorized delete attempt', {
+                screenshotId: command.id.toString(),
+                userId: command.userId,
+                authorId: screenshot.authorId,
+            });
 
-      throw new NotAuthorized(command.userId, command.id.toString());
+            throw new NotAuthorized(command.userId, command.id.toString());
+        }
+
+        await this.screenshotRepository.delete(command.id);
+
+        this.logger.info('Screenshot deleted successfully', {
+            id: command.id.toString(),
+            userId: command.userId,
+        });
     }
-
-    await this.screenshotRepository.delete(command.id);
-
-    this.logger.info('Screenshot deleted successfully', {
-      id: command.id.toString(),
-      userId: command.userId
-    });
-  }
 }

--- a/discord-bot/src/Application/Write/Screenshot/DeleteScreenshot/NotAuthorized.ts
+++ b/discord-bot/src/Application/Write/Screenshot/DeleteScreenshot/NotAuthorized.ts
@@ -1,6 +1,6 @@
 export class NotAuthorized extends Error {
-  constructor(userId: string, screenshotId: string) {
-    super(`User "${userId}" is not authorized to delete screenshot "${screenshotId}"`);
-    this.name = 'NotAuthorized';
-  }
+    constructor(userId: string, screenshotId: string) {
+        super(`User "${userId}" is not authorized to delete screenshot "${screenshotId}"`);
+        this.name = 'NotAuthorized';
+    }
 }

--- a/discord-bot/src/Application/Write/Trophy/CreateProfile/CreateProfile.ts
+++ b/discord-bot/src/Application/Write/Trophy/CreateProfile/CreateProfile.ts
@@ -1,10 +1,10 @@
-import type Command from "../../../../Domain/Command/Command.ts";
-import { TrophyProfileId } from "../../../../Domain/Trophy/TrophyProfileId.ts";
+import type Command from '../../../../Domain/Command/Command.ts';
+import { TrophyProfileId } from '../../../../Domain/Trophy/TrophyProfileId.ts';
 
 export class CreateProfile implements Command {
-  constructor(
-    public readonly id: TrophyProfileId,
-    public readonly userId: string,
-    public readonly psnProfile: string
-  ) {}
+    constructor(
+        public readonly id: TrophyProfileId,
+        public readonly userId: string,
+        public readonly psnProfile: string,
+    ) {}
 }

--- a/discord-bot/src/Application/Write/Trophy/CreateProfile/CreateProfileHandler.ts
+++ b/discord-bot/src/Application/Write/Trophy/CreateProfile/CreateProfileHandler.ts
@@ -1,54 +1,57 @@
-import { inject, injectable } from "inversify";
-import type CommandHandler from "../../../../Domain/Command/CommandHandler";
-import { CreateProfile } from "./CreateProfile";
-import type { TrophyProfileRepository } from "../../../../Domain/Trophy/TrophyProfileRepository";
-import { TYPES } from "../../../../Infrastructure/DependencyInjection/types";
-import type Logger from "../../../Logger/Logger";
-import { TrophyProfile } from "../../../../Domain/Trophy/TrophyProfile";
-import { ProfileAlreadyExists } from "./ProfileAlreadyExists";
+import { inject, injectable } from 'inversify';
+import type CommandHandler from '../../../../Domain/Command/CommandHandler';
+import { CreateProfile } from './CreateProfile';
+import type { TrophyProfileRepository } from '../../../../Domain/Trophy/TrophyProfileRepository';
+import { TYPES } from '../../../../Infrastructure/DependencyInjection/types';
+import type Logger from '../../../Logger/Logger';
+import { TrophyProfile } from '../../../../Domain/Trophy/TrophyProfile';
+import { ProfileAlreadyExists } from './ProfileAlreadyExists';
 
 @injectable()
 export class CreateProfileHandler implements CommandHandler<CreateProfile> {
-  constructor(
-    @inject(TYPES.TrophyProfileRepository) private readonly trophyProfileRepository: TrophyProfileRepository,
-    @inject(TYPES.Logger) private readonly logger: Logger
-  ) {}
+    constructor(
+        @inject(TYPES.TrophyProfileRepository)
+        private readonly trophyProfileRepository: TrophyProfileRepository,
+        @inject(TYPES.Logger) private readonly logger: Logger,
+    ) {}
 
-  async handle(command: CreateProfile): Promise<void> {
-    // Check if a profile already exists for this user or PSN profile
-    const existingUserProfile = await this.trophyProfileRepository.findByUserId(command.userId);
-    const existingPsnProfile = await this.trophyProfileRepository.findByPsnProfile(command.psnProfile);
+    async handle(command: CreateProfile): Promise<void> {
+        // Check if a profile already exists for this user or PSN profile
+        const existingUserProfile = await this.trophyProfileRepository.findByUserId(command.userId);
+        const existingPsnProfile = await this.trophyProfileRepository.findByPsnProfile(
+            command.psnProfile,
+        );
 
-    if (existingUserProfile !== null || existingPsnProfile !== null) {
-      this.logger.warn('Attempted to create duplicate trophy profile', {
-        userId: command.userId,
-        psnProfile: command.psnProfile,
-        existingUserProfile: existingUserProfile?.id.toString(),
-        existingPsnProfile: existingPsnProfile?.id.toString()
-      });
+        if (existingUserProfile !== null || existingPsnProfile !== null) {
+            this.logger.warn('Attempted to create duplicate trophy profile', {
+                userId: command.userId,
+                psnProfile: command.psnProfile,
+                existingUserProfile: existingUserProfile?.id.toString(),
+                existingPsnProfile: existingPsnProfile?.id.toString(),
+            });
 
-      throw new ProfileAlreadyExists(command.userId, command.psnProfile);
+            throw new ProfileAlreadyExists(command.userId, command.psnProfile);
+        }
+
+        // Create a new TrophyProfile entity
+        const trophyProfile = new TrophyProfile(
+            command.id,
+            command.userId,
+            command.psnProfile,
+            false, // isBanned
+            false, // hasLeft
+            false, // isExcluded
+            new Date(),
+            new Date(),
+        );
+
+        // Save the trophy profile using the repository
+        await this.trophyProfileRepository.save(trophyProfile);
+
+        this.logger.info('Trophy profile created successfully', {
+            id: command.id.toString(),
+            userId: command.userId,
+            psnProfile: command.psnProfile,
+        });
     }
-
-    // Create a new TrophyProfile entity
-    const trophyProfile = new TrophyProfile(
-      command.id,
-      command.userId,
-      command.psnProfile,
-      false, // isBanned
-      false, // hasLeft
-      false, // isExcluded
-      new Date(),
-      new Date()
-    );
-
-    // Save the trophy profile using the repository
-    await this.trophyProfileRepository.save(trophyProfile);
-
-    this.logger.info('Trophy profile created successfully', {
-      id: command.id.toString(),
-      userId: command.userId,
-      psnProfile: command.psnProfile
-    });
-  }
 }

--- a/discord-bot/src/Application/Write/Trophy/CreateProfile/ProfileAlreadyExists.ts
+++ b/discord-bot/src/Application/Write/Trophy/CreateProfile/ProfileAlreadyExists.ts
@@ -1,9 +1,9 @@
 export class ProfileAlreadyExists extends Error {
-  constructor(
-      public readonly userId: string,
-      public readonly psnProfile: string
-  ) {
-    super(`Profile already exists for user ${userId} or PSN profile ${psnProfile}`);
-    this.name = 'ProfileAlreadyExists';
-  }
+    constructor(
+        public readonly userId: string,
+        public readonly psnProfile: string,
+    ) {
+        super(`Profile already exists for user ${userId} or PSN profile ${psnProfile}`);
+        this.name = 'ProfileAlreadyExists';
+    }
 }

--- a/discord-bot/src/Domain/AbstractStringVo.ts
+++ b/discord-bot/src/Domain/AbstractStringVo.ts
@@ -1,14 +1,11 @@
 export abstract class AbstractStringVo<T> {
-  constructor (
-    public readonly value: string
-  ) {
-  }
+    constructor(public readonly value: string) {}
 
-  public equals (other: AbstractStringVo<T>): boolean {
-    return this.value === other.value
-  }
+    public equals(other: AbstractStringVo<T>): boolean {
+        return this.value === other.value;
+    }
 
-  public toString (): string {
-    return this.value
-  }
+    public toString(): string {
+        return this.value;
+    }
 }

--- a/discord-bot/src/Domain/Bot/MentionContext.ts
+++ b/discord-bot/src/Domain/Bot/MentionContext.ts
@@ -6,8 +6,8 @@ export interface MentionContext {
         threadTs: string;
         userId?: string;
         teamId?: string;
-    },
-    client: any,
+    };
+    client: any;
 
     reply: (text: string) => Promise<void>;
 }

--- a/discord-bot/src/Domain/Bot/MentionHandler.ts
+++ b/discord-bot/src/Domain/Bot/MentionHandler.ts
@@ -1,4 +1,4 @@
-import type {MentionContext} from "./MentionContext";
+import type { MentionContext } from './MentionContext';
 
 export interface MentionHandler {
     handle: (context: MentionContext) => Promise<void>;

--- a/discord-bot/src/Domain/Bot/SlashCommandHandler.ts
+++ b/discord-bot/src/Domain/Bot/SlashCommandHandler.ts
@@ -1,4 +1,4 @@
-import type {SlashCommandContext} from "./SlashCommandContext";
+import type { SlashCommandContext } from './SlashCommandContext';
 
 export interface SlashCommandHandler {
     getName: () => string;

--- a/discord-bot/src/Domain/Command/Command.ts
+++ b/discord-bot/src/Domain/Command/Command.ts
@@ -1,4 +1,2 @@
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export default interface Command {
-
-}
+export default interface Command {}

--- a/discord-bot/src/Domain/Command/Command.ts
+++ b/discord-bot/src/Domain/Command/Command.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export default interface Command {}

--- a/discord-bot/src/Domain/Command/CommandHandler.ts
+++ b/discord-bot/src/Domain/Command/CommandHandler.ts
@@ -1,3 +1,3 @@
 export default interface CommandHandler<C> {
-  handle: (command: C) => Promise<any>
+    handle: (command: C) => Promise<any>;
 }

--- a/discord-bot/src/Domain/Community/ClientError.ts
+++ b/discord-bot/src/Domain/Community/ClientError.ts
@@ -1,6 +1,6 @@
 export class ClientError extends Error {
-    constructor (message: string) {
-        super(message)
-        this.name = 'ClientError'
+    constructor(message: string) {
+        super(message);
+        this.name = 'ClientError';
     }
 }

--- a/discord-bot/src/Domain/Community/CommunityChannels.ts
+++ b/discord-bot/src/Domain/Community/CommunityChannels.ts
@@ -1,3 +1,3 @@
 export enum CommunityChannels {
-    SCREENSHOTS = 'screenshots'
+    SCREENSHOTS = 'screenshots',
 }

--- a/discord-bot/src/Domain/Community/GuildClient.ts
+++ b/discord-bot/src/Domain/Community/GuildClient.ts
@@ -1,8 +1,12 @@
-import type {CustomEmoji} from "./CustomEmoji.ts";
-import type {CommunityChannels} from "./CommunityChannels.ts";
+import type { CustomEmoji } from './CustomEmoji.ts';
+import type { CommunityChannels } from './CommunityChannels.ts';
 
 export interface GuildClient {
-    getTotalReactionsByEmoji(channel: CommunityChannels, messageId: string, emoji: CustomEmoji): Promise<number>
+    getTotalReactionsByEmoji(
+        channel: CommunityChannels,
+        messageId: string,
+        emoji: CustomEmoji,
+    ): Promise<number>;
 
     getMessageUrl(channel: CommunityChannels, messageId: string): Promise<string>;
 

--- a/discord-bot/src/Domain/Console/AbstractInputArgument.ts
+++ b/discord-bot/src/Domain/Console/AbstractInputArgument.ts
@@ -1,23 +1,22 @@
 export default abstract class AbstractInputArgument {
-  protected value: any
+    protected value: any;
 
-  constructor (
-    public name: string,
-    public description: string,
-    public required: boolean,
-    protected defaultValue: number | undefined
-  ) {
-  }
+    constructor(
+        public name: string,
+        public description: string,
+        public required: boolean,
+        protected defaultValue: number | undefined,
+    ) {}
 
-  setValue (value: any): void {
-    this.value = value
-  };
+    setValue(value: any): void {
+        this.value = value;
+    }
 
-  isValid (): boolean {
-    return this.required && this.getValue() !== undefined
-  };
+    isValid(): boolean {
+        return this.required && this.getValue() !== undefined;
+    }
 
-  getValue (): any {
-    return this.value ?? this.defaultValue
-  }
+    getValue(): any {
+        return this.value ?? this.defaultValue;
+    }
 }

--- a/discord-bot/src/Domain/Console/ConsoleCommand.ts
+++ b/discord-bot/src/Domain/Console/ConsoleCommand.ts
@@ -1,5 +1,5 @@
 export interface ConsoleCommand {
-  configureArgs: (inputArgs: any) => void
+    configureArgs: (inputArgs: any) => void;
 
-  run: (inputArgs: any) => Promise<number>
+    run: (inputArgs: any) => Promise<number>;
 }

--- a/discord-bot/src/Domain/Console/NumberArgument.ts
+++ b/discord-bot/src/Domain/Console/NumberArgument.ts
@@ -1,7 +1,7 @@
-import AbstractInputArgument from './AbstractInputArgument'
+import AbstractInputArgument from './AbstractInputArgument';
 
 export default class NumberArgument extends AbstractInputArgument {
-  getValue (): number | undefined {
-    return super.getValue() as number | undefined
-  }
+    getValue(): number | undefined {
+        return super.getValue() as number | undefined;
+    }
 }

--- a/discord-bot/src/Domain/Console/StringArgument.ts
+++ b/discord-bot/src/Domain/Console/StringArgument.ts
@@ -1,7 +1,7 @@
-import AbstractInputArgument from './AbstractInputArgument'
+import AbstractInputArgument from './AbstractInputArgument';
 
 export default class StringArgument extends AbstractInputArgument {
-  getValue (): string | undefined {
-    return super.getValue() as string | undefined
-  }
+    getValue(): string | undefined {
+        return super.getValue() as string | undefined;
+    }
 }

--- a/discord-bot/src/Domain/Http/HttpClient.ts
+++ b/discord-bot/src/Domain/Http/HttpClient.ts
@@ -1,9 +1,9 @@
 export interface HttpClient {
-  get: (url: string, options?: any) => Promise<any>
+    get: (url: string, options?: any) => Promise<any>;
 
-  post: (url: string, body?: any) => Promise<any>
+    post: (url: string, body?: any) => Promise<any>;
 
-  put: (url: string, body?: any) => Promise<any>
+    put: (url: string, body?: any) => Promise<any>;
 
-  delete: (url: string) => Promise<any>
+    delete: (url: string) => Promise<any>;
 }

--- a/discord-bot/src/Domain/Id.ts
+++ b/discord-bot/src/Domain/Id.ts
@@ -1,21 +1,21 @@
-import { AbstractStringVo } from './AbstractStringVo'
-import { v7 as uuidv7 } from 'uuid'
-import {InvalidId} from "./InvalidId.ts";
+import { AbstractStringVo } from './AbstractStringVo';
+import { v7 as uuidv7 } from 'uuid';
+import { InvalidId } from './InvalidId.ts';
 
 export abstract class Id<T> extends AbstractStringVo<T> {
-  public static fromString<T extends Id<T>>(this: new (id: string) => T, id: string): T {
-    if (id === undefined || !Id.isValid(id)) {
-      throw new InvalidId(`Invalid ${this.name} id`)
+    public static fromString<T extends Id<T>>(this: new (id: string) => T, id: string): T {
+        if (id === undefined || !Id.isValid(id)) {
+            throw new InvalidId(`Invalid ${this.name} id`);
+        }
+
+        return new this(id);
     }
 
-    return new this(id)
-  }
+    public static generate<T extends Id<T>>(this: new (id: string) => T): T {
+        return new this(uuidv7());
+    }
 
-  public static generate<T extends Id<T>>(this: new (id: string) => T): T {
-    return new this(uuidv7())
-  }
-
-  public static isValid (id: string): boolean {
-    return id.length === 36
-  }
+    public static isValid(id: string): boolean {
+        return id.length === 36;
+    }
 }

--- a/discord-bot/src/Domain/InvalidId.ts
+++ b/discord-bot/src/Domain/InvalidId.ts
@@ -1,6 +1,6 @@
 export class InvalidId extends Error {
-    constructor (message: string) {
-        super(message)
-        this.name = 'InvalidId'
+    constructor(message: string) {
+        super(message);
+        this.name = 'InvalidId';
     }
 }

--- a/discord-bot/src/Domain/Marketplace/Ad.ts
+++ b/discord-bot/src/Domain/Marketplace/Ad.ts
@@ -1,56 +1,56 @@
-import { AdId } from './AdId'
+import { AdId } from './AdId';
 
 export interface AdArray {
-  id: string
-  name: string | null
-  author_id: string | null
-  channel_id: string | null
-  message_id: string | null
-  state: string
-  price: string | null
-  zone: string | null
-  dispatch: string | null
-  warranty: string | null
-  description: string | null
-  adType: string | null
-  createdAt: Date
-  updatedAt: Date
+    id: string;
+    name: string | null;
+    author_id: string | null;
+    channel_id: string | null;
+    message_id: string | null;
+    state: string;
+    price: string | null;
+    zone: string | null;
+    dispatch: string | null;
+    warranty: string | null;
+    description: string | null;
+    adType: string | null;
+    createdAt: Date;
+    updatedAt: Date;
 }
 
 export class Ad {
-  constructor(
-    public readonly id: AdId,
-    public readonly name: string | null,
-    public readonly authorId: string | null,
-    public readonly channelId: string | null,
-    public readonly messageId: string | null,
-    public readonly state: string,
-    public readonly price: string | null,
-    public readonly zone: string | null,
-    public readonly dispatch: string | null,
-    public readonly warranty: string | null,
-    public readonly description: string | null,
-    public readonly adType: string | null,
-    public readonly createdAt: Date,
-    public readonly updatedAt: Date
-  ) {}
+    constructor(
+        public readonly id: AdId,
+        public readonly name: string | null,
+        public readonly authorId: string | null,
+        public readonly channelId: string | null,
+        public readonly messageId: string | null,
+        public readonly state: string,
+        public readonly price: string | null,
+        public readonly zone: string | null,
+        public readonly dispatch: string | null,
+        public readonly warranty: string | null,
+        public readonly description: string | null,
+        public readonly adType: string | null,
+        public readonly createdAt: Date,
+        public readonly updatedAt: Date,
+    ) {}
 
-  public static fromArray(array: AdArray): Ad {
-    return new Ad(
-      AdId.fromString(array.id),
-      array.name,
-      array.author_id,
-      array.channel_id,
-      array.message_id,
-      array.state,
-      array.price,
-      array.zone,
-      array.dispatch,
-      array.warranty,
-      array.description,
-      array.adType,
-      array.createdAt,
-      array.updatedAt
-    )
-  }
+    public static fromArray(array: AdArray): Ad {
+        return new Ad(
+            AdId.fromString(array.id),
+            array.name,
+            array.author_id,
+            array.channel_id,
+            array.message_id,
+            array.state,
+            array.price,
+            array.zone,
+            array.dispatch,
+            array.warranty,
+            array.description,
+            array.adType,
+            array.createdAt,
+            array.updatedAt,
+        );
+    }
 }

--- a/discord-bot/src/Domain/Marketplace/AdId.ts
+++ b/discord-bot/src/Domain/Marketplace/AdId.ts
@@ -1,4 +1,3 @@
-import { Id } from '../Id'
+import { Id } from '../Id';
 
-export class AdId extends Id<AdId> {
-}
+export class AdId extends Id<AdId> {}

--- a/discord-bot/src/Domain/Marketplace/AdRepository.ts
+++ b/discord-bot/src/Domain/Marketplace/AdRepository.ts
@@ -1,15 +1,15 @@
-import type { Ad } from './Ad'
-import type { AdId } from './AdId'
+import type { Ad } from './Ad';
+import type { AdId } from './AdId';
 
 export interface AdRepository {
-  save(ad: Ad): Promise<void>
+    save(ad: Ad): Promise<void>;
 
-  /**
-   * @throws RecordNotFound
-   */
-  get(id: AdId): Promise<Ad>
+    /**
+     * @throws RecordNotFound
+     */
+    get(id: AdId): Promise<Ad>;
 
-  delete(id: AdId): Promise<void>
+    delete(id: AdId): Promise<void>;
 
-  findByUserId(userId: string): Promise<Ad[]>
+    findByUserId(userId: string): Promise<Ad[]>;
 }

--- a/discord-bot/src/Domain/Marketplace/UnauthorizedAdDeletion.ts
+++ b/discord-bot/src/Domain/Marketplace/UnauthorizedAdDeletion.ts
@@ -1,6 +1,6 @@
 export class UnauthorizedAdDeletion extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'UnauthorizedAdDeletion'
-  }
+    constructor(message: string) {
+        super(message);
+        this.name = 'UnauthorizedAdDeletion';
+    }
 }

--- a/discord-bot/src/Domain/RecordNotFound.ts
+++ b/discord-bot/src/Domain/RecordNotFound.ts
@@ -1,6 +1,6 @@
 export default class RecordNotFound extends Error {
-  constructor (message: string) {
-    super(message)
-    this.name = 'RecordNotFound'
-  }
+    constructor(message: string) {
+        super(message);
+        this.name = 'RecordNotFound';
+    }
 }

--- a/discord-bot/src/Domain/Screenshot/Screenshot.ts
+++ b/discord-bot/src/Domain/Screenshot/Screenshot.ts
@@ -1,83 +1,82 @@
-import { ScreenshotId } from './ScreenshotId'
+import { ScreenshotId } from './ScreenshotId';
 
 export interface ScreenshotArray {
-  id: string
-  name: string | null
-  author_id: string | null
-  channel_id: string | null
-  message_id: string | null
-  plataform: string | null
-  image: string | null
-  image_md5: string | null
-  createdAt: Date
-  updatedAt: Date
+    id: string;
+    name: string | null;
+    author_id: string | null;
+    channel_id: string | null;
+    message_id: string | null;
+    plataform: string | null;
+    image: string | null;
+    image_md5: string | null;
+    createdAt: Date;
+    updatedAt: Date;
 }
 
 export class Screenshot {
-  constructor (
-    public readonly id: ScreenshotId,
-    public readonly name: string | null,
-    public readonly authorId: string | null,
-    public readonly channelId: string | null,
-    public readonly messageId: string | null,
-    public readonly platform: string | null,
-    public readonly image: string | null,
-    public readonly imageMd5: string | null,
-    public readonly createdAt: Date,
-    public readonly updatedAt: Date
-  ) {
-  }
+    constructor(
+        public readonly id: ScreenshotId,
+        public readonly name: string | null,
+        public readonly authorId: string | null,
+        public readonly channelId: string | null,
+        public readonly messageId: string | null,
+        public readonly platform: string | null,
+        public readonly image: string | null,
+        public readonly imageMd5: string | null,
+        public readonly createdAt: Date,
+        public readonly updatedAt: Date,
+    ) {}
 
-  update (
-    name?: string | null,
-    authorId?: string | null,
-    channelId?: string | null,
-    messageId?: string | null,
-    platform?: string | null,
-    image?: string | null,
-    imageMd5?: string | null
-  ): Screenshot {
-    return new Screenshot(
-      this.id,
-      name ?? this.name,
-      authorId ?? this.authorId,
-      channelId ?? this.channelId,
-      messageId ?? this.messageId,
-      platform ?? this.platform,
-      image ?? this.image,
-      imageMd5 ?? this.imageMd5,
-      this.createdAt,
-      new Date()
-    )
-  }
-
-  static fromArray (screenshot: ScreenshotArray): Screenshot {
-    return new Screenshot(
-      ScreenshotId.fromString(screenshot.id),
-      screenshot.name,
-      screenshot.author_id,
-      screenshot.channel_id,
-      screenshot.message_id,
-      screenshot.plataform,
-      screenshot.image,
-      screenshot.image_md5,
-      screenshot.createdAt,
-      screenshot.updatedAt
-    )
-  }
-
-  toArray (): ScreenshotArray {
-    return {
-      id: this.id.toString(),
-      name: this.name,
-      author_id: this.authorId,
-      channel_id: this.channelId,
-      message_id: this.messageId,
-      plataform: this.platform,
-      image: this.image,
-      image_md5: this.imageMd5,
-      createdAt: this.createdAt,
-      updatedAt: this.updatedAt
+    update(
+        name?: string | null,
+        authorId?: string | null,
+        channelId?: string | null,
+        messageId?: string | null,
+        platform?: string | null,
+        image?: string | null,
+        imageMd5?: string | null,
+    ): Screenshot {
+        return new Screenshot(
+            this.id,
+            name ?? this.name,
+            authorId ?? this.authorId,
+            channelId ?? this.channelId,
+            messageId ?? this.messageId,
+            platform ?? this.platform,
+            image ?? this.image,
+            imageMd5 ?? this.imageMd5,
+            this.createdAt,
+            new Date(),
+        );
     }
-  }
+
+    static fromArray(screenshot: ScreenshotArray): Screenshot {
+        return new Screenshot(
+            ScreenshotId.fromString(screenshot.id),
+            screenshot.name,
+            screenshot.author_id,
+            screenshot.channel_id,
+            screenshot.message_id,
+            screenshot.plataform,
+            screenshot.image,
+            screenshot.image_md5,
+            screenshot.createdAt,
+            screenshot.updatedAt,
+        );
+    }
+
+    toArray(): ScreenshotArray {
+        return {
+            id: this.id.toString(),
+            name: this.name,
+            author_id: this.authorId,
+            channel_id: this.channelId,
+            message_id: this.messageId,
+            plataform: this.platform,
+            image: this.image,
+            image_md5: this.imageMd5,
+            createdAt: this.createdAt,
+            updatedAt: this.updatedAt,
+        };
+    }
 }

--- a/discord-bot/src/Domain/Screenshot/ScreenshotId.ts
+++ b/discord-bot/src/Domain/Screenshot/ScreenshotId.ts
@@ -1,4 +1,3 @@
-import { Id } from '../Id'
+import { Id } from '../Id';
 
-export class ScreenshotId extends Id<ScreenshotId> {
-}
+export class ScreenshotId extends Id<ScreenshotId> {}

--- a/discord-bot/src/Domain/Screenshot/ScreenshotRepository.ts
+++ b/discord-bot/src/Domain/Screenshot/ScreenshotRepository.ts
@@ -1,19 +1,19 @@
-import type {Screenshot} from "./Screenshot.ts";
-import type {ScreenshotId} from "./ScreenshotId.ts";
+import type { Screenshot } from './Screenshot.ts';
+import type { ScreenshotId } from './ScreenshotId.ts';
 
 export interface ScreenshotRepository {
-    save: (screenshot: Screenshot) => Promise<void>
+    save: (screenshot: Screenshot) => Promise<void>;
 
     /**
      * @throws RecordNotFound
      */
-    get(id: ScreenshotId): Promise<Screenshot>
+    get(id: ScreenshotId): Promise<Screenshot>;
 
-    findByWeek(week: Date): Promise<Screenshot[]>
+    findByWeek(week: Date): Promise<Screenshot[]>;
 
-    delete(id: ScreenshotId): Promise<void>
+    delete(id: ScreenshotId): Promise<void>;
 
-    findByMd5(md5: string): Promise<Screenshot | null>
+    findByMd5(md5: string): Promise<Screenshot | null>;
 
-    findBy(userId: string | null): Promise<Screenshot[]>
+    findBy(userId: string | null): Promise<Screenshot[]>;
 }

--- a/discord-bot/src/Domain/Trophy/Trophy.ts
+++ b/discord-bot/src/Domain/Trophy/Trophy.ts
@@ -1,35 +1,35 @@
-import { TrophyId } from './TrophyId'
+import { TrophyId } from './TrophyId';
 
 export interface TrophyArray {
-  id: string
-  trophyProfile: string | null
-  url: string | null
-  points: number | null
-  completionDate: Date | null
-  createdAt: Date
-  updatedAt: Date
+    id: string;
+    trophyProfile: string | null;
+    url: string | null;
+    points: number | null;
+    completionDate: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
 }
 
 export class Trophy {
-  constructor(
-    public readonly id: TrophyId,
-    public readonly trophyProfile: string | null,
-    public readonly url: string | null,
-    public readonly points: number | null,
-    public readonly completionDate: Date | null,
-    public readonly createdAt: Date,
-    public readonly updatedAt: Date
-  ) {}
+    constructor(
+        public readonly id: TrophyId,
+        public readonly trophyProfile: string | null,
+        public readonly url: string | null,
+        public readonly points: number | null,
+        public readonly completionDate: Date | null,
+        public readonly createdAt: Date,
+        public readonly updatedAt: Date,
+    ) {}
 
-  public static fromArray(array: TrophyArray): Trophy {
-    return new Trophy(
-      TrophyId.fromString(array.id),
-      array.trophyProfile,
-      array.url,
-      array.points,
-      array.completionDate,
-      array.createdAt,
-      array.updatedAt
-    )
-  }
+    public static fromArray(array: TrophyArray): Trophy {
+        return new Trophy(
+            TrophyId.fromString(array.id),
+            array.trophyProfile,
+            array.url,
+            array.points,
+            array.completionDate,
+            array.createdAt,
+            array.updatedAt,
+        );
+    }
 }

--- a/discord-bot/src/Domain/Trophy/TrophyId.ts
+++ b/discord-bot/src/Domain/Trophy/TrophyId.ts
@@ -1,4 +1,3 @@
-import { Id } from '../Id'
+import { Id } from '../Id';
 
-export class TrophyId extends Id<TrophyId> {
-}
+export class TrophyId extends Id<TrophyId> {}

--- a/discord-bot/src/Domain/Trophy/TrophyProfile.ts
+++ b/discord-bot/src/Domain/Trophy/TrophyProfile.ts
@@ -1,38 +1,38 @@
-import { TrophyProfileId } from './TrophyProfileId'
+import { TrophyProfileId } from './TrophyProfileId';
 
 export interface TrophyProfileArray {
-  id: string
-  userId: string | null
-  psnProfile: string | null
-  isBanned: boolean | null
-  hasLeft: boolean | null
-  isExcluded: boolean | null
-  createdAt: Date
-  updatedAt: Date
+    id: string;
+    userId: string | null;
+    psnProfile: string | null;
+    isBanned: boolean | null;
+    hasLeft: boolean | null;
+    isExcluded: boolean | null;
+    createdAt: Date;
+    updatedAt: Date;
 }
 
 export class TrophyProfile {
-  constructor(
-    public readonly id: TrophyProfileId,
-    public readonly userId: string | null,
-    public readonly psnProfile: string | null,
-    public readonly isBanned: boolean | null,
-    public readonly hasLeft: boolean | null,
-    public readonly isExcluded: boolean | null,
-    public readonly createdAt: Date,
-    public readonly updatedAt: Date
-  ) {}
+    constructor(
+        public readonly id: TrophyProfileId,
+        public readonly userId: string | null,
+        public readonly psnProfile: string | null,
+        public readonly isBanned: boolean | null,
+        public readonly hasLeft: boolean | null,
+        public readonly isExcluded: boolean | null,
+        public readonly createdAt: Date,
+        public readonly updatedAt: Date,
+    ) {}
 
-  public static fromArray(array: TrophyProfileArray): TrophyProfile {
-    return new TrophyProfile(
-      TrophyProfileId.fromString(array.id),
-      array.userId,
-      array.psnProfile,
-      array.isBanned,
-      array.hasLeft,
-      array.isExcluded,
-      array.createdAt,
-      array.updatedAt
-    )
-  }
+    public static fromArray(array: TrophyProfileArray): TrophyProfile {
+        return new TrophyProfile(
+            TrophyProfileId.fromString(array.id),
+            array.userId,
+            array.psnProfile,
+            array.isBanned,
+            array.hasLeft,
+            array.isExcluded,
+            array.createdAt,
+            array.updatedAt,
+        );
+    }
 }

--- a/discord-bot/src/Domain/Trophy/TrophyProfileId.ts
+++ b/discord-bot/src/Domain/Trophy/TrophyProfileId.ts
@@ -1,4 +1,3 @@
-import { Id } from '../Id'
+import { Id } from '../Id';
 
-export class TrophyProfileId extends Id<TrophyProfileId> {
-}
+export class TrophyProfileId extends Id<TrophyProfileId> {}

--- a/discord-bot/src/Domain/Trophy/TrophyProfileRepository.ts
+++ b/discord-bot/src/Domain/Trophy/TrophyProfileRepository.ts
@@ -1,17 +1,17 @@
-import type { TrophyProfile } from './TrophyProfile'
-import type { TrophyProfileId } from './TrophyProfileId'
+import type { TrophyProfile } from './TrophyProfile';
+import type { TrophyProfileId } from './TrophyProfileId';
 
 export interface TrophyProfileRepository {
-  save: (trophyProfile: TrophyProfile) => Promise<void>
+    save: (trophyProfile: TrophyProfile) => Promise<void>;
 
-  /**
-   * @throws RecordNotFound
-   */
-  get(id: TrophyProfileId): Promise<TrophyProfile>
+    /**
+     * @throws RecordNotFound
+     */
+    get(id: TrophyProfileId): Promise<TrophyProfile>;
 
-  delete(id: TrophyProfileId): Promise<void>
+    delete(id: TrophyProfileId): Promise<void>;
 
-  findByUserId(userId: string): Promise<TrophyProfile | null>
+    findByUserId(userId: string): Promise<TrophyProfile | null>;
 
-  findByPsnProfile(psnProfile: string): Promise<TrophyProfile | null>
+    findByPsnProfile(psnProfile: string): Promise<TrophyProfile | null>;
 }

--- a/discord-bot/src/Domain/Trophy/TrophyRepository.ts
+++ b/discord-bot/src/Domain/Trophy/TrophyRepository.ts
@@ -1,26 +1,26 @@
-import type { Trophy } from './Trophy'
-import type { TrophyId } from './TrophyId'
-import type { TrophyRankData } from './TrophyRankData'
-import type { TrophyProfileId } from './TrophyProfileId'
-import type { UserPosition } from './UserPosition'
+import type { Trophy } from './Trophy';
+import type { TrophyId } from './TrophyId';
+import type { TrophyRankData } from './TrophyRankData';
+import type { TrophyProfileId } from './TrophyProfileId';
+import type { UserPosition } from './UserPosition';
 
 export interface TrophyRepository {
-  save(trophy: Trophy): Promise<void>
+    save(trophy: Trophy): Promise<void>;
 
-  /**
-   * @throws RecordNotFound
-   */
-  get(id: TrophyId): Promise<Trophy>
+    /**
+     * @throws RecordNotFound
+     */
+    get(id: TrophyId): Promise<Trophy>;
 
-  delete(id: TrophyId): Promise<void>
+    delete(id: TrophyId): Promise<void>;
 
-  findByProfile(profileId: string): Promise<Trophy[]>
+    findByProfile(profileId: string): Promise<Trophy[]>;
 
-  getTopMonthlyHunters(limit: number, monthFilter: Date): Promise<TrophyRankData[]>
+    getTopMonthlyHunters(limit: number, monthFilter: Date): Promise<TrophyRankData[]>;
 
-  getTopSinceCreationHunters(limit: number): Promise<TrophyRankData[]>
+    getTopSinceCreationHunters(limit: number): Promise<TrophyRankData[]>;
 
-  getTopLifetimeHunters(limit: number): Promise<TrophyRankData[]>
+    getTopLifetimeHunters(limit: number): Promise<TrophyRankData[]>;
 
-  findUserPosition(userId: string): Promise<UserPosition>
+    findUserPosition(userId: string): Promise<UserPosition>;
 }

--- a/discord-bot/src/Domain/Trophy/UserPosition.ts
+++ b/discord-bot/src/Domain/Trophy/UserPosition.ts
@@ -9,7 +9,7 @@ export interface UserPosition {
     ranks: [
         RankData, // monthly
         RankData, // creation
-        RankData  // lifetime
+        RankData, // lifetime
     ];
     totalTrophies: number;
     totalPoints: number;

--- a/discord-bot/src/Infrastructure/Bot/BotExecutor.ts
+++ b/discord-bot/src/Infrastructure/Bot/BotExecutor.ts
@@ -63,6 +63,5 @@ export class BotExecutor {
 }
 
 function isMentionContext(context: any): context is MentionContext {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- is just to facilitate
     return (context as MentionContext).event !== undefined;
 }

--- a/discord-bot/src/Infrastructure/Bot/BotExecutor.ts
+++ b/discord-bot/src/Infrastructure/Bot/BotExecutor.ts
@@ -1,27 +1,26 @@
-import {inject, injectable, multiInject} from "inversify";
-import type {SlashCommandHandler} from "../../Domain/Bot/SlashCommandHandler";
-import type {SlashCommandContext} from "../../Domain/Bot/SlashCommandContext";
-import Logger from "../../Application/Logger/Logger";
-import {TYPES} from "../DependencyInjection/types.ts";
-import {BotExecutorError} from "./BotExecutorError.ts";
-import type {MentionContext} from "../../Domain/Bot/MentionContext.ts";
-import type {MentionHandler} from "../../Domain/Bot/MentionHandler.ts";
+import { inject, injectable, multiInject } from 'inversify';
+import type { SlashCommandHandler } from '../../Domain/Bot/SlashCommandHandler';
+import type { SlashCommandContext } from '../../Domain/Bot/SlashCommandContext';
+import Logger from '../../Application/Logger/Logger';
+import { TYPES } from '../DependencyInjection/types.ts';
+import { BotExecutorError } from './BotExecutorError.ts';
+import type { MentionContext } from '../../Domain/Bot/MentionContext.ts';
+import type { MentionHandler } from '../../Domain/Bot/MentionHandler.ts';
 
 @injectable()
 export class BotExecutor {
-
     constructor(
-        @multiInject(TYPES.SlashCommandHandler) public readonly slashCommandHandlers: SlashCommandHandler[],
+        @multiInject(TYPES.SlashCommandHandler)
+        public readonly slashCommandHandlers: SlashCommandHandler[],
         @multiInject(TYPES.MentionHandler) public readonly mentionHandlers: MentionHandler[],
-        @inject(TYPES.Logger) private readonly logger: Logger
-    ) {
-    }
+        @inject(TYPES.Logger) private readonly logger: Logger,
+    ) {}
 
     public getCommandNames(): string[] {
-        return this.slashCommandHandlers.map(handler => handler.getName());
+        return this.slashCommandHandlers.map((handler) => handler.getName());
     }
 
-    public async execute(context: MentionContext|SlashCommandContext): Promise<void> {
+    public async execute(context: MentionContext | SlashCommandContext): Promise<void> {
         if (isMentionContext(context)) {
             await this.executeMention(context);
             return;
@@ -35,10 +34,11 @@ export class BotExecutor {
             if (handler.supports(context)) {
                 this.logger.info('Mention handler found', {
                     handler: handler.constructor.name,
-                    text: context.event.text.trim()
+                    text: context.event.text.trim(),
                 });
 
-                await handler.handle(context); return;
+                await handler.handle(context);
+                return;
             }
         }
 
@@ -50,10 +50,11 @@ export class BotExecutor {
             if (handler.getName() === context.command) {
                 this.logger.info('Slash command handler found', {
                     handler: handler.constructor.name,
-                    command: context.command
+                    command: context.command,
                 });
 
-                await handler.handle(context); return;
+                await handler.handle(context);
+                return;
             }
         }
 

--- a/discord-bot/src/Infrastructure/Bot/BotExecutorError.ts
+++ b/discord-bot/src/Infrastructure/Bot/BotExecutorError.ts
@@ -1,8 +1,11 @@
-import type {SlashCommandContext} from "../../Domain/Bot/SlashCommandContext";
-import type {MentionContext} from "../../Domain/Bot/MentionContext.ts";
+import type { SlashCommandContext } from '../../Domain/Bot/SlashCommandContext';
+import type { MentionContext } from '../../Domain/Bot/MentionContext.ts';
 
 export class BotExecutorError extends Error {
-    private constructor(message: string, public readonly context?: MentionContext|SlashCommandContext) {
+    private constructor(
+        message: string,
+        public readonly context?: MentionContext | SlashCommandContext,
+    ) {
         super(message);
     }
 
@@ -10,7 +13,13 @@ export class BotExecutorError extends Error {
         return new BotExecutorError(`Error executing mention: ${error}`, context);
     }
 
-    public static createForSlashCommand(error: string, context: SlashCommandContext): BotExecutorError {
-        return new BotExecutorError(`Error executing slash command ${context.command}: ${error}`, context);
+    public static createForSlashCommand(
+        error: string,
+        context: SlashCommandContext,
+    ): BotExecutorError {
+        return new BotExecutorError(
+            `Error executing slash command ${context.command}: ${error}`,
+            context,
+        );
     }
 }

--- a/discord-bot/src/Infrastructure/Bot/Discord/DiscordBot.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/DiscordBot.ts
@@ -1,10 +1,10 @@
-import {inject, injectable} from "inversify";
-import {Client, Events, GatewayIntentBits, MessageFlags, REST, Routes} from "discord.js";
-import {TYPES} from "../../DependencyInjection/types.ts";
-import type Logger from "../../../Application/Logger/Logger.ts";
-import type { Bot } from "../../../Domain/Bot/Bot.ts";
-import {BotExecutor} from "../BotExecutor.ts";
-import type {SlashCommandContext} from "../../../Domain/Bot/SlashCommandContext.ts";
+import { inject, injectable } from 'inversify';
+import { Client, Events, GatewayIntentBits, MessageFlags, REST, Routes } from 'discord.js';
+import { TYPES } from '../../DependencyInjection/types.ts';
+import type Logger from '../../../Application/Logger/Logger.ts';
+import type { Bot } from '../../../Domain/Bot/Bot.ts';
+import { BotExecutor } from '../BotExecutor.ts';
+import type { SlashCommandContext } from '../../../Domain/Bot/SlashCommandContext.ts';
 
 @injectable()
 export class DiscordBot implements Bot {
@@ -19,11 +19,10 @@ export class DiscordBot implements Bot {
         this.client = new Client({ intents: [GatewayIntentBits.Guilds] });
     }
 
-    async start(): Promise<void>
-    {
+    async start(): Promise<void> {
         await this.registerSlashCommands();
 
-        this.client.once(Events.ClientReady, readyClient => {
+        this.client.once(Events.ClientReady, (readyClient) => {
             this.logger.info(`Ready! Logged in as ${readyClient.user.tag}`);
         });
 
@@ -39,13 +38,19 @@ export class DiscordBot implements Bot {
             };
 
             try {
-                await this.botExecutor.execute(slashCommandContext)
+                await this.botExecutor.execute(slashCommandContext);
             } catch (error: any) {
                 this.logger.error('error happened', { error });
                 if (interaction.replied || interaction.deferred) {
-                    await interaction.followUp({ content: 'There was an error while executing this command!', flags: MessageFlags.Ephemeral });
+                    await interaction.followUp({
+                        content: 'There was an error while executing this command!',
+                        flags: MessageFlags.Ephemeral,
+                    });
                 } else {
-                    await interaction.reply({ content: 'There was an error while executing this command!', flags: MessageFlags.Ephemeral });
+                    await interaction.reply({
+                        content: 'There was an error while executing this command!',
+                        flags: MessageFlags.Ephemeral,
+                    });
                 }
             }
         });
@@ -64,10 +69,9 @@ export class DiscordBot implements Bot {
             this.logger.log(`Started refreshing ${commands.length} application (/) commands.`);
 
             // The put method is used to fully refresh all commands in the guild with the current set
-            const data = await rest.put(
-                Routes.applicationCommands(this.clientId),
-                { body: commands },
-            ) as any;
+            const data = (await rest.put(Routes.applicationCommands(this.clientId), {
+                body: commands,
+            })) as any;
 
             this.logger.log(`Successfully reloaded ${data.length} application (/) commands.`);
         } catch (error) {

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/DeleteAdSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/DeleteAdSubcommand.ts
@@ -11,57 +11,61 @@ import type { Ad } from '../../../../../Domain/Marketplace/Ad';
 
 @injectable()
 export class DeleteAdSubcommand {
-  constructor(
-    @inject(CommandHandlerManager) private readonly commandHandlerManager: CommandHandlerManager
-  ) {}
+    constructor(
+        @inject(CommandHandlerManager)
+        private readonly commandHandlerManager: CommandHandlerManager,
+    ) {}
 
-  public async handle(context: SlashCommandContext): Promise<void> {
-    const interaction = context.interaction
-    const identifier = interaction.options.getString('id', true)
-    const userId = interaction.user.id
+    public async handle(context: SlashCommandContext): Promise<void> {
+        const interaction = context.interaction;
+        const identifier = interaction.options.getString('id', true);
+        const userId = interaction.user.id;
 
-    let adId: AdId
-    try {
-      if (/^\d+$/.test(identifier)) {
-        const position = parseInt(identifier, 10) - 1
-        const ads: Ad[] = await this.commandHandlerManager.handle(new ListUserAds(userId))
-        // Look the ad up rather than bounds-check then index: `noUncheckedIndexedAccess`
-        // types the element as possibly-undefined and cannot see the guard above.
-        const ad = ads[position]
-        if (!ad) {
-          await interaction.reply({ content: 'Invalid ad position', ephemeral: true })
-          return
+        let adId: AdId;
+        try {
+            if (/^\d+$/.test(identifier)) {
+                const position = parseInt(identifier, 10) - 1;
+                const ads: Ad[] = await this.commandHandlerManager.handle(new ListUserAds(userId));
+                // Look the ad up rather than bounds-check then index: `noUncheckedIndexedAccess`
+                // types the element as possibly-undefined and cannot see the guard above.
+                const ad = ads[position];
+                if (!ad) {
+                    await interaction.reply({ content: 'Invalid ad position', ephemeral: true });
+                    return;
+                }
+                adId = ad.id;
+            } else {
+                adId = AdId.fromString(identifier);
+            }
+        } catch (error) {
+            if (error instanceof InvalidId) {
+                await interaction.reply({ content: 'Invalid Ad ID', ephemeral: true });
+                return;
+            }
+            throw error;
         }
-        adId = ad.id
-      } else {
-        adId = AdId.fromString(identifier)
-      }
-    } catch (error) {
-      if (error instanceof InvalidId) {
-        await interaction.reply({ content: 'Invalid Ad ID', ephemeral: true })
-        return
-      }
-      throw error
-    }
 
-    try {
-      await this.commandHandlerManager.handle(new DeleteAd(adId, userId))
-      await interaction.reply({ content: 'Ad deleted successfully', ephemeral: true })
-    } catch (error) {
-      if (error instanceof UnauthorizedAdDeletion) {
-        await interaction.reply({
-          content: 'You are not authorized to delete this ad',
-          ephemeral: true
-        })
-      } else if (error instanceof RecordNotFound) {
-        await interaction.reply({
-          content: 'Ad not found',
-          ephemeral: true
-        })
-      } else {
-        const message = error instanceof Error ? error.message : String(error)
-        await interaction.reply({ content: `Error deleting ad: ${message}`, ephemeral: true })
-      }
+        try {
+            await this.commandHandlerManager.handle(new DeleteAd(adId, userId));
+            await interaction.reply({ content: 'Ad deleted successfully', ephemeral: true });
+        } catch (error) {
+            if (error instanceof UnauthorizedAdDeletion) {
+                await interaction.reply({
+                    content: 'You are not authorized to delete this ad',
+                    ephemeral: true,
+                });
+            } else if (error instanceof RecordNotFound) {
+                await interaction.reply({
+                    content: 'Ad not found',
+                    ephemeral: true,
+                });
+            } else {
+                const message = error instanceof Error ? error.message : String(error);
+                await interaction.reply({
+                    content: `Error deleting ad: ${message}`,
+                    ephemeral: true,
+                });
+            }
+        }
     }
-  }
 }

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/ListAdsSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/ListAdsSubcommand.ts
@@ -1,51 +1,64 @@
-import { inject, injectable } from "inversify";
-import type { SlashCommandContext } from "../../../../../Domain/Bot/SlashCommandContext";
-import { MessageFlags, EmbedBuilder } from "discord.js";
-import { TYPES } from "../../../../DependencyInjection/types";
-import type Logger from "../../../../../Application/Logger/Logger";
-import { ListUserAds } from "../../../../../Application/Query/Marketplace/ListUserAds/ListUserAds";
-import CommandHandlerManager from "../../../../CommandHandler/CommandHandlerManager.ts";
-import type {Ad} from "../../../../../Domain/Marketplace/Ad.ts";
+import { inject, injectable } from 'inversify';
+import type { SlashCommandContext } from '../../../../../Domain/Bot/SlashCommandContext';
+import { MessageFlags, EmbedBuilder } from 'discord.js';
+import { TYPES } from '../../../../DependencyInjection/types';
+import type Logger from '../../../../../Application/Logger/Logger';
+import { ListUserAds } from '../../../../../Application/Query/Marketplace/ListUserAds/ListUserAds';
+import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerManager.ts';
+import type { Ad } from '../../../../../Domain/Marketplace/Ad.ts';
 
 @injectable()
 export class ListAdsSubcommand {
     constructor(
         @inject(TYPES.Logger) private readonly logger: Logger,
-        @inject(CommandHandlerManager) private readonly commandHandlerManager: CommandHandlerManager
+        @inject(CommandHandlerManager)
+        private readonly commandHandlerManager: CommandHandlerManager,
     ) {}
 
     private getStateEmoji(state: string): string {
         switch (state) {
-            case 'new': return '🆕';
-            case 'like_new': return '✨';
-            case 'used_good': return '👍';
-            case 'used_marks': return '📝';
-            case 'broken': return '🔧';
-            default: return '❓';
+            case 'new':
+                return '🆕';
+            case 'like_new':
+                return '✨';
+            case 'used_good':
+                return '👍';
+            case 'used_marks':
+                return '📝';
+            case 'broken':
+                return '🔧';
+            default:
+                return '❓';
         }
     }
 
     private getStateDisplay(state: string): string {
         switch (state) {
-            case 'new': return 'New';
-            case 'like_new': return 'Like new';
-            case 'used_good': return 'Used - Good condition';
-            case 'used_marks': return 'Used - With marks';
-            case 'broken': return 'Broken';
-            default: return state;
+            case 'new':
+                return 'New';
+            case 'like_new':
+                return 'Like new';
+            case 'used_good':
+                return 'Used - Good condition';
+            case 'used_marks':
+                return 'Used - With marks';
+            case 'broken':
+                return 'Broken';
+            default:
+                return state;
         }
     }
 
     public async handle(context: SlashCommandContext): Promise<void> {
         const targetUser = context.interaction.options.getUser('user') ?? context.interaction.user;
-        
+
         try {
             const ads = await this.commandHandlerManager.handle(new ListUserAds(targetUser.id));
 
             if (ads.length === 0) {
                 await context.interaction.reply({
                     content: `${targetUser.id === context.interaction.user.id ? "You don't" : "This user doesn't"} have any active listings.`,
-                    flags: MessageFlags.Ephemeral
+                    flags: MessageFlags.Ephemeral,
                 });
                 return;
             }
@@ -67,18 +80,19 @@ export class ListAdsSubcommand {
                         `🆔 ID: ${ad.id.toString()}`,
                         ad.warranty ? `⚡ Warranty: ${ad.warranty}` : null,
                         ad.description ? `📝 ${ad.description}` : null,
-                        `\n[View Listing](https://discord.com/channels/${context.interaction.guildId}/${ad.channelId}/${ad.messageId})`
-                    ].filter(Boolean).join('\n')
+                        `\n[View Listing](https://discord.com/channels/${context.interaction.guildId}/${ad.channelId}/${ad.messageId})`,
+                    ]
+                        .filter(Boolean)
+                        .join('\n'),
                 });
             });
 
             await context.interaction.reply({ embeds: [embed] });
-
         } catch (error) {
             this.logger.error('Error listing ads', { error });
             await context.interaction.reply({
                 content: 'There was an error fetching the listings. Please try again.',
-                flags: MessageFlags.Ephemeral
+                flags: MessageFlags.Ephemeral,
             });
         }
     }

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/MarketplaceSlashCommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/MarketplaceSlashCommand.ts
@@ -1,12 +1,12 @@
-import { inject, injectable } from "inversify";
-import type { SlashCommandHandler } from "../../../../../Domain/Bot/SlashCommandHandler";
-import type { SlashCommandContext } from "../../../../../Domain/Bot/SlashCommandContext";
-import { SlashCommandBuilder } from "discord.js";
-import { TYPES } from "../../../../DependencyInjection/types";
-import type Logger from "../../../../../Application/Logger/Logger";
-import { SellSubcommand } from "./SellSubcommand";
-import { ListAdsSubcommand } from "./ListAdsSubcommand";
-import { DeleteAdSubcommand } from "./DeleteAdSubcommand";
+import { inject, injectable } from 'inversify';
+import type { SlashCommandHandler } from '../../../../../Domain/Bot/SlashCommandHandler';
+import type { SlashCommandContext } from '../../../../../Domain/Bot/SlashCommandContext';
+import { SlashCommandBuilder } from 'discord.js';
+import { TYPES } from '../../../../DependencyInjection/types';
+import type Logger from '../../../../../Application/Logger/Logger';
+import { SellSubcommand } from './SellSubcommand';
+import { ListAdsSubcommand } from './ListAdsSubcommand';
+import { DeleteAdSubcommand } from './DeleteAdSubcommand';
 
 @injectable()
 export class MarketplaceSlashCommand implements SlashCommandHandler {
@@ -14,33 +14,33 @@ export class MarketplaceSlashCommand implements SlashCommandHandler {
         @inject(TYPES.Logger) private readonly logger: Logger,
         @inject(SellSubcommand) private readonly sellSubcommand: SellSubcommand,
         @inject(ListAdsSubcommand) private readonly listAdsSubcommand: ListAdsSubcommand,
-        @inject(DeleteAdSubcommand) private readonly deleteAdSubcommand: DeleteAdSubcommand
+        @inject(DeleteAdSubcommand) private readonly deleteAdSubcommand: DeleteAdSubcommand,
     ) {}
 
     public getName(): string {
-        return "marketplace";
+        return 'marketplace';
     }
 
     public builder(): any {
         return new SlashCommandBuilder()
             .setName('marketplace')
-            .setDescription("Manage marketplace listings")
-            .addSubcommand(subcommand =>
+            .setDescription('Manage marketplace listings')
+            .addSubcommand((subcommand) =>
                 subcommand
                     .setName('sell')
                     .setDescription('Create a new sale listing')
-                    .addStringOption(option =>
-                        option.setName('name')
-                            .setDescription('Name of the item')
-                            .setRequired(true)
+                    .addStringOption((option) =>
+                        option.setName('name').setDescription('Name of the item').setRequired(true),
                     )
-                    .addStringOption(option =>
-                        option.setName('price')
+                    .addStringOption((option) =>
+                        option
+                            .setName('price')
                             .setDescription('Price of the item')
-                            .setRequired(true)
+                            .setRequired(true),
                     )
-                    .addStringOption(option =>
-                        option.setName('state')
+                    .addStringOption((option) =>
+                        option
+                            .setName('state')
                             .setDescription('Condition of the item')
                             .setRequired(true)
                             .addChoices(
@@ -48,54 +48,57 @@ export class MarketplaceSlashCommand implements SlashCommandHandler {
                                 { name: 'Like new', value: 'like_new' },
                                 { name: 'Used - Good condition', value: 'used_good' },
                                 { name: 'Used - With marks', value: 'used_marks' },
-                                { name: 'Broken', value: 'broken' }
-                            )
+                                { name: 'Broken', value: 'broken' },
+                            ),
                     )
-                    .addStringOption(option =>
-                        option.setName('zone')
-                            .setDescription('Your location')
-                            .setRequired(true)
+                    .addStringOption((option) =>
+                        option.setName('zone').setDescription('Your location').setRequired(true),
                     )
-                    .addStringOption(option =>
-                        option.setName('dispatch')
+                    .addStringOption((option) =>
+                        option
+                            .setName('dispatch')
                             .setDescription('Dispatch method')
                             .setRequired(true)
                             .addChoices(
                                 { name: 'Included', value: 'included' },
                                 { name: 'Not included', value: 'not_included' },
-                                { name: 'Face to face', value: 'face_to_face' }
-                            )
+                                { name: 'Face to face', value: 'face_to_face' },
+                            ),
                     )
-                    .addStringOption(option =>
-                        option.setName('warranty')
+                    .addStringOption((option) =>
+                        option
+                            .setName('warranty')
                             .setDescription('Warranty information')
-                            .setRequired(false)
+                            .setRequired(false),
                     )
-                    .addStringOption(option =>
-                        option.setName('description')
+                    .addStringOption((option) =>
+                        option
+                            .setName('description')
                             .setDescription('Description of the item')
-                            .setRequired(false)
-                    )
+                            .setRequired(false),
+                    ),
             )
-            .addSubcommand(subcommand =>
+            .addSubcommand((subcommand) =>
                 subcommand
                     .setName('list')
                     .setDescription('List marketplace items from a user')
-                    .addUserOption(option =>
-                        option.setName('user')
+                    .addUserOption((option) =>
+                        option
+                            .setName('user')
                             .setDescription('User to list items from (defaults to yourself)')
-                            .setRequired(false)
-                    )
+                            .setRequired(false),
+                    ),
             )
-            .addSubcommand(subcommand =>
+            .addSubcommand((subcommand) =>
                 subcommand
                     .setName('delete')
                     .setDescription('Delete one of your marketplace items')
-                    .addStringOption(option =>
-                        option.setName('id')
+                    .addStringOption((option) =>
+                        option
+                            .setName('id')
                             .setDescription('ID of the item to delete')
-                            .setRequired(true)
-                    )
+                            .setRequired(true),
+                    ),
             );
     }
 
@@ -116,7 +119,7 @@ export class MarketplaceSlashCommand implements SlashCommandHandler {
                 this.logger.error('Unknown subcommand', { subcommand });
                 await context.interaction.reply({
                     content: 'Unknown subcommand',
-                    ephemeral: true
+                    ephemeral: true,
                 });
         }
     }

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/SellSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/SellSubcommand.ts
@@ -1,38 +1,51 @@
-import { inject, injectable } from "inversify";
-import type { SlashCommandContext } from "../../../../../Domain/Bot/SlashCommandContext";
-import { MessageFlags } from "discord.js";
-import { TYPES } from "../../../../DependencyInjection/types";
-import type Logger from "../../../../../Application/Logger/Logger";
-import CommandHandlerManager from "../../../../CommandHandler/CommandHandlerManager";
-import { CreateAd } from "../../../../../Application/Write/Marketplace/CreateAd/CreateAd";
-import { AdId } from "../../../../../Domain/Marketplace/AdId";
+import { inject, injectable } from 'inversify';
+import type { SlashCommandContext } from '../../../../../Domain/Bot/SlashCommandContext';
+import { MessageFlags } from 'discord.js';
+import { TYPES } from '../../../../DependencyInjection/types';
+import type Logger from '../../../../../Application/Logger/Logger';
+import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerManager';
+import { CreateAd } from '../../../../../Application/Write/Marketplace/CreateAd/CreateAd';
+import { AdId } from '../../../../../Domain/Marketplace/AdId';
 
 @injectable()
 export class SellSubcommand {
     constructor(
         @inject(TYPES.Logger) private readonly logger: Logger,
-        @inject(CommandHandlerManager) private readonly commandHandlerManager: CommandHandlerManager
+        @inject(CommandHandlerManager)
+        private readonly commandHandlerManager: CommandHandlerManager,
     ) {}
 
     private getStateEmoji(state: string): string {
         switch (state) {
-            case 'new': return '🆕';
-            case 'like_new': return '✨';
-            case 'used_good': return '👍';
-            case 'used_marks': return '📝';
-            case 'broken': return '🔧';
-            default: return '❓';
+            case 'new':
+                return '🆕';
+            case 'like_new':
+                return '✨';
+            case 'used_good':
+                return '👍';
+            case 'used_marks':
+                return '📝';
+            case 'broken':
+                return '🔧';
+            default:
+                return '❓';
         }
     }
 
     private getStateDisplay(state: string): string {
         switch (state) {
-            case 'new': return 'New';
-            case 'like_new': return 'Like new';
-            case 'used_good': return 'Used - Good condition';
-            case 'used_marks': return 'Used - With marks';
-            case 'broken': return 'Broken';
-            default: return state;
+            case 'new':
+                return 'New';
+            case 'like_new':
+                return 'Like new';
+            case 'used_good':
+                return 'Used - Good condition';
+            case 'used_marks':
+                return 'Used - With marks';
+            case 'broken':
+                return 'Broken';
+            default:
+                return state;
         }
     }
 
@@ -58,7 +71,7 @@ export class SellSubcommand {
                 dispatch,
                 warranty,
                 description,
-                'sale'
+                'sale',
             );
 
             const ad = await this.commandHandlerManager.handle(command);
@@ -73,12 +86,14 @@ export class SellSubcommand {
                 warranty ? `⚡ Warranty: ${warranty}` : '',
                 description ? `📝 Description: ${description}` : '',
                 '',
-                `Listed by: <@${context.interaction.user.id}>`
-            ].filter(Boolean).join('\n');
+                `Listed by: <@${context.interaction.user.id}>`,
+            ]
+                .filter(Boolean)
+                .join('\n');
 
             const reply = await context.interaction.reply({
                 content: replyContent,
-                fetchReply: true
+                fetchReply: true,
             });
 
             // Update the ad with the message ID
@@ -94,16 +109,15 @@ export class SellSubcommand {
                 ad.dispatch,
                 ad.warranty,
                 ad.description,
-                ad.adType
+                ad.adType,
             );
 
             await this.commandHandlerManager.handle(updateCommand);
-
         } catch (error) {
             this.logger.error('Error creating sale listing', { error });
             await context.interaction.reply({
                 content: 'There was an error creating your sale listing. Please try again.',
-                flags: MessageFlags.Ephemeral
+                flags: MessageFlags.Ephemeral,
             });
         }
     }

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/PingSlashCommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/PingSlashCommand.ts
@@ -1,26 +1,23 @@
-import {inject, injectable} from "inversify";
-import type {SlashCommandHandler} from "../../../../Domain/Bot/SlashCommandHandler.ts";
-import type {SlashCommandContext} from "../../../../Domain/Bot/SlashCommandContext.ts";
-import CommandHandlerManager from "../../../CommandHandler/CommandHandlerManager.ts";
-import {Ping} from "../../../../Application/Query/Ping/Ping.ts";
-import {SlashCommandBuilder} from "discord.js";
+import { inject, injectable } from 'inversify';
+import type { SlashCommandHandler } from '../../../../Domain/Bot/SlashCommandHandler.ts';
+import type { SlashCommandContext } from '../../../../Domain/Bot/SlashCommandContext.ts';
+import CommandHandlerManager from '../../../CommandHandler/CommandHandlerManager.ts';
+import { Ping } from '../../../../Application/Query/Ping/Ping.ts';
+import { SlashCommandBuilder } from 'discord.js';
 
 @injectable()
 export class PingSlashCommand implements SlashCommandHandler {
-
     constructor(
-        @inject(CommandHandlerManager) private readonly commandHandlerManager: CommandHandlerManager
-    ) {
-    }
+        @inject(CommandHandlerManager)
+        private readonly commandHandlerManager: CommandHandlerManager,
+    ) {}
 
     public getName(): string {
-        return "ping";
+        return 'ping';
     }
 
     public builder(): any {
-        return new SlashCommandBuilder()
-            .setName('ping')
-            .setDescription("Replies with a pong!")
+        return new SlashCommandBuilder().setName('ping').setDescription('Replies with a pong!');
     }
 
     async handle(context: SlashCommandContext): Promise<void> {

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/CreateScreenshotSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/CreateScreenshotSubcommand.ts
@@ -1,22 +1,20 @@
-import {inject, injectable} from "inversify";
-import CommandHandlerManager from "../../../../CommandHandler/CommandHandlerManager.ts";
-import type Logger from "../../../../../Application/Logger/Logger.ts";
-import {TYPES} from "../../../../DependencyInjection/types.ts";
-import {MessageFlags} from "discord.js";
-import {ScreenshotId} from "../../../../../Domain/Screenshot/ScreenshotId.ts";
-import {CreateScreenshot} from "../../../../../Application/Write/Screenshot/CreateScreenshot/CreateScreenshot.ts";
-import {
-    ScreenshotAlreadyExist
-} from "../../../../../Application/Write/Screenshot/CreateScreenshot/ScreenshotAlreadyExist.ts";
-import {DiscordEmoji} from "../../../../Community/Discord/DiscordEmoji.ts";
+import { inject, injectable } from 'inversify';
+import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerManager.ts';
+import type Logger from '../../../../../Application/Logger/Logger.ts';
+import { TYPES } from '../../../../DependencyInjection/types.ts';
+import { MessageFlags } from 'discord.js';
+import { ScreenshotId } from '../../../../../Domain/Screenshot/ScreenshotId.ts';
+import { CreateScreenshot } from '../../../../../Application/Write/Screenshot/CreateScreenshot/CreateScreenshot.ts';
+import { ScreenshotAlreadyExist } from '../../../../../Application/Write/Screenshot/CreateScreenshot/ScreenshotAlreadyExist.ts';
+import { DiscordEmoji } from '../../../../Community/Discord/DiscordEmoji.ts';
 
 @injectable()
 export class CreateScreenshotSubcommand {
     constructor(
-        @inject(CommandHandlerManager) private readonly commandHandlerManager: CommandHandlerManager,
-        @inject(TYPES.Logger) private readonly logger: Logger
-    ) {
-    }
+        @inject(CommandHandlerManager)
+        private readonly commandHandlerManager: CommandHandlerManager,
+        @inject(TYPES.Logger) private readonly logger: Logger,
+    ) {}
 
     public async handle(interaction: any): Promise<void> {
         const image = interaction.options.getAttachment('image');
@@ -25,45 +23,52 @@ export class CreateScreenshotSubcommand {
 
         // Validate required data
         if (!image || !name || !platform) {
-            await interaction.reply('Error: Missing required information for the screenshot.', {flags: MessageFlags.Ephemeral});
+            await interaction.reply('Error: Missing required information for the screenshot.', {
+                flags: MessageFlags.Ephemeral,
+            });
             return;
         }
 
         // Validate image
         if (!image.contentType?.startsWith('image/')) {
-            await interaction.reply('Error: The attachment must be an image.', {flags: MessageFlags.Ephemeral});
+            await interaction.reply('Error: The attachment must be an image.', {
+                flags: MessageFlags.Ephemeral,
+            });
             return;
         }
 
         // Create a new screenshot
         const screenshotId = ScreenshotId.generate();
         try {
-            await this.commandHandlerManager.handle(new CreateScreenshot(
-                screenshotId,
-                name,
-                interaction.user.id,
-                interaction.channelId,
-                interaction.id,
-                platform,
-                image.url
-            ));
+            await this.commandHandlerManager.handle(
+                new CreateScreenshot(
+                    screenshotId,
+                    name,
+                    interaction.user.id,
+                    interaction.channelId,
+                    interaction.id,
+                    platform,
+                    image.url,
+                ),
+            );
 
             // Reply with the formatted message and the image
             const message = await interaction.reply({
-                content: `📸 **Screenshot Submitted!**\n\n` +
+                content:
+                    `📸 **Screenshot Submitted!**\n\n` +
                     `ID: #${screenshotId.toString()}\n` +
                     `Author: ${interaction.user.username}\n` +
                     `Name: ${name}\n` +
                     `Platform: ${platform.charAt(0).toUpperCase() + platform.slice(1)}`,
                 files: [image.url],
-                fetchReply: true // This ensures we get the message object back
+                fetchReply: true, // This ensures we get the message object back
             });
 
             // Add the trophy reaction to the message
             try {
                 await message.react(DiscordEmoji.TROPHY_PLAT);
             } catch (reactionError) {
-                this.logger.error('Failed to add trophy reaction', {error: reactionError});
+                this.logger.error('Failed to add trophy reaction', { error: reactionError });
                 // Continue execution even if reaction fails
             }
 
@@ -71,21 +76,21 @@ export class CreateScreenshotSubcommand {
                 id: screenshotId.toString(),
                 name: name,
                 userId: interaction.user.id,
-                platform: platform
+                platform: platform,
             });
         } catch (error) {
             this.logger.error('Error submitting screenshot', {
                 name: name,
                 userId: interaction.user.id,
                 platform: platform,
-                error: error
+                error: error,
             });
 
             // Check for specific error types
             if (error instanceof ScreenshotAlreadyExist) {
                 await interaction.reply({
                     content: '⚠️ Error: This screenshot has already been submitted.',
-                    flags: MessageFlags.Ephemeral
+                    flags: MessageFlags.Ephemeral,
                 });
                 return;
             }
@@ -93,7 +98,7 @@ export class CreateScreenshotSubcommand {
             // Generic error message for other errors
             await interaction.reply({
                 content: 'There was an error submitting your screenshot. Please try again later.',
-                flags: MessageFlags.Ephemeral
+                flags: MessageFlags.Ephemeral,
             });
         }
     }

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/DeleteScreenshotSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/DeleteScreenshotSubcommand.ts
@@ -1,20 +1,20 @@
-import CommandHandlerManager from "../../../../CommandHandler/CommandHandlerManager.ts";
-import {inject} from "inversify";
-import type Logger from "../../../../../Application/Logger/Logger.ts";
-import {TYPES} from "../../../../DependencyInjection/types.ts";
-import {ScreenshotId} from "../../../../../Domain/Screenshot/ScreenshotId.ts";
-import {DeleteScreenshot} from "../../../../../Application/Write/Screenshot/DeleteScreenshot/DeleteScreenshot.ts";
-import {MessageFlags} from "discord.js";
-import {InvalidId} from "../../../../../Domain/InvalidId.ts";
-import RecordNotFound from "../../../../../Domain/RecordNotFound.ts";
-import {NotAuthorized} from "../../../../../Application/Write/Screenshot/DeleteScreenshot/NotAuthorized.ts";
+import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerManager.ts';
+import { inject } from 'inversify';
+import type Logger from '../../../../../Application/Logger/Logger.ts';
+import { TYPES } from '../../../../DependencyInjection/types.ts';
+import { ScreenshotId } from '../../../../../Domain/Screenshot/ScreenshotId.ts';
+import { DeleteScreenshot } from '../../../../../Application/Write/Screenshot/DeleteScreenshot/DeleteScreenshot.ts';
+import { MessageFlags } from 'discord.js';
+import { InvalidId } from '../../../../../Domain/InvalidId.ts';
+import RecordNotFound from '../../../../../Domain/RecordNotFound.ts';
+import { NotAuthorized } from '../../../../../Application/Write/Screenshot/DeleteScreenshot/NotAuthorized.ts';
 
 export class DeleteScreenshotSubcommand {
     constructor(
-        @inject(CommandHandlerManager) private readonly commandHandlerManager: CommandHandlerManager,
-        @inject(TYPES.Logger) private readonly logger: Logger
-    ) {
-    }
+        @inject(CommandHandlerManager)
+        private readonly commandHandlerManager: CommandHandlerManager,
+        @inject(TYPES.Logger) private readonly logger: Logger,
+    ) {}
 
     public async handle(interaction: any): Promise<void> {
         const screenshotIdString = interaction.options.getString('id');
@@ -24,31 +24,30 @@ export class DeleteScreenshotSubcommand {
 
         try {
             const screenshotId = ScreenshotId.fromString(cleanId);
-            await this.commandHandlerManager.handle(new DeleteScreenshot(
-                screenshotId,
-                interaction.user.id
-            ));
+            await this.commandHandlerManager.handle(
+                new DeleteScreenshot(screenshotId, interaction.user.id),
+            );
 
             await interaction.reply({
                 content: `✅ Screenshot #${cleanId} has been deleted successfully.`,
-                flags: MessageFlags.Ephemeral
+                flags: MessageFlags.Ephemeral,
             });
 
             this.logger.info('Screenshot deleted successfully', {
                 id: cleanId,
-                userId: interaction.user.id
+                userId: interaction.user.id,
             });
         } catch (error) {
             this.logger.error('Error deleting screenshot', {
                 id: cleanId,
                 userId: interaction.user.id,
-                error: error
+                error: error,
             });
 
             if (error instanceof InvalidId) {
                 await interaction.reply({
                     content: `⚠️ Error: Invalid screenshot ID format.`,
-                    flags: MessageFlags.Ephemeral
+                    flags: MessageFlags.Ephemeral,
                 });
                 return;
             }
@@ -56,7 +55,7 @@ export class DeleteScreenshotSubcommand {
             if (error instanceof RecordNotFound) {
                 await interaction.reply({
                     content: `⚠️ Error: Screenshot with ID #${cleanId} was not found.`,
-                    flags: MessageFlags.Ephemeral
+                    flags: MessageFlags.Ephemeral,
                 });
                 return;
             }
@@ -64,14 +63,14 @@ export class DeleteScreenshotSubcommand {
             if (error instanceof NotAuthorized) {
                 await interaction.reply({
                     content: `⛔ Error: You are not authorized to delete this screenshot.`,
-                    flags: MessageFlags.Ephemeral
+                    flags: MessageFlags.Ephemeral,
                 });
                 return;
             }
 
             await interaction.reply({
                 content: 'There was an error deleting the screenshot. Please try again later.',
-                flags: MessageFlags.Ephemeral
+                flags: MessageFlags.Ephemeral,
             });
         }
     }

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ListScreenshotSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ListScreenshotSubcommand.ts
@@ -1,17 +1,17 @@
-import {inject, injectable} from "inversify";
-import CommandHandlerManager from "../../../../CommandHandler/CommandHandlerManager.ts";
-import type Logger from "../../../../../Application/Logger/Logger.ts";
-import {TYPES} from "../../../../DependencyInjection/types.ts";
-import {GetScreenshots} from "../../../../../Application/Query/Screenshot/GetScreenshots/GetScreenshots.ts";
-import {EmbedBuilder, MessageFlags} from "discord.js";
+import { inject, injectable } from 'inversify';
+import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerManager.ts';
+import type Logger from '../../../../../Application/Logger/Logger.ts';
+import { TYPES } from '../../../../DependencyInjection/types.ts';
+import { GetScreenshots } from '../../../../../Application/Query/Screenshot/GetScreenshots/GetScreenshots.ts';
+import { EmbedBuilder, MessageFlags } from 'discord.js';
 
 @injectable()
 export class ListScreenshotSubcommand {
     constructor(
-        @inject(CommandHandlerManager) private readonly commandHandlerManager: CommandHandlerManager,
-        @inject(TYPES.Logger) private readonly logger: Logger
-    ) {
-    }
+        @inject(CommandHandlerManager)
+        private readonly commandHandlerManager: CommandHandlerManager,
+        @inject(TYPES.Logger) private readonly logger: Logger,
+    ) {}
 
     public async handle(interaction: any): Promise<void> {
         try {
@@ -31,13 +31,15 @@ export class ListScreenshotSubcommand {
 
                 await interaction.reply({
                     content: message,
-                    flags: MessageFlags.Ephemeral
+                    flags: MessageFlags.Ephemeral,
                 });
                 return;
             }
 
             // Create an embed to display the screenshots
-            const title = isOwnScreenshots ? '🔍 Your Screenshots' : `🔍 ${targetUser.username}'s Screenshots`;
+            const title = isOwnScreenshots
+                ? '🔍 Your Screenshots'
+                : `🔍 ${targetUser.username}'s Screenshots`;
             const description = isOwnScreenshots
                 ? `You have submitted ${screenshots.length} screenshot(s).`
                 : `${targetUser.username} has submitted ${screenshots.length} screenshot(s).`;
@@ -52,40 +54,42 @@ export class ListScreenshotSubcommand {
             const displayLimit = Math.min(screenshots.length, 10);
             for (let i = 0; i < displayLimit; i++) {
                 const screenshot = screenshots[i];
-                const platform = screenshot.platform ?
-                    (screenshot.platform.charAt(0).toUpperCase() + screenshot.platform.slice(1)) :
-                    'Unknown';
+                const platform = screenshot.platform
+                    ? screenshot.platform.charAt(0).toUpperCase() + screenshot.platform.slice(1)
+                    : 'Unknown';
 
                 embed.addFields({
                     name: `#${i + 1} - ${screenshot.name || 'Unnamed'}`,
-                    value: `ID: ${screenshot.id.toString()}\nPlatform: ${platform}\nSubmitted: ${screenshot.createdAt.toLocaleDateString()}`
+                    value: `ID: ${screenshot.id.toString()}\nPlatform: ${platform}\nSubmitted: ${screenshot.createdAt.toLocaleDateString()}`,
                 });
             }
 
             // Add a note if there are more screenshots than shown
             if (screenshots.length > displayLimit) {
-                embed.setFooter({text: `Showing ${displayLimit} of ${screenshots.length} screenshots.`});
+                embed.setFooter({
+                    text: `Showing ${displayLimit} of ${screenshots.length} screenshots.`,
+                });
             }
 
             await interaction.reply({
                 embeds: [embed],
-                flags: MessageFlags.Ephemeral
+                flags: MessageFlags.Ephemeral,
             });
 
             this.logger.info('Screenshot list requested', {
                 userId: userId,
                 requestedBy: interaction.user.id,
-                count: screenshots.length
+                count: screenshots.length,
             });
         } catch (error) {
             this.logger.error('Error listing screenshots', {
                 userId: interaction.user.id,
-                error: error
+                error: error,
             });
 
             await interaction.reply({
                 content: 'There was an error retrieving the screenshots. Please try again later.',
-                flags: MessageFlags.Ephemeral
+                flags: MessageFlags.Ephemeral,
             });
         }
     }

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ScreenshotSlashCommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ScreenshotSlashCommand.ts
@@ -1,82 +1,93 @@
-import {inject, injectable} from "inversify";
-import type {SlashCommandHandler} from "../../../../../Domain/Bot/SlashCommandHandler.ts";
-import type {SlashCommandContext} from "../../../../../Domain/Bot/SlashCommandContext.ts";
-import {MessageFlags, SlashCommandBuilder} from "discord.js";
-import {TYPES} from "../../../../DependencyInjection/types.ts";
-import type Logger from "../../../../../Application/Logger/Logger.ts";
-import {CreateScreenshotSubcommand} from "./CreateScreenshotSubcommand.ts";
-import {ListScreenshotSubcommand} from "./ListScreenshotSubcommand.ts";
-import {DeleteScreenshotSubcommand} from "./DeleteScreenshotSubcommand.ts";
+import { inject, injectable } from 'inversify';
+import type { SlashCommandHandler } from '../../../../../Domain/Bot/SlashCommandHandler.ts';
+import type { SlashCommandContext } from '../../../../../Domain/Bot/SlashCommandContext.ts';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
+import { TYPES } from '../../../../DependencyInjection/types.ts';
+import type Logger from '../../../../../Application/Logger/Logger.ts';
+import { CreateScreenshotSubcommand } from './CreateScreenshotSubcommand.ts';
+import { ListScreenshotSubcommand } from './ListScreenshotSubcommand.ts';
+import { DeleteScreenshotSubcommand } from './DeleteScreenshotSubcommand.ts';
 
 @injectable()
 export class ScreenshotSlashCommand implements SlashCommandHandler {
     constructor(
         @inject(TYPES.Logger) private readonly logger: Logger,
-        @inject(CreateScreenshotSubcommand) private readonly createScreenshotSubcommand: CreateScreenshotSubcommand,
-        @inject(ListScreenshotSubcommand) private readonly listScreenshotSubcommand: ListScreenshotSubcommand,
-        @inject(DeleteScreenshotSubcommand) private readonly deleteScreenshotSubcommand: DeleteScreenshotSubcommand,
-    ) {
-    }
+        @inject(CreateScreenshotSubcommand)
+        private readonly createScreenshotSubcommand: CreateScreenshotSubcommand,
+        @inject(ListScreenshotSubcommand)
+        private readonly listScreenshotSubcommand: ListScreenshotSubcommand,
+        @inject(DeleteScreenshotSubcommand)
+        private readonly deleteScreenshotSubcommand: DeleteScreenshotSubcommand,
+    ) {}
 
     public getName(): string {
-        return "screenshot";
+        return 'screenshot';
     }
 
     public builder(): any {
-        return new SlashCommandBuilder()
-            .setName('screenshot')
-            .setDescription("Manage screenshots for the contest")
-            // Create subcommand
-            .addSubcommand(subcommand =>
-                subcommand
-                    .setName('create')
-                    .setDescription('Submit a new screenshot to the contest')
-                    .addAttachmentOption(option =>
-                        option.setName('image')
-                            .setDescription('The screenshot you want to submit')
-                            .setRequired(true)
-                    )
-                    .addStringOption(option =>
-                        option.setName('name')
-                            .setDescription('Name for your screenshot')
-                            .setRequired(true)
-                    )
-                    .addStringOption(option =>
-                        option.setName('platform')
-                            .setDescription('Platform the screenshot was taken on')
-                            .setRequired(true)
-                            .addChoices(
-                                {name: 'PlayStation', value: 'playstation'},
-                                {name: 'Xbox', value: 'xbox'},
-                                {name: 'Nintendo Switch', value: 'switch'},
-                                {name: 'PC', value: 'pc'},
-                                {name: 'Mobile', value: 'mobile'},
-                                {name: 'Other', value: 'other'}
-                            )
-                    )
-            )
-            // List subcommand
-            .addSubcommand(subcommand =>
-                subcommand
-                    .setName('list')
-                    .setDescription('List submitted screenshots')
-                    .addUserOption(option =>
-                        option.setName('user')
-                            .setDescription('User whose screenshots to view (defaults to yourself)')
-                            .setRequired(false)
-                    )
-            )
-            // Delete subcommand
-            .addSubcommand(subcommand =>
-                subcommand
-                    .setName('delete')
-                    .setDescription('Delete one of your screenshots')
-                    .addStringOption(option =>
-                        option.setName('id')
-                            .setDescription('ID of the screenshot to delete')
-                            .setRequired(true)
-                    )
-            );
+        return (
+            new SlashCommandBuilder()
+                .setName('screenshot')
+                .setDescription('Manage screenshots for the contest')
+                // Create subcommand
+                .addSubcommand((subcommand) =>
+                    subcommand
+                        .setName('create')
+                        .setDescription('Submit a new screenshot to the contest')
+                        .addAttachmentOption((option) =>
+                            option
+                                .setName('image')
+                                .setDescription('The screenshot you want to submit')
+                                .setRequired(true),
+                        )
+                        .addStringOption((option) =>
+                            option
+                                .setName('name')
+                                .setDescription('Name for your screenshot')
+                                .setRequired(true),
+                        )
+                        .addStringOption((option) =>
+                            option
+                                .setName('platform')
+                                .setDescription('Platform the screenshot was taken on')
+                                .setRequired(true)
+                                .addChoices(
+                                    { name: 'PlayStation', value: 'playstation' },
+                                    { name: 'Xbox', value: 'xbox' },
+                                    { name: 'Nintendo Switch', value: 'switch' },
+                                    { name: 'PC', value: 'pc' },
+                                    { name: 'Mobile', value: 'mobile' },
+                                    { name: 'Other', value: 'other' },
+                                ),
+                        ),
+                )
+                // List subcommand
+                .addSubcommand((subcommand) =>
+                    subcommand
+                        .setName('list')
+                        .setDescription('List submitted screenshots')
+                        .addUserOption((option) =>
+                            option
+                                .setName('user')
+                                .setDescription(
+                                    'User whose screenshots to view (defaults to yourself)',
+                                )
+                                .setRequired(false),
+                        ),
+                )
+                // Delete subcommand
+                .addSubcommand((subcommand) =>
+                    subcommand
+                        .setName('delete')
+                        .setDescription('Delete one of your screenshots')
+                        .addStringOption((option) =>
+                            option
+                                .setName('id')
+                                .setDescription('ID of the screenshot to delete')
+                                .setRequired(true),
+                        ),
+                )
+        );
     }
 
     async handle(context: SlashCommandContext): Promise<void> {
@@ -98,13 +109,17 @@ export class ScreenshotSlashCommand implements SlashCommandHandler {
                     break;
                 default:
                     await interaction.reply({
-                        content: 'Unknown subcommand. Please use `/screenshot create`, `/screenshot list`, or `/screenshot delete`.',
-                        flags: MessageFlags.Ephemeral
+                        content:
+                            'Unknown subcommand. Please use `/screenshot create`, `/screenshot list`, or `/screenshot delete`.',
+                        flags: MessageFlags.Ephemeral,
                     });
             }
         } catch (error) {
-            await interaction.reply('There was an error processing your screenshot command. Please try again later.', {flags: MessageFlags.Ephemeral});
-            this.logger.error('Error processing screenshot command', {error});
+            await interaction.reply(
+                'There was an error processing your screenshot command. Please try again later.',
+                { flags: MessageFlags.Ephemeral },
+            );
+            this.logger.error('Error processing screenshot command', { error });
         }
     }
 }

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.ts
@@ -1,75 +1,76 @@
-import {inject, injectable} from "inversify";
-import type {SlashCommandContext} from "../../../../../Domain/Bot/SlashCommandContext";
-import {EmbedBuilder, MessageFlags} from "discord.js";
-import {TYPES} from "../../../../DependencyInjection/types";
-import type Logger from "../../../../../Application/Logger/Logger";
-import CommandHandlerManager from "../../../../CommandHandler/CommandHandlerManager";
-import {GetProfile} from "../../../../../Application/Query/Trophy/GetProfile/GetProfile";
-import {ProfileNotFound} from "../../../../../Application/Query/Trophy/GetProfile/ProfileNotFound";
+import { inject, injectable } from 'inversify';
+import type { SlashCommandContext } from '../../../../../Domain/Bot/SlashCommandContext';
+import { EmbedBuilder, MessageFlags } from 'discord.js';
+import { TYPES } from '../../../../DependencyInjection/types';
+import type Logger from '../../../../../Application/Logger/Logger';
+import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerManager';
+import { GetProfile } from '../../../../../Application/Query/Trophy/GetProfile/GetProfile';
+import { ProfileNotFound } from '../../../../../Application/Query/Trophy/GetProfile/ProfileNotFound';
 
 @injectable()
 export class CheckTrophyProfileSubcommand {
     constructor(
         @inject(TYPES.Logger) private readonly logger: Logger,
-        @inject(CommandHandlerManager) private readonly commandHandlerManager: CommandHandlerManager
+        @inject(CommandHandlerManager)
+        private readonly commandHandlerManager: CommandHandlerManager,
     ) {}
 
     public async handle(context: SlashCommandContext): Promise<void> {
         const targetUser = context.interaction.options.getUser('user') ?? context.interaction.user;
-        
+
         try {
             const command = new GetProfile(targetUser.id);
             const profile = await this.commandHandlerManager.handle(command);
 
             const embed = new EmbedBuilder()
-                .setColor(profile.isBanned ? 0xFF0000 : profile.hasLeft ? 0xFFA500 : 0x00FF00)
+                .setColor(profile.isBanned ? 0xff0000 : profile.hasLeft ? 0xffa500 : 0x00ff00)
                 .setTitle(`🎮 PSN Profile: ${profile.psnProfile}`)
                 .setDescription(`Profile for ${targetUser}`)
                 .addFields(
-                    { 
+                    {
                         name: '📊 Status',
                         value: [
                             `${profile.isBanned ? '🚫' : '✅'} Banned: ${profile.isBanned ? 'Yes' : 'No'}`,
                             `${profile.hasLeft ? '👋' : '🏃'} Left Server: ${profile.hasLeft ? 'Yes' : 'No'}`,
-                            `${profile.isExcluded ? '❌' : '✨'} Excluded: ${profile.isExcluded ? 'Yes' : 'No'}`
+                            `${profile.isExcluded ? '❌' : '✨'} Excluded: ${profile.isExcluded ? 'Yes' : 'No'}`,
                         ].join('\n'),
-                        inline: true
+                        inline: true,
                     },
                     {
                         name: '📅 Dates',
                         value: [
                             `🆕 Registered: ${profile.createdAt.toLocaleDateString()}`,
-                            `🔄 Last Updated: ${profile.updatedAt.toLocaleDateString()}`
+                            `🔄 Last Updated: ${profile.updatedAt.toLocaleDateString()}`,
                         ].join('\n'),
-                        inline: true
-                    }
+                        inline: true,
+                    },
                 )
                 .setFooter({ text: 'PSN Profile Status' })
                 .setTimestamp();
 
             await context.interaction.reply({
-                embeds: [embed]
+                embeds: [embed],
             });
-
         } catch (error) {
             if (error instanceof ProfileNotFound) {
                 await context.interaction.reply({
-                    content: targetUser.id === context.interaction.user.id
-                        ? '❌ You have not registered your PSN profile yet. Use `/trophy create` to register.'
-                        : '❌ This user has not registered their PSN profile.',
-                    flags: MessageFlags.Ephemeral
+                    content:
+                        targetUser.id === context.interaction.user.id
+                            ? '❌ You have not registered your PSN profile yet. Use `/trophy create` to register.'
+                            : '❌ This user has not registered their PSN profile.',
+                    flags: MessageFlags.Ephemeral,
                 });
                 return;
             }
 
             this.logger.error('Error getting trophy profile', {
                 error: error instanceof Error ? error.message : 'Unknown error',
-                userId: targetUser.id
+                userId: targetUser.id,
             });
 
             await context.interaction.reply({
                 content: '⚠️ An error occurred while retrieving the PSN profile.',
-                flags: MessageFlags.Ephemeral
+                flags: MessageFlags.Ephemeral,
             });
         }
     }

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/CreateTrophyProfileSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/CreateTrophyProfileSubcommand.ts
@@ -1,35 +1,36 @@
-import {inject, injectable} from "inversify";
-import type {SlashCommandContext} from "../../../../../Domain/Bot/SlashCommandContext";
-import {MessageFlags} from "discord.js";
-import {TYPES} from "../../../../DependencyInjection/types";
-import type Logger from "../../../../../Application/Logger/Logger";
-import CommandHandlerManager from "../../../../CommandHandler/CommandHandlerManager";
-import {CreateProfile} from "../../../../../Application/Write/Trophy/CreateProfile/CreateProfile";
-import {TrophyProfileId} from "../../../../../Domain/Trophy/TrophyProfileId";
-import {ProfileAlreadyExists} from "../../../../../Application/Write/Trophy/CreateProfile/ProfileAlreadyExists";
+import { inject, injectable } from 'inversify';
+import type { SlashCommandContext } from '../../../../../Domain/Bot/SlashCommandContext';
+import { MessageFlags } from 'discord.js';
+import { TYPES } from '../../../../DependencyInjection/types';
+import type Logger from '../../../../../Application/Logger/Logger';
+import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerManager';
+import { CreateProfile } from '../../../../../Application/Write/Trophy/CreateProfile/CreateProfile';
+import { TrophyProfileId } from '../../../../../Domain/Trophy/TrophyProfileId';
+import { ProfileAlreadyExists } from '../../../../../Application/Write/Trophy/CreateProfile/ProfileAlreadyExists';
 
 @injectable()
 export class CreateTrophyProfileSubcommand {
     constructor(
         @inject(TYPES.Logger) private readonly logger: Logger,
-        @inject(CommandHandlerManager) private readonly commandHandlerManager: CommandHandlerManager
-    ) {
-    }
+        @inject(CommandHandlerManager)
+        private readonly commandHandlerManager: CommandHandlerManager,
+    ) {}
 
     public getName(): string {
-        return "trophy create";
+        return 'trophy create';
     }
 
     public async handle(context: SlashCommandContext): Promise<void> {
         const psnprofilesUrl = context.interaction.options.getString('psnprofiles_url', true);
-        
+
         // Extract PSN profile name from URL (e.g., https://psnprofiles.com/username -> username)
         const psnProfile = this.extractPsnProfileFromUrl(psnprofilesUrl);
-        
+
         if (!psnProfile) {
             await context.interaction.reply({
-                content: 'Invalid PSNProfiles URL. Please provide a valid profile URL (e.g., https://psnprofiles.com/username)',
-                flags: MessageFlags.Ephemeral
+                content:
+                    'Invalid PSNProfiles URL. Please provide a valid profile URL (e.g., https://psnprofiles.com/username)',
+                flags: MessageFlags.Ephemeral,
             });
             return;
         }
@@ -38,29 +39,29 @@ export class CreateTrophyProfileSubcommand {
             const command = new CreateProfile(
                 TrophyProfileId.generate(),
                 context.interaction.user.id,
-                psnProfile
+                psnProfile,
             );
 
             await this.commandHandlerManager.handle(command);
 
             await context.interaction.reply({
                 content: `Successfully registered PSN profile: ${psnProfile}`,
-                flags: MessageFlags.Ephemeral
+                flags: MessageFlags.Ephemeral,
             });
-
         } catch (error) {
             if (error instanceof ProfileAlreadyExists) {
                 if (error.userId === context.interaction.user.id) {
                     await context.interaction.reply({
                         content: 'You have already registered this PSN profile.',
-                        flags: MessageFlags.Ephemeral
+                        flags: MessageFlags.Ephemeral,
                     });
                     return;
                 }
 
                 await context.interaction.reply({
-                    content: 'Someone else has already registered this PSN profile. If you think this is an error please report to an administrator',
-                    flags: MessageFlags.Ephemeral
+                    content:
+                        'Someone else has already registered this PSN profile. If you think this is an error please report to an administrator',
+                    flags: MessageFlags.Ephemeral,
                 });
                 return;
             }
@@ -68,12 +69,12 @@ export class CreateTrophyProfileSubcommand {
             this.logger.error('Error creating trophy profile', {
                 error: error instanceof Error ? error.message : 'Unknown error',
                 userId: context.interaction.user.id,
-                psnProfile
+                psnProfile,
             });
 
             await context.interaction.reply({
                 content: 'An error occurred while registering your PSN profile.',
-                flags: MessageFlags.Ephemeral
+                flags: MessageFlags.Ephemeral,
             });
         }
     }
@@ -88,11 +89,10 @@ export class CreateTrophyProfileSubcommand {
             if (parsedUrl.hostname !== 'psnprofiles.com') {
                 return null;
             }
-            
+
             // The PSN username should be the first path segment
             const username = parsedUrl.pathname.split('/')[1];
             return username || null;
-            
         } catch {
             return null;
         }

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/RankSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/RankSubcommand.ts
@@ -1,18 +1,23 @@
-import {inject, injectable} from "inversify";
-import type {SlashCommandContext} from "../../../../../Domain/Bot/SlashCommandContext";
-import {EmbedBuilder, MessageFlags} from "discord.js";
-import {TYPES} from "../../../../DependencyInjection/types";
-import type Logger from "../../../../../Application/Logger/Logger";
-import CommandHandlerManager from "../../../../CommandHandler/CommandHandlerManager";
-import {GetRank, type RankType, type MonthOption} from "../../../../../Application/Query/Trophy/GetRank/GetRank";
-import type {TrophyRankData} from "../../../../../Domain/Trophy/TrophyRankData";
-import type {UserPosition} from "../../../../../Domain/Trophy/UserPosition";
+import { inject, injectable } from 'inversify';
+import type { SlashCommandContext } from '../../../../../Domain/Bot/SlashCommandContext';
+import { EmbedBuilder, MessageFlags } from 'discord.js';
+import { TYPES } from '../../../../DependencyInjection/types';
+import type Logger from '../../../../../Application/Logger/Logger';
+import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerManager';
+import {
+    GetRank,
+    type RankType,
+    type MonthOption,
+} from '../../../../../Application/Query/Trophy/GetRank/GetRank';
+import type { TrophyRankData } from '../../../../../Domain/Trophy/TrophyRankData';
+import type { UserPosition } from '../../../../../Domain/Trophy/UserPosition';
 
 @injectable()
 export class RankSubcommand {
     constructor(
         @inject(TYPES.Logger) private readonly logger: Logger,
-        @inject(CommandHandlerManager) private readonly commandHandlerManager: CommandHandlerManager
+        @inject(CommandHandlerManager)
+        private readonly commandHandlerManager: CommandHandlerManager,
     ) {}
 
     private formatNumber(num: number): string {
@@ -21,27 +26,36 @@ export class RankSubcommand {
 
     private getRankEmoji(position: number): string {
         switch (position) {
-            case 1: return '🥇';
-            case 2: return '🥈';
-            case 3: return '🥉';
-            default: return '🏅';
+            case 1:
+                return '🥇';
+            case 2:
+                return '🥈';
+            case 3:
+                return '🥉';
+            default:
+                return '🏅';
         }
     }
 
     private formatRankTitle(type: RankType, targetUser?: string): string {
         switch (type) {
-            case 'monthly': return '📅 Monthly Trophy Rankings';
-            case 'creation': return '🎮 Since Creation Trophy Rankings';
-            case 'lifetime': return '🏆 Lifetime Trophy Rankings';
-            case 'user': return `📊 ${targetUser}'s Trophy Rankings`;
-            default: return 'Trophy Rankings';
+            case 'monthly':
+                return '📅 Monthly Trophy Rankings';
+            case 'creation':
+                return '🎮 Since Creation Trophy Rankings';
+            case 'lifetime':
+                return '🏆 Lifetime Trophy Rankings';
+            case 'user':
+                return `📊 ${targetUser}'s Trophy Rankings`;
+            default:
+                return 'Trophy Rankings';
         }
     }
 
     private getMonthDate(monthOption: string | null, yearOption: string | null): Date {
         const now = new Date();
         const year = yearOption ? parseInt(yearOption) : now.getFullYear();
-        
+
         if (!monthOption) {
             return new Date(year, now.getMonth());
         }
@@ -64,9 +78,13 @@ export class RankSubcommand {
         return date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
     }
 
-    private async createRankingEmbed(data: TrophyRankData[], type: RankType, date?: Date): Promise<EmbedBuilder> {
+    private async createRankingEmbed(
+        data: TrophyRankData[],
+        type: RankType,
+        date?: Date,
+    ): Promise<EmbedBuilder> {
         const embed = new EmbedBuilder()
-            .setColor(0x00FF00)
+            .setColor(0x00ff00)
             .setTitle(this.formatRankTitle(type))
             .setTimestamp();
 
@@ -77,12 +95,19 @@ export class RankSubcommand {
         if (data.length === 0) {
             embed.setDescription('No trophies found for this period.');
         } else {
-            embed.setDescription(data.map((rank, index) => {
-                const position = index + 1;
-                return `${this.getRankEmoji(position)} **#${position}** ${rank.psnProfile}\n` +
-                    `Points: ${this.formatNumber(rank.points)} | Trophies: ${this.formatNumber(rank.num_trophies)}`;
-            }).join('\n\n'))
-            .setFooter({text: `Top ${data.length} Trophy Hunters`});
+            embed
+                .setDescription(
+                    data
+                        .map((rank, index) => {
+                            const position = index + 1;
+                            return (
+                                `${this.getRankEmoji(position)} **#${position}** ${rank.psnProfile}\n` +
+                                `Points: ${this.formatNumber(rank.points)} | Trophies: ${this.formatNumber(rank.num_trophies)}`
+                            );
+                        })
+                        .join('\n\n'),
+                )
+                .setFooter({ text: `Top ${data.length} Trophy Hunters` });
         }
 
         return embed;
@@ -90,37 +115,40 @@ export class RankSubcommand {
 
     private createUserPositionEmbed(data: UserPosition, targetUser: string): EmbedBuilder {
         return new EmbedBuilder()
-            .setColor(0x00FF00)
+            .setColor(0x00ff00)
             .setTitle(`📊 ${targetUser}'s Trophy Rankings`)
             .addFields(
                 {
                     name: '📅 Monthly Rank',
-                    value: data.ranks[0].position > 0
-                        ? `${this.getRankEmoji(data.ranks[0].position)} #${data.ranks[0].position}\nPoints: ${this.formatNumber(data.ranks[0].points)}\nTrophies: ${this.formatNumber(data.ranks[0].trophies)}`
-                        : 'No trophies this month',
-                    inline: true
+                    value:
+                        data.ranks[0].position > 0
+                            ? `${this.getRankEmoji(data.ranks[0].position)} #${data.ranks[0].position}\nPoints: ${this.formatNumber(data.ranks[0].points)}\nTrophies: ${this.formatNumber(data.ranks[0].trophies)}`
+                            : 'No trophies this month',
+                    inline: true,
                 },
                 {
                     name: '🎮 Since Creation',
-                    value: data.ranks[1].position > 0
-                        ? `${this.getRankEmoji(data.ranks[1].position)} #${data.ranks[1].position}\nPoints: ${this.formatNumber(data.ranks[1].points)}\nTrophies: ${this.formatNumber(data.ranks[1].trophies)}`
-                        : 'No trophies recorded',
-                    inline: true
+                    value:
+                        data.ranks[1].position > 0
+                            ? `${this.getRankEmoji(data.ranks[1].position)} #${data.ranks[1].position}\nPoints: ${this.formatNumber(data.ranks[1].points)}\nTrophies: ${this.formatNumber(data.ranks[1].trophies)}`
+                            : 'No trophies recorded',
+                    inline: true,
                 },
                 {
                     name: '🏆 Lifetime',
-                    value: data.ranks[2].position > 0
-                        ? `${this.getRankEmoji(data.ranks[2].position)} #${data.ranks[2].position}\nPoints: ${this.formatNumber(data.ranks[2].points)}\nTrophies: ${this.formatNumber(data.ranks[2].trophies)}`
-                        : 'No trophies recorded',
-                    inline: true
+                    value:
+                        data.ranks[2].position > 0
+                            ? `${this.getRankEmoji(data.ranks[2].position)} #${data.ranks[2].position}\nPoints: ${this.formatNumber(data.ranks[2].points)}\nTrophies: ${this.formatNumber(data.ranks[2].trophies)}`
+                            : 'No trophies recorded',
+                    inline: true,
                 },
                 {
                     name: '📊 Total Stats',
                     value: `Total Points: ${this.formatNumber(data.totalPoints)}\nTotal Trophies: ${this.formatNumber(data.totalTrophies)}`,
-                    inline: false
-                }
+                    inline: false,
+                },
             )
-            .setFooter({text: 'Trophy Rankings'})
+            .setFooter({ text: 'Trophy Rankings' })
             .setTimestamp();
     }
 
@@ -128,18 +156,23 @@ export class RankSubcommand {
         try {
             const type = context.interaction.options.getString('type', true) as RankType;
             const limit = context.interaction.options.getInteger('limit') ?? 10;
-            const monthOption = type === 'monthly' ? context.interaction.options.getString('month') : null;
-            const yearOption = type === 'monthly' ? context.interaction.options.getString('year') : null;
-            const targetUser = context.interaction.options.getUser('user') ?? context.interaction.user;
+            const monthOption =
+                type === 'monthly' ? context.interaction.options.getString('month') : null;
+            const yearOption =
+                type === 'monthly' ? context.interaction.options.getString('year') : null;
+            const targetUser =
+                context.interaction.options.getUser('user') ?? context.interaction.user;
             const date = this.getMonthDate(monthOption, yearOption);
 
-            const result = await this.commandHandlerManager.handle(new GetRank(
-                type,
-                targetUser?.id,
-                limit,
-                monthOption as MonthOption,
-                yearOption ? parseInt(yearOption) : undefined,
-            ));
+            const result = await this.commandHandlerManager.handle(
+                new GetRank(
+                    type,
+                    targetUser?.id,
+                    limit,
+                    monthOption as MonthOption,
+                    yearOption ? parseInt(yearOption) : undefined,
+                ),
+            );
 
             const embed = Array.isArray(result)
                 ? await this.createRankingEmbed(result, type, type === 'monthly' ? date : undefined)
@@ -147,18 +180,18 @@ export class RankSubcommand {
 
             await context.interaction.reply({
                 embeds: [embed],
-                flags: MessageFlags.Ephemeral
+                flags: MessageFlags.Ephemeral,
             });
-
         } catch (error) {
             this.logger.error('Error getting trophy ranks', {
                 error: error instanceof Error ? error.message : 'Unknown error',
-                stack: error instanceof Error ? error.stack : undefined
+                stack: error instanceof Error ? error.stack : undefined,
             });
 
             await context.interaction.reply({
-                content: '⚠️ An error occurred while retrieving the trophy rankings. Please try again later.',
-                flags: MessageFlags.Ephemeral
+                content:
+                    '⚠️ An error occurred while retrieving the trophy rankings. Please try again later.',
+                flags: MessageFlags.Ephemeral,
             });
         }
     }

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/TrophySlashCommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/TrophySlashCommand.ts
@@ -1,114 +1,127 @@
-import {inject, injectable} from "inversify";
-import type {SlashCommandHandler} from "../../../../../Domain/Bot/SlashCommandHandler";
-import type {SlashCommandContext} from "../../../../../Domain/Bot/SlashCommandContext";
-import {MessageFlags, SlashCommandBuilder} from "discord.js";
-import {TYPES} from "../../../../DependencyInjection/types";
-import type Logger from "../../../../../Application/Logger/Logger";
-import {CreateTrophyProfileSubcommand} from "./CreateTrophyProfileSubcommand";
-import {CheckTrophyProfileSubcommand} from "./CheckTrophyProfileSubcommand";
-import {RankSubcommand} from "./RankSubcommand.ts";
+import { inject, injectable } from 'inversify';
+import type { SlashCommandHandler } from '../../../../../Domain/Bot/SlashCommandHandler';
+import type { SlashCommandContext } from '../../../../../Domain/Bot/SlashCommandContext';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
+import { TYPES } from '../../../../DependencyInjection/types';
+import type Logger from '../../../../../Application/Logger/Logger';
+import { CreateTrophyProfileSubcommand } from './CreateTrophyProfileSubcommand';
+import { CheckTrophyProfileSubcommand } from './CheckTrophyProfileSubcommand';
+import { RankSubcommand } from './RankSubcommand.ts';
 
 @injectable()
 export class TrophySlashCommand implements SlashCommandHandler {
     constructor(
         @inject(TYPES.Logger) private readonly logger: Logger,
-        @inject(CreateTrophyProfileSubcommand) private readonly createTrophyProfileSubcommand: CreateTrophyProfileSubcommand,
-        @inject(CheckTrophyProfileSubcommand) private readonly checkTrophyProfileSubcommand: CheckTrophyProfileSubcommand,
-        @inject(RankSubcommand) private readonly getRankSubcommand: RankSubcommand
+        @inject(CreateTrophyProfileSubcommand)
+        private readonly createTrophyProfileSubcommand: CreateTrophyProfileSubcommand,
+        @inject(CheckTrophyProfileSubcommand)
+        private readonly checkTrophyProfileSubcommand: CheckTrophyProfileSubcommand,
+        @inject(RankSubcommand) private readonly getRankSubcommand: RankSubcommand,
     ) {}
 
     public getName(): string {
-        return "trophy";
+        return 'trophy';
     }
 
     public builder(): any {
         const currentYear = new Date().getFullYear();
         const yearChoices = Array.from({ length: 5 }, (_, i) => ({
             name: `${currentYear - i}`,
-            value: `${currentYear - i}`
+            value: `${currentYear - i}`,
         }));
 
-        return new SlashCommandBuilder()
-            .setName('trophy')
-            .setDescription("Manage trophy profiles and submissions")
-            // Create subcommand
-            .addSubcommand(subcommand =>
-                subcommand
-                    .setName('create')
-                    .setDescription('Register your PSN profile for trophy tracking')
-                    .addStringOption(option =>
-                        option.setName('psnprofiles_url')
-                            .setDescription('Your PSNProfiles.com profile URL')
-                            .setRequired(true)
-                    )
-            )
-            // Check subcommand
-            .addSubcommand(subcommand =>
-                subcommand
-                    .setName('check')
-                    .setDescription('Get PSN profile information')
-                    .addUserOption(option =>
-                        option.setName('user')
-                            .setDescription('User to get PSN profile for (defaults to yourself)')
-                            .setRequired(false)
-                    )
-            )
-            // Rank subcommand
-            .addSubcommand(subcommand =>
-                subcommand
-                    .setName('rank')
-                    .setDescription('View trophy rankings')
-                    .addStringOption(option =>
-                        option.setName('type')
-                            .setDescription('Type of ranking to view')
-                            .setRequired(true)
-                            .addChoices(
-                                { name: '📅 Monthly Rankings', value: 'monthly' },
-                                { name: '🎮 Since Creation Rankings', value: 'creation' },
-                                { name: '🏆 Lifetime Rankings', value: 'lifetime' },
-                                { name: '📊 User Rankings', value: 'user' }
-                            )
-                    )
-                    .addUserOption(option =>
-                        option.setName('user')
-                            .setDescription('User to view rankings for (defaults to yourself)')
-                            .setRequired(false)
-                    )
-                    .addIntegerOption(option =>
-                        option.setName('limit')
-                            .setDescription('Number of results to show (default: 10)')
-                            .setMinValue(1)
-                            .setMaxValue(10)
-                            .setRequired(false)
-                    )
-                    .addStringOption(option =>
-                        option.setName('month')
-                            .setDescription('Month to view (current, last, or 1-12)')
-                            .setRequired(false)
-                            .addChoices(
-                                { name: 'Current Month', value: 'current' },
-                                { name: 'Last Month', value: 'last' },
-                                { name: 'January', value: '1' },
-                                { name: 'February', value: '2' },
-                                { name: 'March', value: '3' },
-                                { name: 'April', value: '4' },
-                                { name: 'May', value: '5' },
-                                { name: 'June', value: '6' },
-                                { name: 'July', value: '7' },
-                                { name: 'August', value: '8' },
-                                { name: 'September', value: '9' },
-                                { name: 'October', value: '10' },
-                                { name: 'November', value: '11' },
-                                { name: 'December', value: '12' }
-                            )
-                    )
-                    .addStringOption(option =>
-                        option.setName('year')
-                            .setDescription('Year to view (defaults to current year)')
-                            .setRequired(false)
-                            .addChoices(...yearChoices)
-                    )
-            );
+        return (
+            new SlashCommandBuilder()
+                .setName('trophy')
+                .setDescription('Manage trophy profiles and submissions')
+                // Create subcommand
+                .addSubcommand((subcommand) =>
+                    subcommand
+                        .setName('create')
+                        .setDescription('Register your PSN profile for trophy tracking')
+                        .addStringOption((option) =>
+                            option
+                                .setName('psnprofiles_url')
+                                .setDescription('Your PSNProfiles.com profile URL')
+                                .setRequired(true),
+                        ),
+                )
+                // Check subcommand
+                .addSubcommand((subcommand) =>
+                    subcommand
+                        .setName('check')
+                        .setDescription('Get PSN profile information')
+                        .addUserOption((option) =>
+                            option
+                                .setName('user')
+                                .setDescription(
+                                    'User to get PSN profile for (defaults to yourself)',
+                                )
+                                .setRequired(false),
+                        ),
+                )
+                // Rank subcommand
+                .addSubcommand((subcommand) =>
+                    subcommand
+                        .setName('rank')
+                        .setDescription('View trophy rankings')
+                        .addStringOption((option) =>
+                            option
+                                .setName('type')
+                                .setDescription('Type of ranking to view')
+                                .setRequired(true)
+                                .addChoices(
+                                    { name: '📅 Monthly Rankings', value: 'monthly' },
+                                    { name: '🎮 Since Creation Rankings', value: 'creation' },
+                                    { name: '🏆 Lifetime Rankings', value: 'lifetime' },
+                                    { name: '📊 User Rankings', value: 'user' },
+                                ),
+                        )
+                        .addUserOption((option) =>
+                            option
+                                .setName('user')
+                                .setDescription('User to view rankings for (defaults to yourself)')
+                                .setRequired(false),
+                        )
+                        .addIntegerOption((option) =>
+                            option
+                                .setName('limit')
+                                .setDescription('Number of results to show (default: 10)')
+                                .setMinValue(1)
+                                .setMaxValue(10)
+                                .setRequired(false),
+                        )
+                        .addStringOption((option) =>
+                            option
+                                .setName('month')
+                                .setDescription('Month to view (current, last, or 1-12)')
+                                .setRequired(false)
+                                .addChoices(
+                                    { name: 'Current Month', value: 'current' },
+                                    { name: 'Last Month', value: 'last' },
+                                    { name: 'January', value: '1' },
+                                    { name: 'February', value: '2' },
+                                    { name: 'March', value: '3' },
+                                    { name: 'April', value: '4' },
+                                    { name: 'May', value: '5' },
+                                    { name: 'June', value: '6' },
+                                    { name: 'July', value: '7' },
+                                    { name: 'August', value: '8' },
+                                    { name: 'September', value: '9' },
+                                    { name: 'October', value: '10' },
+                                    { name: 'November', value: '11' },
+                                    { name: 'December', value: '12' },
+                                ),
+                        )
+                        .addStringOption((option) =>
+                            option
+                                .setName('year')
+                                .setDescription('Year to view (defaults to current year)')
+                                .setRequired(false)
+                                .addChoices(...yearChoices),
+                        ),
+                )
+        );
     }
 
     public async handle(context: SlashCommandContext): Promise<void> {
@@ -128,18 +141,18 @@ export class TrophySlashCommand implements SlashCommandHandler {
                 default:
                     await context.interaction.reply({
                         content: `Unknown subcommand: ${subcommand}`,
-                        flags: MessageFlags.Ephemeral
+                        flags: MessageFlags.Ephemeral,
                     });
             }
         } catch (error) {
             this.logger.error('Error handling trophy command', {
                 error: error instanceof Error ? error.message : 'Unknown error',
-                subcommand
+                subcommand,
             });
 
             await context.interaction.reply({
                 content: 'An error occurred while processing your command.',
-                flags: MessageFlags.Ephemeral
+                flags: MessageFlags.Ephemeral,
             });
         }
     }

--- a/discord-bot/src/Infrastructure/Bot/InMemory/InMemoryClient.ts
+++ b/discord-bot/src/Infrastructure/Bot/InMemory/InMemoryClient.ts
@@ -1,5 +1,5 @@
-import type {Bot} from "../../../Domain/Bot/Bot.ts";
-import {injectable} from "inversify";
+import type { Bot } from '../../../Domain/Bot/Bot.ts';
+import { injectable } from 'inversify';
 
 @injectable()
 export class InMemoryClient implements Bot {

--- a/discord-bot/src/Infrastructure/CommandHandler/CommandHandlerManager.ts
+++ b/discord-bot/src/Infrastructure/CommandHandler/CommandHandlerManager.ts
@@ -1,36 +1,39 @@
-import type Command from '../../Domain/Command/Command'
-import type CommandHandler from '../../Domain/Command/CommandHandler'
-import { inject, injectable, multiInject } from 'inversify'
-import 'reflect-metadata'
-import { TYPES } from '../DependencyInjection/types'
-import Logger from '../../Application/Logger/Logger'
+import type Command from '../../Domain/Command/Command';
+import type CommandHandler from '../../Domain/Command/CommandHandler';
+import { inject, injectable, multiInject } from 'inversify';
+import 'reflect-metadata';
+import { TYPES } from '../DependencyInjection/types';
+import Logger from '../../Application/Logger/Logger';
 
 @injectable()
 export default class CommandHandlerManager {
-  private readonly handlersMap: Map<string, CommandHandler<Command>>
+    private readonly handlersMap: Map<string, CommandHandler<Command>>;
 
-  public constructor (
-    @multiInject(TYPES.CommandHandler) handlers: Array<CommandHandler<Command>> = new Array<CommandHandler<Command>>(),
-    @inject(TYPES.Logger) private readonly logger: Logger
-  ) {
-    this.handlersMap = new Map()
-    handlers.forEach(handler => {
-      const handlerName = handler.constructor.name.replace('Handler', '')
-      this.handlersMap.set(handlerName, handler)
-    })
-  }
-
-  public async handle (command: Command): Promise<any> {
-    const handler = this.handlersMap.get(command.constructor.name)
-    if (handler !== undefined) {
-      this.logger.info(`Handling command ${command.constructor.name}`)
-      return await handler.handle(command)
+    public constructor(
+        @multiInject(TYPES.CommandHandler)
+        handlers: Array<CommandHandler<Command>> = new Array<CommandHandler<Command>>(),
+        @inject(TYPES.Logger) private readonly logger: Logger,
+    ) {
+        this.handlersMap = new Map();
+        handlers.forEach((handler) => {
+            const handlerName = handler.constructor.name.replace('Handler', '');
+            this.handlersMap.set(handlerName, handler);
+        });
     }
 
-    this.logger.error(`No handler registered for command ${command.constructor.name}. Did you forget to register`)
+    public async handle(command: Command): Promise<any> {
+        const handler = this.handlersMap.get(command.constructor.name);
+        if (handler !== undefined) {
+            this.logger.info(`Handling command ${command.constructor.name}`);
+            return await handler.handle(command);
+        }
 
-    throw new Error(
-        `No handler registered for command ${command.constructor.name}. Did you forget to register it?`
-    )
-  }
+        this.logger.error(
+            `No handler registered for command ${command.constructor.name}. Did you forget to register`,
+        );
+
+        throw new Error(
+            `No handler registered for command ${command.constructor.name}. Did you forget to register it?`,
+        );
+    }
 }

--- a/discord-bot/src/Infrastructure/Community/Discord/DiscordChannels.ts
+++ b/discord-bot/src/Infrastructure/Community/Discord/DiscordChannels.ts
@@ -1,4 +1,4 @@
-import {CommunityChannels} from "../../../Domain/Community/CommunityChannels.ts";
+import { CommunityChannels } from '../../../Domain/Community/CommunityChannels.ts';
 
 export enum DiscordChannels {
     SCREENSHOTS = '827646847483904040',
@@ -9,4 +9,4 @@ export const convertChannel = (channel: CommunityChannels): DiscordChannels => {
         case CommunityChannels.SCREENSHOTS:
             return DiscordChannels.SCREENSHOTS;
     }
-}
+};

--- a/discord-bot/src/Infrastructure/Community/Discord/DiscordEmoji.ts
+++ b/discord-bot/src/Infrastructure/Community/Discord/DiscordEmoji.ts
@@ -1,4 +1,4 @@
-import {CustomEmoji} from "../../../Domain/Community/CustomEmoji.ts";
+import { CustomEmoji } from '../../../Domain/Community/CustomEmoji.ts';
 
 export enum DiscordEmoji {
     TROPHY_PLAT = '820982755927392297',
@@ -18,4 +18,4 @@ export const convertEmoji = (emoji: CustomEmoji): DiscordEmoji => {
         case CustomEmoji.TROPHY_BRONZE:
             return DiscordEmoji.TROPHY_BRONZE;
     }
-}
+};

--- a/discord-bot/src/Infrastructure/Community/Discord/DiscordGuildClient.ts
+++ b/discord-bot/src/Infrastructure/Community/Discord/DiscordGuildClient.ts
@@ -1,27 +1,29 @@
-import type {GuildClient} from "../../../Domain/Community/GuildClient.ts";
-import {injectable} from "inversify";
-import {Client, type Message, TextChannel} from 'discord.js';
-import {CommunityChannels} from "../../../Domain/Community/CommunityChannels.ts";
-import {CustomEmoji} from "../../../Domain/Community/CustomEmoji.ts";
-import {convertChannel} from "./DiscordChannels.ts";
-import {convertEmoji} from "./DiscordEmoji.ts";
-import {ClientError} from "../../../Domain/Community/ClientError.ts";
+import type { GuildClient } from '../../../Domain/Community/GuildClient.ts';
+import { injectable } from 'inversify';
+import { Client, type Message, TextChannel } from 'discord.js';
+import { CommunityChannels } from '../../../Domain/Community/CommunityChannels.ts';
+import { CustomEmoji } from '../../../Domain/Community/CustomEmoji.ts';
+import { convertChannel } from './DiscordChannels.ts';
+import { convertEmoji } from './DiscordEmoji.ts';
+import { ClientError } from '../../../Domain/Community/ClientError.ts';
 
 @injectable()
 export class DiscordGuildClient implements GuildClient {
-    private client: Client|undefined = undefined;
+    private client: Client | undefined = undefined;
 
-    constructor(
-        private readonly token: string,
-    ) {
-    }
+    constructor(private readonly token: string) {}
 
-    async getTotalReactionsByEmoji(channel: CommunityChannels, messageId: string, emoji: CustomEmoji): Promise<number> {
+    async getTotalReactionsByEmoji(
+        channel: CommunityChannels,
+        messageId: string,
+        emoji: CustomEmoji,
+    ): Promise<number> {
         const discordEmoji = convertEmoji(emoji);
 
         const message = await this.getMessage(channel, messageId);
-        const reactions = message.reactions.cache
-            .filter(reaction => reaction.emoji.id === discordEmoji);
+        const reactions = message.reactions.cache.filter(
+            (reaction) => reaction.emoji.id === discordEmoji,
+        );
         const reaction = reactions.first();
         if (!reaction) {
             throw new ClientError('Reaction not found');
@@ -49,14 +51,14 @@ export class DiscordGuildClient implements GuildClient {
 
     private async getMessage(channel: CommunityChannels, messageId: string): Promise<Message> {
         const client = await this.getClient();
-        const discordChannel = await client.channels.fetch(convertChannel(channel))
+        const discordChannel = await client.channels.fetch(convertChannel(channel));
 
         if (!discordChannel?.isTextBased()) {
-            throw new ClientError('Channel not found or is not a text channel')
+            throw new ClientError('Channel not found or is not a text channel');
         }
         const message = await discordChannel.messages.fetch(messageId);
         if (!message) {
-            throw new ClientError('Message not found')
+            throw new ClientError('Message not found');
         }
 
         return message;

--- a/discord-bot/src/Infrastructure/DependencyInjection/inversify.config.ts
+++ b/discord-bot/src/Infrastructure/DependencyInjection/inversify.config.ts
@@ -1,141 +1,144 @@
-import 'reflect-metadata'
-import { Container } from 'inversify'
-import CommandHandlerManager from '../CommandHandler/CommandHandlerManager'
-import { TYPES } from './types'
-import { PrismaClient } from '@prisma/client'
-import ConsoleLogProvider from '../Logger/ConsoleLogProvider'
-import LoggerManager from '../../Application/Logger/LoggerManager'
-import {isEmpty} from "../../Application/Shared/StringTools.ts";
-import LokiLogProvider from '../Logger/LokiLogProvider.ts'
-import type Logger from '../../Application/Logger/Logger.ts'
-import EventDispatcher from "../../Application/Event/EventDispatcher/EventDispatcher.ts";
-import type {HttpClient} from "../../Domain/Http/HttpClient.ts";
-import RetryAxiosHttpClient from "../Http/RetryAxiosHttpClient.ts";
-import AxiosHttpClient from "../Http/AxiosHttpClient.ts";
-import {PingHandler} from "../../Application/Query/Ping/PingHandler.ts";
-import {DiscordBot} from "../Bot/Discord/DiscordBot.ts";
-import {BotExecutor} from "../Bot/BotExecutor.ts";
-import {PingSlashCommand} from "../Bot/Discord/SlashCommand/PingSlashCommand.ts";
-import {ScreenshotSlashCommand} from "../Bot/Discord/SlashCommand/Screenshot/ScreenshotSlashCommand.ts";
-import {CreateScreenshotHandler} from "../../Application/Write/Screenshot/CreateScreenshot/CreateScreenshotHandler.ts";
-import OrmScreenshotRepository from "../Orm/OrmScreenshotRepository.ts";
-import {GetScreenshotsHandler} from "../../Application/Query/Screenshot/GetScreenshots/GetScreenshotsHandler.ts";
-import {DeleteScreenshotHandler} from "../../Application/Write/Screenshot/DeleteScreenshot/DeleteScreenshotHandler.ts";
-import {ListScreenshotSubcommand} from "../Bot/Discord/SlashCommand/Screenshot/ListScreenshotSubcommand.ts";
-import {CreateScreenshotSubcommand} from "../Bot/Discord/SlashCommand/Screenshot/CreateScreenshotSubcommand.ts";
-import {DeleteScreenshotSubcommand} from "../Bot/Discord/SlashCommand/Screenshot/DeleteScreenshotSubcommand.ts";
-import {OrmTrophyRepository} from "../Orm/OrmTrophyRepository.ts";
-import {OrmTrophyProfileRepository} from "../Orm/OrmTrophyProfileRepository.ts";
-import {CreateProfileHandler} from "../../Application/Write/Trophy/CreateProfile/CreateProfileHandler.ts";
-import {TrophySlashCommand} from "../Bot/Discord/SlashCommand/Trophy/TrophySlashCommand.ts";
-import {CreateTrophyProfileSubcommand} from "../Bot/Discord/SlashCommand/Trophy/CreateTrophyProfileSubcommand.ts";
-import {GetProfileHandler} from "../../Application/Query/Trophy/GetProfile/GetProfileHandler.ts";
-import {CheckTrophyProfileSubcommand} from "../Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.ts";
-import {GetRankHandler} from "../../Application/Query/Trophy/GetRank/GetRankHandler.ts";
-import {RankSubcommand} from "../Bot/Discord/SlashCommand/Trophy/RankSubcommand.ts";
-import { OrmAdRepository } from "../Orm/OrmAdRepository.ts";
-import type { AdRepository } from "../../Domain/Marketplace/AdRepository.ts";
-import { CreateAdHandler } from "../../Application/Write/Marketplace/CreateAd/CreateAdHandler.ts";
-import { DeleteAdHandler } from "../../Application/Write/Marketplace/DeleteAd/DeleteAdHandler.ts";
-import { DeleteAdSubcommand } from "../Bot/Discord/SlashCommand/Marketplace/DeleteAdSubcommand.ts";
-import { MarketplaceSlashCommand } from "../Bot/Discord/SlashCommand/Marketplace/MarketplaceSlashCommand.ts";
-import { SellSubcommand } from "../Bot/Discord/SlashCommand/Marketplace/SellSubcommand.ts";
-import { ListUserAdsHandler } from "../../Application/Query/Marketplace/ListUserAds/ListUserAdsHandler";
-import { ListAdsSubcommand } from "../Bot/Discord/SlashCommand/Marketplace/ListAdsSubcommand";
-import { GetScreenshotWinnerHandler } from "../../Application/Query/Screenshot/GetScreenshotWinner/GetScreenshotWinnerHandler";
-import type {GuildClient} from "../../Domain/Community/GuildClient.ts";
-import {DiscordGuildClient} from "../Community/Discord/DiscordGuildClient.ts";
-import WeekScreenshotWinner from "../../Ui/Cli/WeekScreenshotWinner.ts";
-import {InMemoryClient} from "../Bot/InMemory/InMemoryClient.ts";
+import 'reflect-metadata';
+import { Container } from 'inversify';
+import CommandHandlerManager from '../CommandHandler/CommandHandlerManager';
+import { TYPES } from './types';
+import { PrismaClient } from '@prisma/client';
+import ConsoleLogProvider from '../Logger/ConsoleLogProvider';
+import LoggerManager from '../../Application/Logger/LoggerManager';
+import { isEmpty } from '../../Application/Shared/StringTools.ts';
+import LokiLogProvider from '../Logger/LokiLogProvider.ts';
+import type Logger from '../../Application/Logger/Logger.ts';
+import EventDispatcher from '../../Application/Event/EventDispatcher/EventDispatcher.ts';
+import type { HttpClient } from '../../Domain/Http/HttpClient.ts';
+import RetryAxiosHttpClient from '../Http/RetryAxiosHttpClient.ts';
+import AxiosHttpClient from '../Http/AxiosHttpClient.ts';
+import { PingHandler } from '../../Application/Query/Ping/PingHandler.ts';
+import { DiscordBot } from '../Bot/Discord/DiscordBot.ts';
+import { BotExecutor } from '../Bot/BotExecutor.ts';
+import { PingSlashCommand } from '../Bot/Discord/SlashCommand/PingSlashCommand.ts';
+import { ScreenshotSlashCommand } from '../Bot/Discord/SlashCommand/Screenshot/ScreenshotSlashCommand.ts';
+import { CreateScreenshotHandler } from '../../Application/Write/Screenshot/CreateScreenshot/CreateScreenshotHandler.ts';
+import OrmScreenshotRepository from '../Orm/OrmScreenshotRepository.ts';
+import { GetScreenshotsHandler } from '../../Application/Query/Screenshot/GetScreenshots/GetScreenshotsHandler.ts';
+import { DeleteScreenshotHandler } from '../../Application/Write/Screenshot/DeleteScreenshot/DeleteScreenshotHandler.ts';
+import { ListScreenshotSubcommand } from '../Bot/Discord/SlashCommand/Screenshot/ListScreenshotSubcommand.ts';
+import { CreateScreenshotSubcommand } from '../Bot/Discord/SlashCommand/Screenshot/CreateScreenshotSubcommand.ts';
+import { DeleteScreenshotSubcommand } from '../Bot/Discord/SlashCommand/Screenshot/DeleteScreenshotSubcommand.ts';
+import { OrmTrophyRepository } from '../Orm/OrmTrophyRepository.ts';
+import { OrmTrophyProfileRepository } from '../Orm/OrmTrophyProfileRepository.ts';
+import { CreateProfileHandler } from '../../Application/Write/Trophy/CreateProfile/CreateProfileHandler.ts';
+import { TrophySlashCommand } from '../Bot/Discord/SlashCommand/Trophy/TrophySlashCommand.ts';
+import { CreateTrophyProfileSubcommand } from '../Bot/Discord/SlashCommand/Trophy/CreateTrophyProfileSubcommand.ts';
+import { GetProfileHandler } from '../../Application/Query/Trophy/GetProfile/GetProfileHandler.ts';
+import { CheckTrophyProfileSubcommand } from '../Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.ts';
+import { GetRankHandler } from '../../Application/Query/Trophy/GetRank/GetRankHandler.ts';
+import { RankSubcommand } from '../Bot/Discord/SlashCommand/Trophy/RankSubcommand.ts';
+import { OrmAdRepository } from '../Orm/OrmAdRepository.ts';
+import type { AdRepository } from '../../Domain/Marketplace/AdRepository.ts';
+import { CreateAdHandler } from '../../Application/Write/Marketplace/CreateAd/CreateAdHandler.ts';
+import { DeleteAdHandler } from '../../Application/Write/Marketplace/DeleteAd/DeleteAdHandler.ts';
+import { DeleteAdSubcommand } from '../Bot/Discord/SlashCommand/Marketplace/DeleteAdSubcommand.ts';
+import { MarketplaceSlashCommand } from '../Bot/Discord/SlashCommand/Marketplace/MarketplaceSlashCommand.ts';
+import { SellSubcommand } from '../Bot/Discord/SlashCommand/Marketplace/SellSubcommand.ts';
+import { ListUserAdsHandler } from '../../Application/Query/Marketplace/ListUserAds/ListUserAdsHandler';
+import { ListAdsSubcommand } from '../Bot/Discord/SlashCommand/Marketplace/ListAdsSubcommand';
+import { GetScreenshotWinnerHandler } from '../../Application/Query/Screenshot/GetScreenshotWinner/GetScreenshotWinnerHandler';
+import type { GuildClient } from '../../Domain/Community/GuildClient.ts';
+import { DiscordGuildClient } from '../Community/Discord/DiscordGuildClient.ts';
+import WeekScreenshotWinner from '../../Ui/Cli/WeekScreenshotWinner.ts';
+import { InMemoryClient } from '../Bot/InMemory/InMemoryClient.ts';
 
-const myContainer = new Container()
+const myContainer = new Container();
 
 // Logger
-myContainer.bind(ConsoleLogProvider).toSelf()
+myContainer.bind(ConsoleLogProvider).toSelf();
 
-const loggerManager = new LoggerManager()
-loggerManager.addProvider(myContainer.get(ConsoleLogProvider))
+const loggerManager = new LoggerManager();
+loggerManager.addProvider(myContainer.get(ConsoleLogProvider));
 if (!isEmpty(process.env.LOKI_HOST)) {
-  loggerManager.addProvider(new LokiLogProvider(
-    String(process.env.LOKI_HOST),
-    isEmpty(process.env.LOKI_AUTH) ? undefined : String(process.env.LOKI_AUTH)
-  ))
+    loggerManager.addProvider(
+        new LokiLogProvider(
+            String(process.env.LOKI_HOST),
+            isEmpty(process.env.LOKI_AUTH) ? undefined : String(process.env.LOKI_AUTH),
+        ),
+    );
 }
-myContainer.bind<Logger>(TYPES.Logger).toConstantValue(loggerManager.createLogger({}))
+myContainer.bind<Logger>(TYPES.Logger).toConstantValue(loggerManager.createLogger({}));
 
 // Repositories
-myContainer.bind<PrismaClient>(TYPES.OrmClient).toConstantValue(new PrismaClient())
-myContainer.bind(TYPES.ScreenshotRepository).to(OrmScreenshotRepository).inSingletonScope()
-myContainer.bind(TYPES.TrophyRepository).to(OrmTrophyRepository).inSingletonScope()
-myContainer.bind(TYPES.TrophyProfileRepository).to(OrmTrophyProfileRepository).inSingletonScope()
-myContainer.bind<AdRepository>(TYPES.AdRepository).to(OrmAdRepository).inSingletonScope()
+myContainer.bind<PrismaClient>(TYPES.OrmClient).toConstantValue(new PrismaClient());
+myContainer.bind(TYPES.ScreenshotRepository).to(OrmScreenshotRepository).inSingletonScope();
+myContainer.bind(TYPES.TrophyRepository).to(OrmTrophyRepository).inSingletonScope();
+myContainer.bind(TYPES.TrophyProfileRepository).to(OrmTrophyProfileRepository).inSingletonScope();
+myContainer.bind<AdRepository>(TYPES.AdRepository).to(OrmAdRepository).inSingletonScope();
 
 // Command Handlers
-myContainer.bind(TYPES.CommandHandler).to(PingHandler)
-myContainer.bind(TYPES.CommandHandler).to(CreateScreenshotHandler)
-myContainer.bind(TYPES.CommandHandler).to(GetScreenshotsHandler)
-myContainer.bind(TYPES.CommandHandler).to(DeleteScreenshotHandler)
-myContainer.bind(TYPES.CommandHandler).to(CreateProfileHandler)
-myContainer.bind(TYPES.CommandHandler).to(GetProfileHandler)
-myContainer.bind(TYPES.CommandHandler).to(GetRankHandler)
-myContainer.bind(TYPES.CommandHandler).to(CreateAdHandler)
-myContainer.bind(TYPES.CommandHandler).to(ListUserAdsHandler)
-myContainer.bind(TYPES.CommandHandler).to(DeleteAdHandler)
-myContainer.bind(TYPES.CommandHandler).to(GetScreenshotWinnerHandler)
+myContainer.bind(TYPES.CommandHandler).to(PingHandler);
+myContainer.bind(TYPES.CommandHandler).to(CreateScreenshotHandler);
+myContainer.bind(TYPES.CommandHandler).to(GetScreenshotsHandler);
+myContainer.bind(TYPES.CommandHandler).to(DeleteScreenshotHandler);
+myContainer.bind(TYPES.CommandHandler).to(CreateProfileHandler);
+myContainer.bind(TYPES.CommandHandler).to(GetProfileHandler);
+myContainer.bind(TYPES.CommandHandler).to(GetRankHandler);
+myContainer.bind(TYPES.CommandHandler).to(CreateAdHandler);
+myContainer.bind(TYPES.CommandHandler).to(ListUserAdsHandler);
+myContainer.bind(TYPES.CommandHandler).to(DeleteAdHandler);
+myContainer.bind(TYPES.CommandHandler).to(GetScreenshotWinnerHandler);
 
 // Slash Commands
-myContainer.bind(TYPES.SlashCommandHandler).to(PingSlashCommand)
-myContainer.bind(TYPES.SlashCommandHandler).to(ScreenshotSlashCommand)
-myContainer.bind(TYPES.SlashCommandHandler).to(TrophySlashCommand)
-myContainer.bind(TYPES.SlashCommandHandler).to(MarketplaceSlashCommand)
+myContainer.bind(TYPES.SlashCommandHandler).to(PingSlashCommand);
+myContainer.bind(TYPES.SlashCommandHandler).to(ScreenshotSlashCommand);
+myContainer.bind(TYPES.SlashCommandHandler).to(TrophySlashCommand);
+myContainer.bind(TYPES.SlashCommandHandler).to(MarketplaceSlashCommand);
 
 // Subcommands
-myContainer.bind(CreateScreenshotSubcommand).toSelf()
-myContainer.bind(ListScreenshotSubcommand).toSelf()
-myContainer.bind(DeleteScreenshotSubcommand).toSelf()
-myContainer.bind(CreateTrophyProfileSubcommand).toSelf()
-myContainer.bind(CheckTrophyProfileSubcommand).toSelf()
-myContainer.bind(RankSubcommand).toSelf()
-myContainer.bind(SellSubcommand).toSelf()
-myContainer.bind(ListAdsSubcommand).toSelf()
-myContainer.bind(DeleteAdSubcommand).toSelf()
+myContainer.bind(CreateScreenshotSubcommand).toSelf();
+myContainer.bind(ListScreenshotSubcommand).toSelf();
+myContainer.bind(DeleteScreenshotSubcommand).toSelf();
+myContainer.bind(CreateTrophyProfileSubcommand).toSelf();
+myContainer.bind(CheckTrophyProfileSubcommand).toSelf();
+myContainer.bind(RankSubcommand).toSelf();
+myContainer.bind(SellSubcommand).toSelf();
+myContainer.bind(ListAdsSubcommand).toSelf();
+myContainer.bind(DeleteAdSubcommand).toSelf();
 
 // Writes
-myContainer.bind<CommandHandlerManager>(CommandHandlerManager).toSelf()
+myContainer.bind<CommandHandlerManager>(CommandHandlerManager).toSelf();
 
 // Events
 // myContainer.bind(TYPES.EventHandler).to(OnCartsItemsUpdatedHandler)
-myContainer.bind<EventDispatcher>(EventDispatcher).toSelf()
+myContainer.bind<EventDispatcher>(EventDispatcher).toSelf();
 
 // Factories
 
 // Security
 
 // Services
-myContainer.bind(AxiosHttpClient).toSelf()
-myContainer.bind(RetryAxiosHttpClient).toSelf()
-myContainer.bind<HttpClient>(TYPES.HttpClient).to(RetryAxiosHttpClient)
+myContainer.bind(AxiosHttpClient).toSelf();
+myContainer.bind(RetryAxiosHttpClient).toSelf();
+myContainer.bind<HttpClient>(TYPES.HttpClient).to(RetryAxiosHttpClient);
 
 // Bot
-myContainer.bind<GuildClient>(TYPES.GuildClient).toConstantValue(
-    new DiscordGuildClient(
-        process.env.DISCORD_TOKEN ?? '',
-    )
-)
-myContainer.bind(BotExecutor).toSelf()
+myContainer
+    .bind<GuildClient>(TYPES.GuildClient)
+    .toConstantValue(new DiscordGuildClient(process.env.DISCORD_TOKEN ?? ''));
+myContainer.bind(BotExecutor).toSelf();
 if (process.env.DISCORD_TOKEN) {
-    myContainer.bind(TYPES.Bot).toConstantValue(new DiscordBot(
-        process.env.DISCORD_TOKEN ?? '',
-        process.env.DISCORD_CLIENT_ID ?? '',
-        myContainer.get(TYPES.Logger),
-        myContainer.get(BotExecutor)
-    ))
+    myContainer
+        .bind(TYPES.Bot)
+        .toConstantValue(
+            new DiscordBot(
+                process.env.DISCORD_TOKEN ?? '',
+                process.env.DISCORD_CLIENT_ID ?? '',
+                myContainer.get(TYPES.Logger),
+                myContainer.get(BotExecutor),
+            ),
+        );
 } else {
-    myContainer.bind(TYPES.Bot).toConstantValue(new InMemoryClient())
+    myContainer.bind(TYPES.Bot).toConstantValue(new InMemoryClient());
 }
 
-
 // Console Command
-myContainer.bind(WeekScreenshotWinner).toSelf()
+myContainer.bind(WeekScreenshotWinner).toSelf();
 
-export { myContainer }
+export { myContainer };

--- a/discord-bot/src/Infrastructure/DependencyInjection/types.ts
+++ b/discord-bot/src/Infrastructure/DependencyInjection/types.ts
@@ -1,28 +1,28 @@
 const TYPES = {
-  // Generics
-  CommandHandler: Symbol.for('CommandHandler'),
-  EventHandler: Symbol.for('EventHandler'),
-  Logger: Symbol.for('Logger'),
-  Bot: Symbol.for('Bot'),
+    // Generics
+    CommandHandler: Symbol.for('CommandHandler'),
+    EventHandler: Symbol.for('EventHandler'),
+    Logger: Symbol.for('Logger'),
+    Bot: Symbol.for('Bot'),
 
-  // Bot
-  MentionHandler: Symbol.for('MentionHandler'),
-  SlashCommandHandler: Symbol.for('SlashCommandHandler'),
+    // Bot
+    MentionHandler: Symbol.for('MentionHandler'),
+    SlashCommandHandler: Symbol.for('SlashCommandHandler'),
 
-  // Security
+    // Security
 
-  // Factories
+    // Factories
 
-  // Repositories
-  ScreenshotRepository: Symbol.for('ScreenshotRepository'),
-  TrophyProfileRepository: Symbol.for('TrophyProfileRepository'),
-  TrophyRepository: Symbol.for('TrophyRepository'),
-  AdRepository: Symbol.for('AdRepository'),
+    // Repositories
+    ScreenshotRepository: Symbol.for('ScreenshotRepository'),
+    TrophyProfileRepository: Symbol.for('TrophyProfileRepository'),
+    TrophyRepository: Symbol.for('TrophyRepository'),
+    AdRepository: Symbol.for('AdRepository'),
 
-  // Clients
-  HttpClient: Symbol.for('HttpClient'),
-  OrmClient: Symbol.for('OrmClient'),
-  GuildClient: Symbol.for('GuildClient'),
-}
+    // Clients
+    HttpClient: Symbol.for('HttpClient'),
+    OrmClient: Symbol.for('OrmClient'),
+    GuildClient: Symbol.for('GuildClient'),
+};
 
-export { TYPES }
+export { TYPES };

--- a/discord-bot/src/Infrastructure/Http/AxiosHttpClient.ts
+++ b/discord-bot/src/Infrastructure/Http/AxiosHttpClient.ts
@@ -19,9 +19,7 @@ export default class AxiosHttpClient implements HttpClient {
     }
 
     async get(url: string, options?: any): Promise<any> {
-        /* eslint-disable @typescript-eslint/no-unsafe-argument */
         return (await this.axios.get(url, options)).data;
-        /* eslint-enable @typescript-eslint/no-unsafe-argument */
     }
 
     async post(url: string, body: any): Promise<any> {

--- a/discord-bot/src/Infrastructure/Http/AxiosHttpClient.ts
+++ b/discord-bot/src/Infrastructure/Http/AxiosHttpClient.ts
@@ -1,38 +1,38 @@
-import { type HttpClient } from '../../Domain/Http/HttpClient'
-import axios, { type AxiosInstance } from 'axios'
-import { injectable } from 'inversify'
-import https from 'https'
-import * as http from 'http'
+import { type HttpClient } from '../../Domain/Http/HttpClient';
+import axios, { type AxiosInstance } from 'axios';
+import { injectable } from 'inversify';
+import https from 'https';
+import * as http from 'http';
 
 @injectable()
 export default class AxiosHttpClient implements HttpClient {
-  private readonly axios: AxiosInstance
+    private readonly axios: AxiosInstance;
 
-  constructor () {
-    this.axios = axios.create({
-      httpsAgent: new https.Agent({
-        rejectUnauthorized: false,
-        checkServerIdentity: () => undefined
-      }),
-      httpAgent: new http.Agent({})
-    })
-  }
+    constructor() {
+        this.axios = axios.create({
+            httpsAgent: new https.Agent({
+                rejectUnauthorized: false,
+                checkServerIdentity: () => undefined,
+            }),
+            httpAgent: new http.Agent({}),
+        });
+    }
 
-  async get (url: string, options?: any): Promise<any> {
-    /* eslint-disable @typescript-eslint/no-unsafe-argument */
-    return (await this.axios.get(url, options)).data
-    /* eslint-enable @typescript-eslint/no-unsafe-argument */
-  }
+    async get(url: string, options?: any): Promise<any> {
+        /* eslint-disable @typescript-eslint/no-unsafe-argument */
+        return (await this.axios.get(url, options)).data;
+        /* eslint-enable @typescript-eslint/no-unsafe-argument */
+    }
 
-  async post (url: string, body: any): Promise<any> {
-    return (await this.axios.post(url, body)).data
-  }
+    async post(url: string, body: any): Promise<any> {
+        return (await this.axios.post(url, body)).data;
+    }
 
-  async put (url: string, body: string): Promise<any> {
-    return (await this.axios.put(url, body)).data
-  }
+    async put(url: string, body: string): Promise<any> {
+        return (await this.axios.put(url, body)).data;
+    }
 
-  async delete (url: string): Promise<any> {
-    return (await this.axios.delete(url)).data
-  }
+    async delete(url: string): Promise<any> {
+        return (await this.axios.delete(url)).data;
+    }
 }

--- a/discord-bot/src/Infrastructure/Http/RetryAxiosHttpClient.ts
+++ b/discord-bot/src/Infrastructure/Http/RetryAxiosHttpClient.ts
@@ -1,90 +1,89 @@
-import { type HttpClient } from '../../Domain/Http/HttpClient'
-import { inject, injectable } from 'inversify'
-import AxiosHttpClient from './AxiosHttpClient'
-import { sleep } from '../../Application/Shared/sleep'
-import { TYPES } from '../DependencyInjection/types'
-import Logger from '../../Application/Logger/Logger'
+import { type HttpClient } from '../../Domain/Http/HttpClient';
+import { inject, injectable } from 'inversify';
+import AxiosHttpClient from './AxiosHttpClient';
+import { sleep } from '../../Application/Shared/sleep';
+import { TYPES } from '../DependencyInjection/types';
+import Logger from '../../Application/Logger/Logger';
 
 @injectable()
 export default class RetryAxiosHttpClient implements HttpClient {
-  constructor (
-    @inject(AxiosHttpClient) private readonly axios: AxiosHttpClient,
-    @inject(TYPES.Logger) private readonly logger: Logger
-  ) {
-  }
+    constructor(
+        @inject(AxiosHttpClient) private readonly axios: AxiosHttpClient,
+        @inject(TYPES.Logger) private readonly logger: Logger,
+    ) {}
 
-  async get (url: string, options?: any, attempt: number = 1): Promise<any> {
-    try {
-      return await this.axios.get(url, options)
-    } catch (error: any) {
-      const sleepMs = attempt ** 2 * 1000
-      this.logger.error(`Retrying ${attempt}, url: ${url}, sleep: ${sleepMs}`, {
-        error_message: error.message,
-        error,
-        url,
-        attempt,
-        sleepMs
-      })
-      if (attempt >= (options?.max_attempts ?? 5)) {
-        throw error
-      }
+    async get(url: string, options?: any, attempt: number = 1): Promise<any> {
+        try {
+            return await this.axios.get(url, options);
+        } catch (error: any) {
+            const sleepMs = attempt ** 2 * 1000;
+            this.logger.error(`Retrying ${attempt}, url: ${url}, sleep: ${sleepMs}`, {
+                error_message: error.message,
+                error,
+                url,
+                attempt,
+                sleepMs,
+            });
+            if (attempt >= (options?.max_attempts ?? 5)) {
+                throw error;
+            }
 
-      await sleep(sleepMs)
-      return await this.get(url, options, attempt + 1)
+            await sleep(sleepMs);
+            return await this.get(url, options, attempt + 1);
+        }
     }
-  }
 
-  async post (url: string, body: any, attempt: number = 1): Promise<any> {
-    try {
-      return await this.axios.post(url, body)
-    } catch (error: any) {
-      this.logger.error('Failed to post', {
-        error_message: error.message,
-        error,
-        url,
-        attempt
-      })
-      if (attempt >= 5) {
-        throw error
-      }
-      await sleep(attempt * 1000)
-      return await this.post(url, body, attempt + 1)
+    async post(url: string, body: any, attempt: number = 1): Promise<any> {
+        try {
+            return await this.axios.post(url, body);
+        } catch (error: any) {
+            this.logger.error('Failed to post', {
+                error_message: error.message,
+                error,
+                url,
+                attempt,
+            });
+            if (attempt >= 5) {
+                throw error;
+            }
+            await sleep(attempt * 1000);
+            return await this.post(url, body, attempt + 1);
+        }
     }
-  }
 
-  async put (url: string, body: string, attempt: number = 1): Promise<any> {
-    try {
-      return await this.axios.put(url, body)
-    } catch (error: any) {
-      this.logger.error('Failed to put', {
-        error_message: error.message,
-        error,
-        url,
-        attempt
-      })
-      if (attempt >= 5) {
-        throw error
-      }
-      await sleep(attempt * 1000)
-      return await this.put(url, body, attempt + 1)
+    async put(url: string, body: string, attempt: number = 1): Promise<any> {
+        try {
+            return await this.axios.put(url, body);
+        } catch (error: any) {
+            this.logger.error('Failed to put', {
+                error_message: error.message,
+                error,
+                url,
+                attempt,
+            });
+            if (attempt >= 5) {
+                throw error;
+            }
+            await sleep(attempt * 1000);
+            return await this.put(url, body, attempt + 1);
+        }
     }
-  }
 
-  async delete (url: string, attempt: number = 1): Promise<any> {
-    try {
-      return await this.axios.delete(url)
-    } catch (error: any) {
-      this.logger.error('Failed to delete', {
-        error_message: error.message,
-        error,
-        url,
-        attempt
-      })
-      if (attempt >= 5) {
-        throw error
-      }
-      await sleep(attempt * 1000)
-      return await this.delete(url, attempt + 1)
+    async delete(url: string, attempt: number = 1): Promise<any> {
+        try {
+            return await this.axios.delete(url);
+        } catch (error: any) {
+            this.logger.error('Failed to delete', {
+                error_message: error.message,
+                error,
+                url,
+                attempt,
+            });
+            if (attempt >= 5) {
+                throw error;
+            }
+            await sleep(attempt * 1000);
+            return await this.delete(url, attempt + 1);
+        }
     }
-  }
 }

--- a/discord-bot/src/Infrastructure/Logger/ConsoleLogProvider.ts
+++ b/discord-bot/src/Infrastructure/Logger/ConsoleLogProvider.ts
@@ -1,25 +1,25 @@
-import type LogProviderInterface from '../../Application/Logger/LogProviderInterface'
-import { injectable } from 'inversify'
+import type LogProviderInterface from '../../Application/Logger/LogProviderInterface';
+import { injectable } from 'inversify';
 
 @injectable()
 export default class ConsoleLogProvider implements LogProviderInterface {
-  debug (message: string, context?: Record<string, any>): void {
-    console.debug(message, context)
-  }
+    debug(message: string, context?: Record<string, any>): void {
+        console.debug(message, context);
+    }
 
-  error (message: string, context?: Record<string, any>): void {
-    console.error(message, context)
-  }
+    error(message: string, context?: Record<string, any>): void {
+        console.error(message, context);
+    }
 
-  info (message: string, context?: Record<string, any>): void {
-    console.info(message, context)
-  }
+    info(message: string, context?: Record<string, any>): void {
+        console.info(message, context);
+    }
 
-  log (message: string, context?: Record<string, any>): void {
-    console.log(message, context)
-  }
+    log(message: string, context?: Record<string, any>): void {
+        console.log(message, context);
+    }
 
-  warn (message: string, context?: Record<string, any>): void {
-    console.warn(message, context)
-  }
+    warn(message: string, context?: Record<string, any>): void {
+        console.warn(message, context);
+    }
 }

--- a/discord-bot/src/Infrastructure/Logger/LokiLogProvider.ts
+++ b/discord-bot/src/Infrastructure/Logger/LokiLogProvider.ts
@@ -1,60 +1,62 @@
-import type LogProviderInterface from '../../Application/Logger/LogProviderInterface'
-import LokiTransport from 'winston-loki'
-import winston from 'winston'
+import type LogProviderInterface from '../../Application/Logger/LogProviderInterface';
+import LokiTransport from 'winston-loki';
+import winston from 'winston';
 
 export default class LokiLogProvider implements LogProviderInterface {
-  private readonly logger: winston.Logger
+    private readonly logger: winston.Logger;
 
-  constructor (
-    readonly address: string,
-    readonly basicAuth?: string
-  ) {
-    this.logger = winston.createLogger()
-    this.logger.add(new LokiTransport({
-      host: address,
-      json: true,
-      ...basicAuth !== undefined ? { basicAuth } : {},
-      labels: { job: 'tedcrypto-campaign' }
-    }))
-  }
+    constructor(
+        readonly address: string,
+        readonly basicAuth?: string,
+    ) {
+        this.logger = winston.createLogger();
+        this.logger.add(
+            new LokiTransport({
+                host: address,
+                json: true,
+                ...(basicAuth !== undefined ? { basicAuth } : {}),
+                labels: { job: 'tedcrypto-campaign' },
+            }),
+        );
+    }
 
-  debug (message: string, context?: Record<string, any>): void {
-    this.logger.debug({
-      level: 'debug',
-      message,
-      ...context
-    })
-  }
+    debug(message: string, context?: Record<string, any>): void {
+        this.logger.debug({
+            level: 'debug',
+            message,
+            ...context,
+        });
+    }
 
-  error (message: string, context?: Record<string, any>): void {
-    this.logger.error({
-      level: 'error',
-      message,
-      ...context
-    })
-  }
+    error(message: string, context?: Record<string, any>): void {
+        this.logger.error({
+            level: 'error',
+            message,
+            ...context,
+        });
+    }
 
-  info (message: string, context?: Record<string, any>): void {
-    this.logger.info({
-      level: 'info',
-      message,
-      ...context
-    })
-  }
+    info(message: string, context?: Record<string, any>): void {
+        this.logger.info({
+            level: 'info',
+            message,
+            ...context,
+        });
+    }
 
-  log (message: string, context?: Record<string, any>): void {
-    this.logger.log({
-      level: 'info',
-      message,
-      ...context
-    })
-  }
+    log(message: string, context?: Record<string, any>): void {
+        this.logger.log({
+            level: 'info',
+            message,
+            ...context,
+        });
+    }
 
-  warn (message: string, context?: Record<string, any>): void {
-    this.logger.warn({
-      level: 'warn',
-      message,
-      ...context
-    })
-  }
+    warn(message: string, context?: Record<string, any>): void {
+        this.logger.warn({
+            level: 'warn',
+            message,
+            ...context,
+        });
+    }
 }

--- a/discord-bot/src/Infrastructure/Orm/OrmAdRepository.ts
+++ b/discord-bot/src/Infrastructure/Orm/OrmAdRepository.ts
@@ -1,77 +1,75 @@
-import { inject, injectable } from 'inversify'
-import { PrismaClient } from '@prisma/client'
-import { TYPES } from '../DependencyInjection/types'
-import { Ad, type AdArray } from '../../Domain/Marketplace/Ad'
-import { AdId } from '../../Domain/Marketplace/AdId'
-import type { AdRepository } from '../../Domain/Marketplace/AdRepository'
-import RecordNotFound from '../../Domain/RecordNotFound'
+import { inject, injectable } from 'inversify';
+import { PrismaClient } from '@prisma/client';
+import { TYPES } from '../DependencyInjection/types';
+import { Ad, type AdArray } from '../../Domain/Marketplace/Ad';
+import { AdId } from '../../Domain/Marketplace/AdId';
+import type { AdRepository } from '../../Domain/Marketplace/AdRepository';
+import RecordNotFound from '../../Domain/RecordNotFound';
 
 @injectable()
 export class OrmAdRepository implements AdRepository {
-  constructor(
-    @inject(TYPES.OrmClient) private readonly prismaClient: PrismaClient
-  ) {}
+    constructor(@inject(TYPES.OrmClient) private readonly prismaClient: PrismaClient) {}
 
-  async save(ad: Ad): Promise<void> {
-    await this.prismaClient.ad.upsert({
-      where: { id: ad.id.toString() },
-      update: {
-        name: ad.name,
-        author_id: ad.authorId,
-        channel_id: ad.channelId,
-        message_id: ad.messageId,
-        state: ad.state,
-        price: ad.price,
-        zone: ad.zone,
-        dispatch: ad.dispatch,
-        warranty: ad.warranty,
-        description: ad.description,
-        adType: ad.adType,
-        updatedAt: ad.updatedAt
-      },
-      create: {
-        id: ad.id.toString(),
-        name: ad.name,
-        author_id: ad.authorId,
-        channel_id: ad.channelId,
-        message_id: ad.messageId,
-        state: ad.state,
-        price: ad.price,
-        zone: ad.zone,
-        dispatch: ad.dispatch,
-        warranty: ad.warranty,
-        description: ad.description,
-        adType: ad.adType,
-        createdAt: ad.createdAt,
-        updatedAt: ad.updatedAt
-      }
-    })
-  }
-
-  async get(id: AdId): Promise<Ad> {
-    const ad = await this.prismaClient.ad.findUnique({
-      where: { id: id.toString() }
-    })
-
-    if (ad === null) {
-      throw new RecordNotFound(`Ad with id ${id.toString()} not found`)
+    async save(ad: Ad): Promise<void> {
+        await this.prismaClient.ad.upsert({
+            where: { id: ad.id.toString() },
+            update: {
+                name: ad.name,
+                author_id: ad.authorId,
+                channel_id: ad.channelId,
+                message_id: ad.messageId,
+                state: ad.state,
+                price: ad.price,
+                zone: ad.zone,
+                dispatch: ad.dispatch,
+                warranty: ad.warranty,
+                description: ad.description,
+                adType: ad.adType,
+                updatedAt: ad.updatedAt,
+            },
+            create: {
+                id: ad.id.toString(),
+                name: ad.name,
+                author_id: ad.authorId,
+                channel_id: ad.channelId,
+                message_id: ad.messageId,
+                state: ad.state,
+                price: ad.price,
+                zone: ad.zone,
+                dispatch: ad.dispatch,
+                warranty: ad.warranty,
+                description: ad.description,
+                adType: ad.adType,
+                createdAt: ad.createdAt,
+                updatedAt: ad.updatedAt,
+            },
+        });
     }
 
-    return Ad.fromArray(ad as AdArray)
-  }
+    async get(id: AdId): Promise<Ad> {
+        const ad = await this.prismaClient.ad.findUnique({
+            where: { id: id.toString() },
+        });
 
-  async delete(id: AdId): Promise<void> {
-    await this.prismaClient.ad.delete({
-      where: { id: id.toString() }
-    })
-  }
+        if (ad === null) {
+            throw new RecordNotFound(`Ad with id ${id.toString()} not found`);
+        }
 
-  async findByUserId(userId: string): Promise<Ad[]> {
-    const ads = await this.prismaClient.ad.findMany({
-      where: { author_id: userId },
-      orderBy: { createdAt: 'desc' }
-    })
+        return Ad.fromArray(ad as AdArray);
+    }
 
-    return ads.map(ad => Ad.fromArray(ad as AdArray))
-  }
+    async delete(id: AdId): Promise<void> {
+        await this.prismaClient.ad.delete({
+            where: { id: id.toString() },
+        });
+    }
+
+    async findByUserId(userId: string): Promise<Ad[]> {
+        const ads = await this.prismaClient.ad.findMany({
+            where: { author_id: userId },
+            orderBy: { createdAt: 'desc' },
+        });
+
+        return ads.map((ad) => Ad.fromArray(ad as AdArray));
+    }
 }

--- a/discord-bot/src/Infrastructure/Orm/OrmScreenshotRepository.ts
+++ b/discord-bot/src/Infrastructure/Orm/OrmScreenshotRepository.ts
@@ -1,82 +1,79 @@
-import { PrismaClient } from '@prisma/client'
-import { inject, injectable } from 'inversify'
-import { TYPES } from '../DependencyInjection/types'
-import RecordNotFound from '../../Domain/RecordNotFound'
-import { Screenshot, type ScreenshotArray } from '../../Domain/Screenshot/Screenshot'
-import { ScreenshotId } from '../../Domain/Screenshot/ScreenshotId'
-import type {ScreenshotRepository} from "../../Domain/Screenshot/ScreenshotRepository.ts";
-import dayjs from 'dayjs'
+import { PrismaClient } from '@prisma/client';
+import { inject, injectable } from 'inversify';
+import { TYPES } from '../DependencyInjection/types';
+import RecordNotFound from '../../Domain/RecordNotFound';
+import { Screenshot, type ScreenshotArray } from '../../Domain/Screenshot/Screenshot';
+import { ScreenshotId } from '../../Domain/Screenshot/ScreenshotId';
+import type { ScreenshotRepository } from '../../Domain/Screenshot/ScreenshotRepository.ts';
+import dayjs from 'dayjs';
 
 @injectable()
 export default class OrmScreenshotRepository implements ScreenshotRepository {
-  constructor (
-    @inject(TYPES.OrmClient) private readonly prismaClient: PrismaClient
-  ) {
-  }
+    constructor(@inject(TYPES.OrmClient) private readonly prismaClient: PrismaClient) {}
 
-  async save (screenshot: Screenshot): Promise<void> {
-    await this.prismaClient.screenshot.upsert({
-      where: { id: screenshot.id.toString() },
-      update: screenshot.toArray(),
-      create: screenshot.toArray()
-    })
-  }
-
-  async get (id: ScreenshotId): Promise<Screenshot> {
-    const object = await this.prismaClient.screenshot.findUnique({
-      where: { id: id.toString() }
-    })
-
-    if (object === null) {
-      throw new RecordNotFound(`Screenshot with "${id.toString()}" id not found`)
+    async save(screenshot: Screenshot): Promise<void> {
+        await this.prismaClient.screenshot.upsert({
+            where: { id: screenshot.id.toString() },
+            update: screenshot.toArray(),
+            create: screenshot.toArray(),
+        });
     }
 
-    return Screenshot.fromArray(object as ScreenshotArray)
-  }
+    async get(id: ScreenshotId): Promise<Screenshot> {
+        const object = await this.prismaClient.screenshot.findUnique({
+            where: { id: id.toString() },
+        });
 
-  async delete (id: ScreenshotId): Promise<void> {
-    await this.prismaClient.screenshot.delete({
-      where: { id: id.toString() }
-    })
-  }
-
-  async findByMd5 (md5: string): Promise<Screenshot | null> {
-    const object = await this.prismaClient.screenshot.findFirst({
-      where: { image_md5: md5 }
-    })
-
-    return object !== null ? Screenshot.fromArray(object as ScreenshotArray) : null;
-  }
-
-  async findBy (userId: string | null): Promise<Screenshot[]> {
-    // Build the where clause based on whether userId is provided
-    const where = userId !== null ? { author_id: userId } : {};
-
-    const objects = await this.prismaClient.screenshot.findMany({
-      where,
-      orderBy: { createdAt: 'desc' } // Most recent first
-    })
-
-    // Convert each database object to a Screenshot domain entity
-    return objects.map(object => Screenshot.fromArray(object as ScreenshotArray));
-  }
-
-  async findByWeek(week: Date): Promise<Screenshot[]> {
-    const startOfWeek = dayjs(week).startOf('week').toDate()
-    const endOfWeek = dayjs(week).endOf('week').toDate()
-
-    const screenshots = await this.prismaClient.screenshot.findMany({
-      where: {
-        createdAt: {
-          gte: startOfWeek,
-          lte: endOfWeek
+        if (object === null) {
+            throw new RecordNotFound(`Screenshot with "${id.toString()}" id not found`);
         }
-      },
-      orderBy: {
-        createdAt: 'desc'
-      }
-    })
 
-    return screenshots.map(screenshot => Screenshot.fromArray(screenshot as ScreenshotArray))
-  }
+        return Screenshot.fromArray(object as ScreenshotArray);
+    }
+
+    async delete(id: ScreenshotId): Promise<void> {
+        await this.prismaClient.screenshot.delete({
+            where: { id: id.toString() },
+        });
+    }
+
+    async findByMd5(md5: string): Promise<Screenshot | null> {
+        const object = await this.prismaClient.screenshot.findFirst({
+            where: { image_md5: md5 },
+        });
+
+        return object !== null ? Screenshot.fromArray(object as ScreenshotArray) : null;
+    }
+
+    async findBy(userId: string | null): Promise<Screenshot[]> {
+        // Build the where clause based on whether userId is provided
+        const where = userId !== null ? { author_id: userId } : {};
+
+        const objects = await this.prismaClient.screenshot.findMany({
+            where,
+            orderBy: { createdAt: 'desc' }, // Most recent first
+        });
+
+        // Convert each database object to a Screenshot domain entity
+        return objects.map((object) => Screenshot.fromArray(object as ScreenshotArray));
+    }
+
+    async findByWeek(week: Date): Promise<Screenshot[]> {
+        const startOfWeek = dayjs(week).startOf('week').toDate();
+        const endOfWeek = dayjs(week).endOf('week').toDate();
+
+        const screenshots = await this.prismaClient.screenshot.findMany({
+            where: {
+                createdAt: {
+                    gte: startOfWeek,
+                    lte: endOfWeek,
+                },
+            },
+            orderBy: {
+                createdAt: 'desc',
+            },
+        });
+
+        return screenshots.map((screenshot) => Screenshot.fromArray(screenshot as ScreenshotArray));
+    }
 }

--- a/discord-bot/src/Infrastructure/Orm/OrmTrophyProfileRepository.ts
+++ b/discord-bot/src/Infrastructure/Orm/OrmTrophyProfileRepository.ts
@@ -1,80 +1,78 @@
-import { inject, injectable } from 'inversify'
-import { PrismaClient } from '@prisma/client'
-import { TYPES } from '../DependencyInjection/types'
-import { TrophyProfile, type TrophyProfileArray } from '../../Domain/Trophy/TrophyProfile'
-import { TrophyProfileId } from '../../Domain/Trophy/TrophyProfileId'
-import type {TrophyProfileRepository} from '../../Domain/Trophy/TrophyProfileRepository'
-import RecordNotFound from '../../Domain/RecordNotFound'
+import { inject, injectable } from 'inversify';
+import { PrismaClient } from '@prisma/client';
+import { TYPES } from '../DependencyInjection/types';
+import { TrophyProfile, type TrophyProfileArray } from '../../Domain/Trophy/TrophyProfile';
+import { TrophyProfileId } from '../../Domain/Trophy/TrophyProfileId';
+import type { TrophyProfileRepository } from '../../Domain/Trophy/TrophyProfileRepository';
+import RecordNotFound from '../../Domain/RecordNotFound';
 
 @injectable()
 export class OrmTrophyProfileRepository implements TrophyProfileRepository {
-  constructor(
-    @inject(TYPES.OrmClient) private readonly prismaClient: PrismaClient
-  ) {}
+    constructor(@inject(TYPES.OrmClient) private readonly prismaClient: PrismaClient) {}
 
-  async save(trophyProfile: TrophyProfile): Promise<void> {
-    await this.prismaClient.trophyProfile.upsert({
-      where: { id: trophyProfile.id.toString() },
-      update: {
-        userId: trophyProfile.userId,
-        psnProfile: trophyProfile.psnProfile,
-        isBanned: trophyProfile.isBanned,
-        hasLeft: trophyProfile.hasLeft,
-        isExcluded: trophyProfile.isExcluded,
-        updatedAt: trophyProfile.updatedAt
-      },
-      create: {
-        id: trophyProfile.id.toString(),
-        userId: trophyProfile.userId,
-        psnProfile: trophyProfile.psnProfile,
-        isBanned: trophyProfile.isBanned,
-        hasLeft: trophyProfile.hasLeft,
-        isExcluded: trophyProfile.isExcluded,
-        createdAt: trophyProfile.createdAt,
-        updatedAt: trophyProfile.updatedAt
-      }
-    })
-  }
-
-  async get(id: TrophyProfileId): Promise<TrophyProfile> {
-    const trophyProfile = await this.prismaClient.trophyProfile.findUnique({
-      where: { id: id.toString() }
-    })
-
-    if (trophyProfile === null) {
-      throw new RecordNotFound(`TrophyProfile with id ${id.toString()} not found`)
+    async save(trophyProfile: TrophyProfile): Promise<void> {
+        await this.prismaClient.trophyProfile.upsert({
+            where: { id: trophyProfile.id.toString() },
+            update: {
+                userId: trophyProfile.userId,
+                psnProfile: trophyProfile.psnProfile,
+                isBanned: trophyProfile.isBanned,
+                hasLeft: trophyProfile.hasLeft,
+                isExcluded: trophyProfile.isExcluded,
+                updatedAt: trophyProfile.updatedAt,
+            },
+            create: {
+                id: trophyProfile.id.toString(),
+                userId: trophyProfile.userId,
+                psnProfile: trophyProfile.psnProfile,
+                isBanned: trophyProfile.isBanned,
+                hasLeft: trophyProfile.hasLeft,
+                isExcluded: trophyProfile.isExcluded,
+                createdAt: trophyProfile.createdAt,
+                updatedAt: trophyProfile.updatedAt,
+            },
+        });
     }
 
-    return TrophyProfile.fromArray(trophyProfile as TrophyProfileArray)
-  }
+    async get(id: TrophyProfileId): Promise<TrophyProfile> {
+        const trophyProfile = await this.prismaClient.trophyProfile.findUnique({
+            where: { id: id.toString() },
+        });
 
-  async delete(id: TrophyProfileId): Promise<void> {
-    await this.prismaClient.trophyProfile.delete({
-      where: { id: id.toString() }
-    })
-  }
+        if (trophyProfile === null) {
+            throw new RecordNotFound(`TrophyProfile with id ${id.toString()} not found`);
+        }
 
-  async findByUserId(userId: string): Promise<TrophyProfile | null> {
-    const trophyProfile = await this.prismaClient.trophyProfile.findFirst({
-      where: { userId }
-    })
-
-    if (trophyProfile === null) {
-      return null
+        return TrophyProfile.fromArray(trophyProfile as TrophyProfileArray);
     }
 
-    return TrophyProfile.fromArray(trophyProfile as TrophyProfileArray)
-  }
-
-  async findByPsnProfile(psnProfile: string): Promise<TrophyProfile | null> {
-    const trophyProfile = await this.prismaClient.trophyProfile.findFirst({
-      where: { psnProfile }
-    })
-
-    if (trophyProfile === null) {
-      return null
+    async delete(id: TrophyProfileId): Promise<void> {
+        await this.prismaClient.trophyProfile.delete({
+            where: { id: id.toString() },
+        });
     }
 
-    return TrophyProfile.fromArray(trophyProfile as TrophyProfileArray)
-  }
+    async findByUserId(userId: string): Promise<TrophyProfile | null> {
+        const trophyProfile = await this.prismaClient.trophyProfile.findFirst({
+            where: { userId },
+        });
+
+        if (trophyProfile === null) {
+            return null;
+        }
+
+        return TrophyProfile.fromArray(trophyProfile as TrophyProfileArray);
+    }
+
+    async findByPsnProfile(psnProfile: string): Promise<TrophyProfile | null> {
+        const trophyProfile = await this.prismaClient.trophyProfile.findFirst({
+            where: { psnProfile },
+        });
+
+        if (trophyProfile === null) {
+            return null;
+        }
+
+        return TrophyProfile.fromArray(trophyProfile as TrophyProfileArray);
+    }
 }

--- a/discord-bot/src/Infrastructure/Orm/OrmTrophyRepository.ts
+++ b/discord-bot/src/Infrastructure/Orm/OrmTrophyRepository.ts
@@ -1,257 +1,252 @@
-import {inject, injectable} from 'inversify'
-import {PrismaClient} from '@prisma/client'
-import {TYPES} from '../DependencyInjection/types'
-import {Trophy, type TrophyArray} from '../../Domain/Trophy/Trophy'
-import {TrophyId} from '../../Domain/Trophy/TrophyId'
-import type {TrophyRepository} from '../../Domain/Trophy/TrophyRepository'
-import type {TrophyRankData} from '../../Domain/Trophy/TrophyRankData'
-import type {UserPosition} from '../../Domain/Trophy/UserPosition'
-import RecordNotFound from '../../Domain/RecordNotFound'
+import { inject, injectable } from 'inversify';
+import { PrismaClient } from '@prisma/client';
+import { TYPES } from '../DependencyInjection/types';
+import { Trophy, type TrophyArray } from '../../Domain/Trophy/Trophy';
+import { TrophyId } from '../../Domain/Trophy/TrophyId';
+import type { TrophyRepository } from '../../Domain/Trophy/TrophyRepository';
+import type { TrophyRankData } from '../../Domain/Trophy/TrophyRankData';
+import type { UserPosition } from '../../Domain/Trophy/UserPosition';
+import RecordNotFound from '../../Domain/RecordNotFound';
 
 @injectable()
 export class OrmTrophyRepository implements TrophyRepository {
-  constructor(
-    @inject(TYPES.OrmClient) private readonly prismaClient: PrismaClient
-  ) {}
+    constructor(@inject(TYPES.OrmClient) private readonly prismaClient: PrismaClient) {}
 
-  async save(trophy: Trophy): Promise<void> {
-    await this.prismaClient.trophies.upsert({
-      where: { id: trophy.id.toString() },
-      update: {
-        trophyProfile: trophy.trophyProfile,
-        url: trophy.url,
-        points: trophy.points,
-        completionDate: trophy.completionDate,
-        updatedAt: trophy.updatedAt
-      },
-      create: {
-        id: trophy.id.toString(),
-        trophyProfile: trophy.trophyProfile,
-        url: trophy.url,
-        points: trophy.points,
-        completionDate: trophy.completionDate,
-        createdAt: trophy.createdAt,
-        updatedAt: trophy.updatedAt
-      }
-    })
-  }
-
-  async get(id: TrophyId): Promise<Trophy> {
-    const trophy = await this.prismaClient.trophies.findUnique({
-      where: { id: id.toString() }
-    })
-
-    if (trophy === null) {
-      throw new RecordNotFound(`Trophy with id ${id.toString()} not found`)
-    }
-
-    return Trophy.fromArray(trophy as TrophyArray)
-  }
-
-  async delete(id: TrophyId): Promise<void> {
-    await this.prismaClient.trophies.delete({
-      where: { id: id.toString() }
-    })
-  }
-
-  async findByProfile(profileId: string): Promise<Trophy[]> {
-    const trophies = await this.prismaClient.trophies.findMany({
-      where: { trophyProfile: profileId },
-      orderBy: { completionDate: 'desc' }
-    })
-
-    return trophies.map(trophy => Trophy.fromArray(trophy as TrophyArray))
-  }
-
-  async getTopMonthlyHunters(limit: number, date: Date): Promise<TrophyRankData[]> {
-    const firstDayOfMonth = new Date(date.getFullYear(), date.getMonth(), 1);
-    const lastDayOfMonth = new Date(date.getFullYear(), date.getMonth() + 1, 0, 23, 59, 59);
-
-    const result = await this.prismaClient.trophyProfile.findMany({
-        where: {
-            isExcluded: false,
-            trophies: {
-                some: {
-                    completionDate: {
-                        gte: firstDayOfMonth,
-                        lte: lastDayOfMonth
-                    }
-                }
-            }
-        },
-        include: {
-            trophies: {
-                where: {
-                    completionDate: {
-                        gte: firstDayOfMonth,
-                        lte: lastDayOfMonth
-                    }
-                }
+    async save(trophy: Trophy): Promise<void> {
+        await this.prismaClient.trophies.upsert({
+            where: { id: trophy.id.toString() },
+            update: {
+                trophyProfile: trophy.trophyProfile,
+                url: trophy.url,
+                points: trophy.points,
+                completionDate: trophy.completionDate,
+                updatedAt: trophy.updatedAt,
             },
-            _count: {
-                select: {
-                    trophies: {
-                        where: {
-                            completionDate: {
-                                gte: firstDayOfMonth,
-                                lte: lastDayOfMonth
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        take: limit
-    });
-
-    if (!result.length) {
-        return [];
+            create: {
+                id: trophy.id.toString(),
+                trophyProfile: trophy.trophyProfile,
+                url: trophy.url,
+                points: trophy.points,
+                completionDate: trophy.completionDate,
+                createdAt: trophy.createdAt,
+                updatedAt: trophy.updatedAt,
+            },
+        });
     }
 
-    const mappedResults = result.map(profile => ({
-        userId: profile.userId ?? '',
-        psnProfile: profile.psnProfile ?? '',
-        points: profile.trophies.reduce((sum, trophy) => sum + (trophy.points ?? 0), 0),
-        num_trophies: profile._count.trophies
-    }));
+    async get(id: TrophyId): Promise<Trophy> {
+        const trophy = await this.prismaClient.trophies.findUnique({
+            where: { id: id.toString() },
+        });
 
-    return mappedResults.sort((a, b) => b.points - a.points);
-}
-
-async getTopSinceCreationHunters(limit: number): Promise<TrophyRankData[]> {
-    const result = await this.prismaClient.trophyProfile.findMany({
-        where: {
-            isExcluded: false,
-            trophies: {
-                some: {}
-            }
-        },
-        include: {
-            trophies: true,
-            _count: {
-                select: {
-                    trophies: true
-                }
-            }
-        },
-        take: limit
-    });
-
-    if (!result.length) {
-        return [];
-    }
-
-    const mappedResults = result.map(profile => ({
-        userId: profile.userId ?? '',
-        psnProfile: profile.psnProfile ?? '',
-        points: profile.trophies.reduce((sum, trophy) => sum + (trophy.points ?? 0), 0),
-        num_trophies: profile._count.trophies
-    }));
-
-    return mappedResults.sort((a, b) => b.points - a.points);
-}
-
-async getTopLifetimeHunters(limit: number): Promise<TrophyRankData[]> {
-    const result = await this.prismaClient.trophyProfile.findMany({
-        where: {
-            isExcluded: false,
-            trophies: {
-                some: {}
-            }
-        },
-        include: {
-            trophies: true,
-            _count: {
-                select: {
-                    trophies: true
-                }
-            }
-        },
-        take: limit
-    });
-
-    if (!result.length) {
-        return [];
-    }
-
-    const mappedResults = result.map(profile => ({
-        userId: profile.userId ?? '',
-        psnProfile: profile.psnProfile ?? '',
-        points: profile.trophies.reduce((sum, trophy) => sum + (trophy.points ?? 0), 0),
-        num_trophies: profile._count.trophies
-    }));
-
-    return mappedResults.sort((a, b) => b.points - a.points);
-}
-
-async findUserPosition(userId: string): Promise<UserPosition> {
-    const userProfile = await this.prismaClient.trophyProfile.findFirst({
-        where: {
-            userId,
-            isExcluded: false
-        },
-        include: {
-            trophies: true
+        if (trophy === null) {
+            throw new RecordNotFound(`Trophy with id ${id.toString()} not found`);
         }
-    });
 
-    if (!userProfile) {
+        return Trophy.fromArray(trophy as TrophyArray);
+    }
+
+    async delete(id: TrophyId): Promise<void> {
+        await this.prismaClient.trophies.delete({
+            where: { id: id.toString() },
+        });
+    }
+
+    async findByProfile(profileId: string): Promise<Trophy[]> {
+        const trophies = await this.prismaClient.trophies.findMany({
+            where: { trophyProfile: profileId },
+            orderBy: { completionDate: 'desc' },
+        });
+
+        return trophies.map((trophy) => Trophy.fromArray(trophy as TrophyArray));
+    }
+
+    async getTopMonthlyHunters(limit: number, date: Date): Promise<TrophyRankData[]> {
+        const firstDayOfMonth = new Date(date.getFullYear(), date.getMonth(), 1);
+        const lastDayOfMonth = new Date(date.getFullYear(), date.getMonth() + 1, 0, 23, 59, 59);
+
+        const result = await this.prismaClient.trophyProfile.findMany({
+            where: {
+                isExcluded: false,
+                trophies: {
+                    some: {
+                        completionDate: {
+                            gte: firstDayOfMonth,
+                            lte: lastDayOfMonth,
+                        },
+                    },
+                },
+            },
+            include: {
+                trophies: {
+                    where: {
+                        completionDate: {
+                            gte: firstDayOfMonth,
+                            lte: lastDayOfMonth,
+                        },
+                    },
+                },
+                _count: {
+                    select: {
+                        trophies: {
+                            where: {
+                                completionDate: {
+                                    gte: firstDayOfMonth,
+                                    lte: lastDayOfMonth,
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            take: limit,
+        });
+
+        if (!result.length) {
+            return [];
+        }
+
+        const mappedResults = result.map((profile) => ({
+            userId: profile.userId ?? '',
+            psnProfile: profile.psnProfile ?? '',
+            points: profile.trophies.reduce((sum, trophy) => sum + (trophy.points ?? 0), 0),
+            num_trophies: profile._count.trophies,
+        }));
+
+        return mappedResults.sort((a, b) => b.points - a.points);
+    }
+
+    async getTopSinceCreationHunters(limit: number): Promise<TrophyRankData[]> {
+        const result = await this.prismaClient.trophyProfile.findMany({
+            where: {
+                isExcluded: false,
+                trophies: {
+                    some: {},
+                },
+            },
+            include: {
+                trophies: true,
+                _count: {
+                    select: {
+                        trophies: true,
+                    },
+                },
+            },
+            take: limit,
+        });
+
+        if (!result.length) {
+            return [];
+        }
+
+        const mappedResults = result.map((profile) => ({
+            userId: profile.userId ?? '',
+            psnProfile: profile.psnProfile ?? '',
+            points: profile.trophies.reduce((sum, trophy) => sum + (trophy.points ?? 0), 0),
+            num_trophies: profile._count.trophies,
+        }));
+
+        return mappedResults.sort((a, b) => b.points - a.points);
+    }
+
+    async getTopLifetimeHunters(limit: number): Promise<TrophyRankData[]> {
+        const result = await this.prismaClient.trophyProfile.findMany({
+            where: {
+                isExcluded: false,
+                trophies: {
+                    some: {},
+                },
+            },
+            include: {
+                trophies: true,
+                _count: {
+                    select: {
+                        trophies: true,
+                    },
+                },
+            },
+            take: limit,
+        });
+
+        if (!result.length) {
+            return [];
+        }
+
+        const mappedResults = result.map((profile) => ({
+            userId: profile.userId ?? '',
+            psnProfile: profile.psnProfile ?? '',
+            points: profile.trophies.reduce((sum, trophy) => sum + (trophy.points ?? 0), 0),
+            num_trophies: profile._count.trophies,
+        }));
+
+        return mappedResults.sort((a, b) => b.points - a.points);
+    }
+
+    async findUserPosition(userId: string): Promise<UserPosition> {
+        const userProfile = await this.prismaClient.trophyProfile.findFirst({
+            where: {
+                userId,
+                isExcluded: false,
+            },
+            include: {
+                trophies: true,
+            },
+        });
+
+        if (!userProfile) {
+            return {
+                totalPoints: 0,
+                totalTrophies: 0,
+                ranks: [
+                    { name: 'monthly', position: 0, points: 0, trophies: 0 }, // Monthly
+                    { name: 'creation', position: 0, points: 0, trophies: 0 }, // Creation
+                    { name: 'lifetime', position: 0, points: 0, trophies: 0 }, // Lifetime
+                ],
+            };
+        }
+
+        const firstDayOfMonth = new Date();
+        firstDayOfMonth.setDate(1);
+        firstDayOfMonth.setHours(0, 0, 0, 0);
+
+        const monthlyTrophies = userProfile.trophies.filter(
+            (t) => t.completionDate && t.completionDate >= firstDayOfMonth,
+        );
+        const monthlyPoints = monthlyTrophies.reduce((sum, t) => sum + (t.points ?? 0), 0);
+
+        const allMonthlyProfiles = await this.getTopMonthlyHunters(1000, new Date());
+        const monthlyRank =
+            monthlyPoints > 0 ? allMonthlyProfiles.findIndex((p) => p.userId === userId) + 1 : 0;
+
+        const totalPoints = userProfile.trophies.reduce((sum, t) => sum + (t.points ?? 0), 0);
+
+        const allCreationProfiles = await this.getTopSinceCreationHunters(1000);
+        const creationRank =
+            totalPoints > 0 ? allCreationProfiles.findIndex((p) => p.userId === userId) + 1 : 0;
+
         return {
-            totalPoints: 0,
-            totalTrophies: 0,
+            totalPoints,
+            totalTrophies: userProfile.trophies.length,
             ranks: [
-                { name: 'monthly', position: 0, points: 0, trophies: 0 }, // Monthly
-                { name: 'creation', position: 0, points: 0, trophies: 0 }, // Creation
-                { name: 'lifetime', position: 0, points: 0, trophies: 0 }  // Lifetime
-            ]
+                {
+                    name: 'monthly',
+                    position: monthlyRank,
+                    points: monthlyPoints,
+                    trophies: monthlyTrophies.length,
+                },
+                {
+                    name: 'creation',
+                    position: creationRank,
+                    points: totalPoints,
+                    trophies: userProfile.trophies.length,
+                },
+                {
+                    name: 'lifetime',
+                    position: creationRank, // Same as creation rank for now
+                    points: totalPoints,
+                    trophies: userProfile.trophies.length,
+                },
+            ],
         };
     }
-
-    const firstDayOfMonth = new Date();
-    firstDayOfMonth.setDate(1);
-    firstDayOfMonth.setHours(0, 0, 0, 0);
-
-    const monthlyTrophies = userProfile.trophies.filter(t => 
-        t.completionDate && t.completionDate >= firstDayOfMonth
-    );
-    const monthlyPoints = monthlyTrophies.reduce((sum, t) => sum + (t.points ?? 0), 0);
-
-    const allMonthlyProfiles = await this.getTopMonthlyHunters(1000, new Date());
-    const monthlyRank = monthlyPoints > 0 
-        ? allMonthlyProfiles.findIndex(p => p.userId === userId) + 1 
-        : 0;
-
-    const totalPoints = userProfile.trophies.reduce((sum, t) => sum + (t.points ?? 0), 0);
-
-    const allCreationProfiles = await this.getTopSinceCreationHunters(1000);
-    const creationRank = totalPoints > 0 
-        ? allCreationProfiles.findIndex(p => p.userId === userId) + 1 
-        : 0;
-
-    return {
-        totalPoints,
-        totalTrophies: userProfile.trophies.length,
-        ranks: [
-            {
-                name: 'monthly',
-                position: monthlyRank,
-                points: monthlyPoints,
-                trophies: monthlyTrophies.length
-            },
-            {
-                name: 'creation',
-                position: creationRank,
-                points: totalPoints,
-                trophies: userProfile.trophies.length
-            },
-            {
-                name: 'lifetime',
-                position: creationRank, // Same as creation rank for now
-                points: totalPoints,
-                trophies: userProfile.trophies.length
-            }
-        ]
-    };
-}
-
 }

--- a/discord-bot/src/Ui/Cli/WeekScreenshotWinner.ts
+++ b/discord-bot/src/Ui/Cli/WeekScreenshotWinner.ts
@@ -1,66 +1,67 @@
-import { inject, injectable } from 'inversify'
-import CommandHandlerManager from '../../Infrastructure/CommandHandler/CommandHandlerManager'
-import { GetScreenshotWinner } from '../../Application/Query/Screenshot/GetScreenshotWinner/GetScreenshotWinner'
-import type { ConsoleCommand } from '../../Domain/Console/ConsoleCommand'
-import { TYPES } from '../../Infrastructure/DependencyInjection/types'
-import type { GuildClient } from '../../Domain/Community/GuildClient'
-import { CommunityChannels } from '../../Domain/Community/CommunityChannels'
-import type Logger from '../../Application/Logger/Logger'
+import { inject, injectable } from 'inversify';
+import CommandHandlerManager from '../../Infrastructure/CommandHandler/CommandHandlerManager';
+import { GetScreenshotWinner } from '../../Application/Query/Screenshot/GetScreenshotWinner/GetScreenshotWinner';
+import type { ConsoleCommand } from '../../Domain/Console/ConsoleCommand';
+import { TYPES } from '../../Infrastructure/DependencyInjection/types';
+import type { GuildClient } from '../../Domain/Community/GuildClient';
+import { CommunityChannels } from '../../Domain/Community/CommunityChannels';
+import type Logger from '../../Application/Logger/Logger';
 
 @injectable()
 export default class WeekScreenshotWinner implements ConsoleCommand {
-  public static commandName = 'week-screenshot-winner'
+    public static commandName = 'week-screenshot-winner';
 
-  constructor (
-    @inject(CommandHandlerManager) private readonly commandHandlerManager: CommandHandlerManager,
-    @inject(TYPES.GuildClient) private readonly guildClient: GuildClient,
-    @inject(TYPES.Logger) private readonly logger: Logger
-  ) {}
+    constructor(
+        @inject(CommandHandlerManager)
+        private readonly commandHandlerManager: CommandHandlerManager,
+        @inject(TYPES.GuildClient) private readonly guildClient: GuildClient,
+        @inject(TYPES.Logger) private readonly logger: Logger,
+    ) {}
 
-  configureArgs (inputArgs: any): void {
-  }
+    configureArgs(inputArgs: any): void {}
 
-  public async run (inputArgs: any): Promise<number> {
-    const date = inputArgs[0] === undefined ? new Date() : new Date(inputArgs[0])
-    const dryRun = inputArgs[1] === undefined ? false : inputArgs[1] === 'true'
+    public async run(inputArgs: any): Promise<number> {
+        const date = inputArgs[0] === undefined ? new Date() : new Date(inputArgs[0]);
+        const dryRun = inputArgs[1] === undefined ? false : inputArgs[1] === 'true';
 
-    this.logger.info('Running week screenshot winner command', { date, dryRun })
-    if (dryRun) {
-      this.logger.warn('Dry run enabled')
+        this.logger.info('Running week screenshot winner command', { date, dryRun });
+        if (dryRun) {
+            this.logger.warn('Dry run enabled');
+        }
+
+        const winner = await this.commandHandlerManager.handle(new GetScreenshotWinner(date));
+
+        if (winner === null) {
+            this.logger.info('No winner found for the specified week');
+            return 0;
+        }
+
+        const winnerInfo = {
+            authorId: winner.screenshot.authorId,
+            reactionCount: winner.reactionCount,
+            messageUrl: winner.messageUrl,
+        };
+
+        if (dryRun) {
+            this.logger.info('Dry run - Winner found:', winnerInfo);
+            return 0;
+        }
+
+        // Send message to screenshots channel
+        const message = `🏆 Screenshot of the Week Winner!\n\nCongratulations <@${winner.screenshot.authorId}>!\nYour screenshot received ${winner.reactionCount} reactions!\nCheck it out here: ${winner.messageUrl}`;
+
+        try {
+            await this.guildClient.sendMessage(CommunityChannels.SCREENSHOTS, message);
+            await this.guildClient.sendMessage(
+                CommunityChannels.SCREENSHOTS,
+                `!give-xp <@${winner.screenshot.authorId}> 1000`,
+            );
+            this.logger.info('Winner announcement sent successfully', winnerInfo);
+        } catch (error: any) {
+            this.logger.error('Failed to send winner announcement', { error: error.message });
+            return 1;
+        }
+
+        return 0;
     }
-
-    const winner = await this.commandHandlerManager.handle(
-      new GetScreenshotWinner(date)
-    )
-
-    if (winner === null) {
-      this.logger.info('No winner found for the specified week')
-      return 0
-    }
-
-    const winnerInfo = {
-      authorId: winner.screenshot.authorId,
-      reactionCount: winner.reactionCount,
-      messageUrl: winner.messageUrl
-    }
-
-    if (dryRun) {
-      this.logger.info('Dry run - Winner found:', winnerInfo)
-      return 0
-    }
-
-    // Send message to screenshots channel
-    const message = `🏆 Screenshot of the Week Winner!\n\nCongratulations <@${winner.screenshot.authorId}>!\nYour screenshot received ${winner.reactionCount} reactions!\nCheck it out here: ${winner.messageUrl}`
-    
-    try {
-      await this.guildClient.sendMessage(CommunityChannels.SCREENSHOTS, message)
-      await this.guildClient.sendMessage(CommunityChannels.SCREENSHOTS, `!give-xp <@${winner.screenshot.authorId}> 1000`)
-      this.logger.info('Winner announcement sent successfully', winnerInfo)
-    } catch (error: any) {
-      this.logger.error('Failed to send winner announcement', { error: error.message })
-      return 1
-    }
-
-    return 0
-  }
 }

--- a/discord-bot/src/index.ts
+++ b/discord-bot/src/index.ts
@@ -1,7 +1,7 @@
-import {myContainer} from "./Infrastructure/DependencyInjection/inversify.config";
-import type {Bot} from "./Domain/Bot/Bot.ts";
-import type Logger from "./Application/Logger/Logger";
-import {TYPES} from "./Infrastructure/DependencyInjection/types.ts";
+import { myContainer } from './Infrastructure/DependencyInjection/inversify.config';
+import type { Bot } from './Domain/Bot/Bot.ts';
+import type Logger from './Application/Logger/Logger';
+import { TYPES } from './Infrastructure/DependencyInjection/types.ts';
 
 const logger = myContainer.get<Logger>(TYPES.Logger);
 const app = myContainer.get<Bot>(TYPES.Bot);
@@ -12,6 +12,6 @@ const app = myContainer.get<Bot>(TYPES.Bot);
         await app.start();
         logger.info('⚡️ Discord Bot app is running!');
     } catch (error) {
-        logger.error('Error starting app:', {error});
+        logger.error('Error starting app:', { error });
     }
 })();

--- a/discord-bot/src/index.ts
+++ b/discord-bot/src/index.ts
@@ -6,7 +6,6 @@ import { TYPES } from './Infrastructure/DependencyInjection/types.ts';
 const logger = myContainer.get<Logger>(TYPES.Logger);
 const app = myContainer.get<Bot>(TYPES.Bot);
 
-// eslint-disable-next-line @typescript-eslint/no-floating-promises -- cuz we want it this way
 (async () => {
     try {
         await app.start();

--- a/discord-bot/tests/Helper/DatabaseUtil.ts
+++ b/discord-bot/tests/Helper/DatabaseUtil.ts
@@ -1,6 +1,6 @@
-import {PrismaClient} from "@prisma/client";
-import {myContainer} from "../../src/Infrastructure/DependencyInjection/inversify.config";
-import {TYPES} from "../../src/Infrastructure/DependencyInjection/types";
+import { PrismaClient } from '@prisma/client';
+import { myContainer } from '../../src/Infrastructure/DependencyInjection/inversify.config';
+import { TYPES } from '../../src/Infrastructure/DependencyInjection/types';
 
 export default class DatabaseUtil {
     public static async truncateAllTables(prismaClient?: PrismaClient) {

--- a/discord-bot/tests/Helper/InMemoryLogger.ts
+++ b/discord-bot/tests/Helper/InMemoryLogger.ts
@@ -1,10 +1,10 @@
-import type LogProviderInterface from "../../src/Application/Logger/LogProviderInterface";
+import type LogProviderInterface from '../../src/Application/Logger/LogProviderInterface';
 
 export default class InMemoryLogger implements LogProviderInterface {
     logs: Record<string, any>[] = [];
 
     hasLog(level: string, message: string) {
-        return this.logs.some(log => log.level === level && log.message === message);
+        return this.logs.some((log) => log.level === level && log.message === message);
     }
 
     info(message: string, context?: Record<string, any>) {

--- a/discord-bot/tests/Helper/StaticFixtures.ts
+++ b/discord-bot/tests/Helper/StaticFixtures.ts
@@ -1,18 +1,18 @@
-import {myContainer} from "../../src/Infrastructure/DependencyInjection/inversify.config";
-import { PrismaClient } from "@prisma/client";
-import {TYPES} from "../../src/Infrastructure/DependencyInjection/types";
-import {ScreenshotId} from "../../src/Domain/Screenshot/ScreenshotId.ts";
-import { Screenshot } from "../../src/Domain/Screenshot/Screenshot.ts";
-import type {ScreenshotRepository} from "../../src/Domain/Screenshot/ScreenshotRepository.ts";
-import { TrophyProfile } from "../../src/Domain/Trophy/TrophyProfile.ts";
-import {TrophyProfileId} from "../../src/Domain/Trophy/TrophyProfileId.ts";
-import type {TrophyProfileRepository} from "../../src/Domain/Trophy/TrophyProfileRepository.ts";
-import {TrophyId} from "../../src/Domain/Trophy/TrophyId.ts";
-import type {TrophyRepository} from "../../src/Domain/Trophy/TrophyRepository.ts";
-import {Trophy} from "../../src/Domain/Trophy/Trophy.ts";
-import { AdId } from "../../src/Domain/Marketplace/AdId.ts";
-import { Ad } from "../../src/Domain/Marketplace/Ad.ts";
-import type { AdRepository } from "../../src/Domain/Marketplace/AdRepository.ts";
+import { myContainer } from '../../src/Infrastructure/DependencyInjection/inversify.config';
+import { PrismaClient } from '@prisma/client';
+import { TYPES } from '../../src/Infrastructure/DependencyInjection/types';
+import { ScreenshotId } from '../../src/Domain/Screenshot/ScreenshotId.ts';
+import { Screenshot } from '../../src/Domain/Screenshot/Screenshot.ts';
+import type { ScreenshotRepository } from '../../src/Domain/Screenshot/ScreenshotRepository.ts';
+import { TrophyProfile } from '../../src/Domain/Trophy/TrophyProfile.ts';
+import { TrophyProfileId } from '../../src/Domain/Trophy/TrophyProfileId.ts';
+import type { TrophyProfileRepository } from '../../src/Domain/Trophy/TrophyProfileRepository.ts';
+import { TrophyId } from '../../src/Domain/Trophy/TrophyId.ts';
+import type { TrophyRepository } from '../../src/Domain/Trophy/TrophyRepository.ts';
+import { Trophy } from '../../src/Domain/Trophy/Trophy.ts';
+import { AdId } from '../../src/Domain/Marketplace/AdId.ts';
+import { Ad } from '../../src/Domain/Marketplace/Ad.ts';
+import type { AdRepository } from '../../src/Domain/Marketplace/AdRepository.ts';
 
 const prismaClient: PrismaClient = myContainer.get(TYPES.OrmClient);
 
@@ -38,7 +38,7 @@ export const createScreenshot = async (
         image ?? 'https://placehold.co/600x400/png',
         imageMd5 ?? '5eb63bbbe01eeed093cb22bb8f5acdc3',
         createdAt ?? new Date(),
-        updatedAt ?? new Date()
+        updatedAt ?? new Date(),
     );
 
     await myContainer.get<ScreenshotRepository>(TYPES.ScreenshotRepository).save(screenshot);
@@ -52,7 +52,7 @@ export const createTrophyProfile = async (
     psnProfile?: string,
     isBanned?: boolean,
     hasLeft?: boolean,
-    isExcluded?: boolean
+    isExcluded?: boolean,
 ): Promise<TrophyProfile> => {
     const trophyProfile = new TrophyProfile(
         id ?? TrophyProfileId.generate(),
@@ -62,10 +62,12 @@ export const createTrophyProfile = async (
         hasLeft ?? false,
         isExcluded ?? false,
         new Date(),
-        new Date()
+        new Date(),
     );
 
-    await myContainer.get<TrophyProfileRepository>(TYPES.TrophyProfileRepository).save(trophyProfile);
+    await myContainer
+        .get<TrophyProfileRepository>(TYPES.TrophyProfileRepository)
+        .save(trophyProfile);
 
     return trophyProfile;
 };
@@ -75,7 +77,7 @@ export const createTrophy = async (
     trophyProfile?: string | TrophyProfile,
     url?: string,
     points?: number,
-    completionDate?: Date
+    completionDate?: Date,
 ): Promise<Trophy> => {
     // Handle trophyProfile parameter
     let profileId: string | null = null;
@@ -93,7 +95,7 @@ export const createTrophy = async (
         points ?? 15,
         completionDate ?? new Date(),
         new Date(),
-        new Date()
+        new Date(),
     );
 
     await myContainer.get<TrophyRepository>(TYPES.TrophyRepository).save(trophy);
@@ -104,17 +106,13 @@ export const createTrophy = async (
 export const createTrophySetup = async (
     userId?: string,
     psnProfile?: string,
-    trophyCount: number = 3
+    trophyCount: number = 3,
 ): Promise<{
-    profile: TrophyProfile,
-    trophies: Trophy[]
+    profile: TrophyProfile;
+    trophies: Trophy[];
 }> => {
     // Create trophy profile
-    const profile = await createTrophyProfile(
-        undefined,
-        userId,
-        psnProfile
-    );
+    const profile = await createTrophyProfile(undefined, userId, psnProfile);
 
     // Create trophies
     const trophies: Trophy[] = [];
@@ -123,15 +121,15 @@ export const createTrophySetup = async (
             undefined,
             profile,
             `https://example.com/trophy${i}.png`,
-            10 + (i * 5), // 10, 15, 20, etc.
-            new Date(Date.now() - (i * 86400000)) // Different dates
+            10 + i * 5, // 10, 15, 20, etc.
+            new Date(Date.now() - i * 86400000), // Different dates
         );
         trophies.push(trophy);
     }
 
     return {
         profile,
-        trophies
+        trophies,
     };
 };
 
@@ -165,7 +163,7 @@ export const createAd = async (
         description ?? 'Test ad description',
         adType ?? 'sale',
         createdAt ?? new Date(),
-        updatedAt ?? new Date()
+        updatedAt ?? new Date(),
     );
 
     await myContainer.get<AdRepository>(TYPES.AdRepository).save(ad);

--- a/discord-bot/tests/Integration/Application/Query/Marketplace/ListUserAds/ListUserAdsHandler.test.ts
+++ b/discord-bot/tests/Integration/Application/Query/Marketplace/ListUserAds/ListUserAdsHandler.test.ts
@@ -3,111 +3,111 @@ import { ListUserAds } from '../../../../../../src/Application/Query/Marketplace
 import { TYPES } from '../../../../../../src/Infrastructure/DependencyInjection/types';
 import CommandHandlerManager from '../../../../../../src/Infrastructure/CommandHandler/CommandHandlerManager';
 import { PrismaClient } from '@prisma/client';
-import { myContainer } from "../../../../../../src/Infrastructure/DependencyInjection/inversify.config";
-import DatabaseUtil from "../../../../../Helper/DatabaseUtil";
-import { createAd } from "../../../../../Helper/StaticFixtures";
-import { Ad } from "../../../../../../src/Domain/Marketplace/Ad";
+import { myContainer } from '../../../../../../src/Infrastructure/DependencyInjection/inversify.config';
+import DatabaseUtil from '../../../../../Helper/DatabaseUtil';
+import { createAd } from '../../../../../Helper/StaticFixtures';
+import { Ad } from '../../../../../../src/Domain/Marketplace/Ad';
 
 describe('ListUserAdsHandler Integration Test', () => {
-  let commandHandlerManager: CommandHandlerManager;
-  let ormClient: PrismaClient;
+    let commandHandlerManager: CommandHandlerManager;
+    let ormClient: PrismaClient;
 
-  beforeEach(async () => {
-    commandHandlerManager = myContainer.get<CommandHandlerManager>(CommandHandlerManager);
-    ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
+    beforeEach(async () => {
+        commandHandlerManager = myContainer.get<CommandHandlerManager>(CommandHandlerManager);
+        ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
 
-    await DatabaseUtil.truncateAllTables();
-  });
+        await DatabaseUtil.truncateAllTables();
+    });
 
-  afterEach(async () => {
-    await ormClient.$disconnect();
-  });
+    afterEach(async () => {
+        await ormClient.$disconnect();
+    });
 
-  test('should return empty array when no ads exist for user', async () => {
-    // Arrange
-    const userId = '123456789012345678';
-    const query = new ListUserAds(userId);
+    test('should return empty array when no ads exist for user', async () => {
+        // Arrange
+        const userId = '123456789012345678';
+        const query = new ListUserAds(userId);
 
-    // Act
-    const result = await commandHandlerManager.handle(query);
+        // Act
+        const result = await commandHandlerManager.handle(query);
 
-    // Assert
-    expect(result).toBeInstanceOf(Array);
-    expect(result).toHaveLength(0);
-  });
+        // Assert
+        expect(result).toBeInstanceOf(Array);
+        expect(result).toHaveLength(0);
+    });
 
-  test('should return only ads for specified user', async () => {
-    // Arrange
-    const userId = '123456789012345678';
-    const differentUserId = '987654321098765432';
-    
-    // Create ads for first user
-    const ad1 = await createAd(undefined, 'PS5', userId);
-    const ad2 = await createAd(undefined, 'Xbox Series X', userId);
+    test('should return only ads for specified user', async () => {
+        // Arrange
+        const userId = '123456789012345678';
+        const differentUserId = '987654321098765432';
 
-    // Create ad for different user
-    await createAd(undefined, 'Nintendo Switch', differentUserId);
+        // Create ads for first user
+        const ad1 = await createAd(undefined, 'PS5', userId);
+        const ad2 = await createAd(undefined, 'Xbox Series X', userId);
 
-    const query = new ListUserAds(userId);
+        // Create ad for different user
+        await createAd(undefined, 'Nintendo Switch', differentUserId);
 
-    // Act
-    const result = await commandHandlerManager.handle(query);
+        const query = new ListUserAds(userId);
 
-    // Assert
-    expect(result).toHaveLength(2);
-    expect(result.map((a: Ad) => a.id.toString())).toContain(ad1.id.toString());
-    expect(result.map((a: Ad) => a.id.toString())).toContain(ad2.id.toString());
-    expect(result.every((a: Ad) => a.authorId === userId)).toBe(true);
-  });
+        // Act
+        const result = await commandHandlerManager.handle(query);
 
-  test('should return ads sorted by creation date', async () => {
-    // Arrange
-    const userId = '123456789012345678';
-    const olderDate = new Date('2024-01-01');
-    const newerDate = new Date('2024-01-02');
+        // Assert
+        expect(result).toHaveLength(2);
+        expect(result.map((a: Ad) => a.id.toString())).toContain(ad1.id.toString());
+        expect(result.map((a: Ad) => a.id.toString())).toContain(ad2.id.toString());
+        expect(result.every((a: Ad) => a.authorId === userId)).toBe(true);
+    });
 
-    const olderAd = await createAd(
-      undefined,
-      'PS5',
-      userId,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      olderDate,
-      olderDate
-    );
+    test('should return ads sorted by creation date', async () => {
+        // Arrange
+        const userId = '123456789012345678';
+        const olderDate = new Date('2024-01-01');
+        const newerDate = new Date('2024-01-02');
 
-    const newerAd = await createAd(
-      undefined,
-      'Xbox Series X',
-      userId,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      newerDate,
-      newerDate
-    );
+        const olderAd = await createAd(
+            undefined,
+            'PS5',
+            userId,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            olderDate,
+            olderDate,
+        );
 
-    const query = new ListUserAds(userId);
+        const newerAd = await createAd(
+            undefined,
+            'Xbox Series X',
+            userId,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            newerDate,
+            newerDate,
+        );
 
-    // Act
-    const result = await commandHandlerManager.handle(query);
+        const query = new ListUserAds(userId);
 
-    // Assert
-    expect(result).toHaveLength(2);
-    expect(result[0].id.toString()).toBe(newerAd.id.toString());
-    expect(result[1].id.toString()).toBe(olderAd.id.toString());
-  });
+        // Act
+        const result = await commandHandlerManager.handle(query);
+
+        // Assert
+        expect(result).toHaveLength(2);
+        expect(result[0].id.toString()).toBe(newerAd.id.toString());
+        expect(result[1].id.toString()).toBe(olderAd.id.toString());
+    });
 });

--- a/discord-bot/tests/Integration/Application/Query/Screenshot/GetScreenshots/GetScreenshotsHandler.test.ts
+++ b/discord-bot/tests/Integration/Application/Query/Screenshot/GetScreenshots/GetScreenshotsHandler.test.ts
@@ -3,127 +3,119 @@ import { GetScreenshots } from '../../../../../../src/Application/Query/Screensh
 import { TYPES } from '../../../../../../src/Infrastructure/DependencyInjection/types';
 import CommandHandlerManager from '../../../../../../src/Infrastructure/CommandHandler/CommandHandlerManager';
 import { PrismaClient } from '@prisma/client';
-import { myContainer } from "../../../../../../src/Infrastructure/DependencyInjection/inversify.config";
-import DatabaseUtil from "../../../../../Helper/DatabaseUtil";
-import { createScreenshot } from "../../../../../Helper/StaticFixtures";
-import { Screenshot } from "../../../../../../src/Domain/Screenshot/Screenshot";
+import { myContainer } from '../../../../../../src/Infrastructure/DependencyInjection/inversify.config';
+import DatabaseUtil from '../../../../../Helper/DatabaseUtil';
+import { createScreenshot } from '../../../../../Helper/StaticFixtures';
+import { Screenshot } from '../../../../../../src/Domain/Screenshot/Screenshot';
 
 describe('GetScreenshotsHandler Integration Test', () => {
-  let commandHandlerManager: CommandHandlerManager;
-  let ormClient: PrismaClient;
+    let commandHandlerManager: CommandHandlerManager;
+    let ormClient: PrismaClient;
 
-  beforeEach(async () => {
-    commandHandlerManager = myContainer.get<CommandHandlerManager>(CommandHandlerManager);
-    ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
+    beforeEach(async () => {
+        commandHandlerManager = myContainer.get<CommandHandlerManager>(CommandHandlerManager);
+        ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
 
-    await DatabaseUtil.truncateAllTables();
-  });
+        await DatabaseUtil.truncateAllTables();
+    });
 
-  afterEach(async () => {
-    await ormClient.$disconnect();
-  });
+    afterEach(async () => {
+        await ormClient.$disconnect();
+    });
 
-  test('should return empty array when no screenshots exist for user', async () => {
-    // Arrange
-    const userId = '123456789012345678';
-    const command = new GetScreenshots(userId);
+    test('should return empty array when no screenshots exist for user', async () => {
+        // Arrange
+        const userId = '123456789012345678';
+        const command = new GetScreenshots(userId);
 
-    // Act
-    const result = await commandHandlerManager.handle(command);
+        // Act
+        const result = await commandHandlerManager.handle(command);
 
-    // Assert
-    expect(result).toBeInstanceOf(Array);
-    expect(result).toHaveLength(0);
-  });
+        // Assert
+        expect(result).toBeInstanceOf(Array);
+        expect(result).toHaveLength(0);
+    });
 
-  test('should return only screenshots for specified user', async () => {
-    // Arrange
-    const userId = '123456789012345678';
-    const differentUserId = '987654321098765432';
-    
-    // Create screenshots for first user
-    const screenshot1 = await createScreenshot();
-    const screenshot2 = await createScreenshot();
+    test('should return only screenshots for specified user', async () => {
+        // Arrange
+        const userId = '123456789012345678';
+        const differentUserId = '987654321098765432';
 
-    // Create screenshot for different user
-    await createScreenshot(
-      undefined,
-      undefined,
-      differentUserId
-    );
+        // Create screenshots for first user
+        const screenshot1 = await createScreenshot();
+        const screenshot2 = await createScreenshot();
 
-    const command = new GetScreenshots(userId);
+        // Create screenshot for different user
+        await createScreenshot(undefined, undefined, differentUserId);
 
-    // Act
-    const result = await commandHandlerManager.handle(command);
+        const command = new GetScreenshots(userId);
 
-    // Assert
-    expect(result).toHaveLength(2);
-    expect(result.map((s: Screenshot) => s.id.toString())).toContain(screenshot1.id.toString());
-    expect(result.map((s: Screenshot) => s.id.toString())).toContain(screenshot2.id.toString());
-    expect(result.every((s: Screenshot) => s.authorId === userId)).toBe(true);
-  });
+        // Act
+        const result = await commandHandlerManager.handle(command);
 
-  test('should return all screenshots when userId is null', async () => {
-    // Arrange
-    const differentUserId = '987654321098765432';
-    
-    // Create screenshots for multiple users
-    const screenshot1 = await createScreenshot(); // Default user
-    const screenshot2 = await createScreenshot(
-      undefined,
-      undefined,
-      differentUserId
-    );
+        // Assert
+        expect(result).toHaveLength(2);
+        expect(result.map((s: Screenshot) => s.id.toString())).toContain(screenshot1.id.toString());
+        expect(result.map((s: Screenshot) => s.id.toString())).toContain(screenshot2.id.toString());
+        expect(result.every((s: Screenshot) => s.authorId === userId)).toBe(true);
+    });
 
-    const command = new GetScreenshots(null);
+    test('should return all screenshots when userId is null', async () => {
+        // Arrange
+        const differentUserId = '987654321098765432';
 
-    // Act
-    const result = await commandHandlerManager.handle(command);
+        // Create screenshots for multiple users
+        const screenshot1 = await createScreenshot(); // Default user
+        const screenshot2 = await createScreenshot(undefined, undefined, differentUserId);
 
-    // Assert
-    expect(result).toHaveLength(2);
-    expect(result.map((s: Screenshot) => s.id.toString())).toContain(screenshot1.id.toString());
-    expect(result.map((s: Screenshot) => s.id.toString())).toContain(screenshot2.id.toString());
-  });
+        const command = new GetScreenshots(null);
 
-  test('should return screenshots sorted by creation date', async () => {
-    // Arrange
-    const olderDate = new Date('2024-01-01');
-    const newerDate = new Date('2024-01-02');
+        // Act
+        const result = await commandHandlerManager.handle(command);
 
-    const screenshot1 = await createScreenshot(
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      olderDate
-    );
+        // Assert
+        expect(result).toHaveLength(2);
+        expect(result.map((s: Screenshot) => s.id.toString())).toContain(screenshot1.id.toString());
+        expect(result.map((s: Screenshot) => s.id.toString())).toContain(screenshot2.id.toString());
+    });
 
-    const screenshot2 = await createScreenshot(
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      newerDate
-    );
+    test('should return screenshots sorted by creation date', async () => {
+        // Arrange
+        const olderDate = new Date('2024-01-01');
+        const newerDate = new Date('2024-01-02');
 
-    const command = new GetScreenshots('123456789012345678');
+        const screenshot1 = await createScreenshot(
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            olderDate,
+        );
 
-    // Act
-    const result = await commandHandlerManager.handle(command);
+        const screenshot2 = await createScreenshot(
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            newerDate,
+        );
 
-    // Assert
-    expect(result).toHaveLength(2);
-    expect(result[0].id.toString()).toBe(screenshot2.id.toString()); // Newer first
-    expect(result[1].id.toString()).toBe(screenshot1.id.toString()); // Older second
-  });
+        const command = new GetScreenshots('123456789012345678');
+
+        // Act
+        const result = await commandHandlerManager.handle(command);
+
+        // Assert
+        expect(result).toHaveLength(2);
+        expect(result[0].id.toString()).toBe(screenshot2.id.toString()); // Newer first
+        expect(result[1].id.toString()).toBe(screenshot1.id.toString()); // Older second
+    });
 });

--- a/discord-bot/tests/Integration/Application/Query/Trophy/GetProfile/GetProfileHandler.test.ts
+++ b/discord-bot/tests/Integration/Application/Query/Trophy/GetProfile/GetProfileHandler.test.ts
@@ -4,9 +4,9 @@ import { ProfileNotFound } from '../../../../../../src/Application/Query/Trophy/
 import { TYPES } from '../../../../../../src/Infrastructure/DependencyInjection/types';
 import CommandHandlerManager from '../../../../../../src/Infrastructure/CommandHandler/CommandHandlerManager';
 import { PrismaClient } from '@prisma/client';
-import { myContainer } from "../../../../../../src/Infrastructure/DependencyInjection/inversify.config";
-import DatabaseUtil from "../../../../../Helper/DatabaseUtil";
-import { createTrophyProfile } from "../../../../../Helper/StaticFixtures";
+import { myContainer } from '../../../../../../src/Infrastructure/DependencyInjection/inversify.config';
+import DatabaseUtil from '../../../../../Helper/DatabaseUtil';
+import { createTrophyProfile } from '../../../../../Helper/StaticFixtures';
 
 describe('GetProfileHandler Integration Test', () => {
     let commandHandlerManager: CommandHandlerManager;
@@ -47,22 +47,17 @@ describe('GetProfileHandler Integration Test', () => {
         const command = new GetProfile(userId);
 
         // Act & Assert
-        await expect(commandHandlerManager.handle(command))
-            .rejects
-            .toThrow(ProfileNotFound);
+        await expect(commandHandlerManager.handle(command)).rejects.toThrow(ProfileNotFound);
     });
 
     test('should return correct profile when multiple profiles exist', async () => {
         // Arrange
         const userId1 = '123456789012345678';
         const userId2 = '987654321098765432';
-        
+
         // Create two profiles
         const profile1 = await createTrophyProfile();
-        await createTrophyProfile(
-            undefined,
-            userId2
-        );
+        await createTrophyProfile(undefined, userId2);
 
         const command = new GetProfile(userId1);
 

--- a/discord-bot/tests/Integration/Application/Query/Trophy/GetRank/GetRankHandler.test.ts
+++ b/discord-bot/tests/Integration/Application/Query/Trophy/GetRank/GetRankHandler.test.ts
@@ -3,11 +3,11 @@ import { GetRank } from '../../../../../../src/Application/Query/Trophy/GetRank/
 import { TYPES } from '../../../../../../src/Infrastructure/DependencyInjection/types';
 import CommandHandlerManager from '../../../../../../src/Infrastructure/CommandHandler/CommandHandlerManager';
 import { PrismaClient } from '@prisma/client';
-import { myContainer } from "../../../../../../src/Infrastructure/DependencyInjection/inversify.config";
-import DatabaseUtil from "../../../../../Helper/DatabaseUtil";
-import { createTrophyProfile, createTrophy } from "../../../../../Helper/StaticFixtures";
-import type { TrophyRankData } from "../../../../../../src/Domain/Trophy/TrophyRankData";
-import type { UserPosition } from "../../../../../../src/Domain/Trophy/UserPosition";
+import { myContainer } from '../../../../../../src/Infrastructure/DependencyInjection/inversify.config';
+import DatabaseUtil from '../../../../../Helper/DatabaseUtil';
+import { createTrophyProfile, createTrophy } from '../../../../../Helper/StaticFixtures';
+import type { TrophyRankData } from '../../../../../../src/Domain/Trophy/TrophyRankData';
+import type { UserPosition } from '../../../../../../src/Domain/Trophy/UserPosition';
 
 describe('GetRankHandler Integration Test', () => {
     let commandHandlerManager: CommandHandlerManager;
@@ -28,7 +28,7 @@ describe('GetRankHandler Integration Test', () => {
         // Arrange
         const profile1 = await createTrophyProfile(undefined, '123456789012345678');
         const profile2 = await createTrophyProfile(undefined, '987654321098765432');
-        
+
         // Create trophies for this month
         await createTrophy(undefined, profile1.id.toString(), undefined, 100);
         await createTrophy(undefined, profile2.id.toString(), undefined, 50);
@@ -36,7 +36,7 @@ describe('GetRankHandler Integration Test', () => {
         const command = new GetRank('monthly', '123', 10);
 
         // Act
-        const result = await commandHandlerManager.handle(command) as TrophyRankData[];
+        const result = (await commandHandlerManager.handle(command)) as TrophyRankData[];
 
         // Assert
         expect(result).toHaveLength(2);
@@ -53,7 +53,7 @@ describe('GetRankHandler Integration Test', () => {
         const command = new GetRank('lifetime', '123', 10);
 
         // Act
-        const result = await commandHandlerManager.handle(command) as TrophyRankData[];
+        const result = (await commandHandlerManager.handle(command)) as TrophyRankData[];
 
         // Assert
         expect(result).toHaveLength(1);
@@ -71,7 +71,7 @@ describe('GetRankHandler Integration Test', () => {
         const command = new GetRank('user', userId, 10);
 
         // Act
-        const result = await commandHandlerManager.handle(command) as UserPosition;
+        const result = (await commandHandlerManager.handle(command)) as UserPosition;
 
         // Assert
         expect(result.totalPoints).toBe(150);
@@ -87,7 +87,7 @@ describe('GetRankHandler Integration Test', () => {
         const command = new GetRank('user', targetUserId, 10, undefined, undefined);
 
         // Act
-        const result = await commandHandlerManager.handle(command) as UserPosition;
+        const result = (await commandHandlerManager.handle(command)) as UserPosition;
 
         // Assert
         expect(result.totalPoints).toBe(200);
@@ -100,7 +100,7 @@ describe('GetRankHandler Integration Test', () => {
         const command = new GetRank('user', userId, 10);
 
         // Act
-        const result = await commandHandlerManager.handle(command) as UserPosition;
+        const result = (await commandHandlerManager.handle(command)) as UserPosition;
 
         // Assert
         expect(result.totalPoints).toBe(0);
@@ -108,7 +108,7 @@ describe('GetRankHandler Integration Test', () => {
         expect(result.ranks).toEqual([
             { name: 'monthly', position: 0, points: 0, trophies: 0 },
             { name: 'creation', position: 0, points: 0, trophies: 0 },
-            { name: 'lifetime', position: 0, points: 0, trophies: 0 }
+            { name: 'lifetime', position: 0, points: 0, trophies: 0 },
         ]);
     });
 
@@ -117,7 +117,7 @@ describe('GetRankHandler Integration Test', () => {
         const command = new GetRank('monthly', '123', 10);
 
         // Act
-        const result = await commandHandlerManager.handle(command) as TrophyRankData[];
+        const result = (await commandHandlerManager.handle(command)) as TrophyRankData[];
 
         // Assert
         expect(result).toHaveLength(0);
@@ -127,11 +127,13 @@ describe('GetRankHandler Integration Test', () => {
         // Create trophies for last month
         const lastMonth = new Date();
         lastMonth.setMonth(lastMonth.getMonth() - 1);
-        
+
         const profile = await createTrophyProfile(undefined, '123456789012345678', 'User1');
         await createTrophy(undefined, profile.id.toString(), undefined, 100, lastMonth);
 
-        const result = await commandHandlerManager.handle(new GetRank('monthly', '123', 10, 'last'));
+        const result = await commandHandlerManager.handle(
+            new GetRank('monthly', '123', 10, 'last'),
+        );
 
         expect(result).toHaveLength(1);
         expect(result[0]?.points).toBe(100);
@@ -141,7 +143,7 @@ describe('GetRankHandler Integration Test', () => {
         // Create trophies for January
         const january = new Date();
         january.setMonth(0); // January is 0-indexed
-        
+
         const profile = await createTrophyProfile(undefined, '987654321098765432', 'User2');
         await createTrophy(undefined, profile.id.toString(), undefined, 100, january);
 
@@ -154,11 +156,13 @@ describe('GetRankHandler Integration Test', () => {
     test('should return monthly rankings for specific month and year', async () => {
         // Create trophies for April 2024
         const april2024 = new Date(2024, 3); // April is 3 (0-indexed)
-        
+
         const profile = await createTrophyProfile(undefined, '111222333444555666', 'User3');
         await createTrophy(undefined, profile.id.toString(), undefined, 150, april2024);
 
-        const result = await commandHandlerManager.handle(new GetRank('monthly', '123', 10, 4, 2024));
+        const result = await commandHandlerManager.handle(
+            new GetRank('monthly', '123', 10, 4, 2024),
+        );
 
         expect(result).toHaveLength(1);
         expect(result[0]?.points).toBe(150);
@@ -167,11 +171,13 @@ describe('GetRankHandler Integration Test', () => {
     test('should return monthly rankings for last month of previous year', async () => {
         // Create trophies for December 2024
         const dec2024 = new Date(2024, 11); // December is 11 (0-indexed)
-        
+
         const profile = await createTrophyProfile(undefined, '777888999000111222', 'User4');
         await createTrophy(undefined, profile.id.toString(), undefined, 200, dec2024);
 
-        const result = await commandHandlerManager.handle(new GetRank('monthly', '123', 10, 12, 2024));
+        const result = await commandHandlerManager.handle(
+            new GetRank('monthly', '123', 10, 12, 2024),
+        );
 
         expect(result).toHaveLength(1);
         expect(result[0]?.points).toBe(200);
@@ -179,7 +185,9 @@ describe('GetRankHandler Integration Test', () => {
 
     test('should return empty rankings for future month and year', async () => {
         // Try to get rankings for December 2025
-        const result = await commandHandlerManager.handle(new GetRank('monthly', '123', 10, 12, 2025));
+        const result = await commandHandlerManager.handle(
+            new GetRank('monthly', '123', 10, 12, 2025),
+        );
 
         expect(Array.isArray(result)).toBe(true);
         expect(result).toHaveLength(0);

--- a/discord-bot/tests/Integration/Application/Write/Marketplace/CreateAd/CreateAdHandler.test.ts
+++ b/discord-bot/tests/Integration/Application/Write/Marketplace/CreateAd/CreateAdHandler.test.ts
@@ -1,67 +1,67 @@
-import {describe, expect, beforeEach, it, afterEach} from 'bun:test';
-import { myContainer } from '../../../../../../src/Infrastructure/DependencyInjection/inversify.config'
-import { TYPES } from '../../../../../../src/Infrastructure/DependencyInjection/types'
-import { CreateAd } from '../../../../../../src/Application/Write/Marketplace/CreateAd/CreateAd'
-import { AdId } from '../../../../../../src/Domain/Marketplace/AdId'
-import DatabaseUtil from "../../../../../Helper/DatabaseUtil.ts";
-import {PrismaClient} from "@prisma/client";
-import CommandHandlerManager from "../../../../../../src/Infrastructure/CommandHandler/CommandHandlerManager";
-import type {AdRepository} from "../../../../../../src/Domain/Marketplace/AdRepository.ts";
+import { describe, expect, beforeEach, it, afterEach } from 'bun:test';
+import { myContainer } from '../../../../../../src/Infrastructure/DependencyInjection/inversify.config';
+import { TYPES } from '../../../../../../src/Infrastructure/DependencyInjection/types';
+import { CreateAd } from '../../../../../../src/Application/Write/Marketplace/CreateAd/CreateAd';
+import { AdId } from '../../../../../../src/Domain/Marketplace/AdId';
+import DatabaseUtil from '../../../../../Helper/DatabaseUtil.ts';
+import { PrismaClient } from '@prisma/client';
+import CommandHandlerManager from '../../../../../../src/Infrastructure/CommandHandler/CommandHandlerManager';
+import type { AdRepository } from '../../../../../../src/Domain/Marketplace/AdRepository.ts';
 
 describe('CreateAdHandler Integration Test', () => {
-  let commandHandlerManager: CommandHandlerManager;
-  let ormClient: PrismaClient;
+    let commandHandlerManager: CommandHandlerManager;
+    let ormClient: PrismaClient;
 
-  beforeEach(async () => {
-    commandHandlerManager = myContainer.get<CommandHandlerManager>(CommandHandlerManager);
-    ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
+    beforeEach(async () => {
+        commandHandlerManager = myContainer.get<CommandHandlerManager>(CommandHandlerManager);
+        ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
 
-    await DatabaseUtil.truncateAllTables()
-  })
+        await DatabaseUtil.truncateAllTables();
+    });
 
-  afterEach(async () => {
-    await ormClient.$disconnect();
-  });
+    afterEach(async () => {
+        await ormClient.$disconnect();
+    });
 
-  it('should create an ad', async () => {
-    // Arrange
-    const adId = AdId.generate();
-    const command = new CreateAd(
-      adId,
-      'Test Ad',
-      '123456789012345678',
-      '987654321098765432',
-      '123987456654789321',
-      'active',
-      '100€',
-      'Porto',
-      'Included',
-      '2 years',
-      'Test ad description',
-      'sale'
-    )
+    it('should create an ad', async () => {
+        // Arrange
+        const adId = AdId.generate();
+        const command = new CreateAd(
+            adId,
+            'Test Ad',
+            '123456789012345678',
+            '987654321098765432',
+            '123987456654789321',
+            'active',
+            '100€',
+            'Porto',
+            'Included',
+            '2 years',
+            'Test ad description',
+            'sale',
+        );
 
-    // Act
-    await commandHandlerManager.handle(command)
+        // Act
+        await commandHandlerManager.handle(command);
 
-    // Assert
-    const adRepository = myContainer.get<AdRepository>(TYPES.AdRepository)
-    const ad = await adRepository.get(adId)
+        // Assert
+        const adRepository = myContainer.get<AdRepository>(TYPES.AdRepository);
+        const ad = await adRepository.get(adId);
 
-    expect(ad).not.toBeNull()
-    expect(ad.id.toString()).toBe(adId.toString())
-    expect(ad.name).toBe('Test Ad')
-    expect(ad.authorId).toBe('123456789012345678')
-    expect(ad.channelId).toBe('987654321098765432')
-    expect(ad.messageId).toBe('123987456654789321')
-    expect(ad.state).toBe('active')
-    expect(ad.price).toBe('100€')
-    expect(ad.zone).toBe('Porto')
-    expect(ad.dispatch).toBe('Included')
-    expect(ad.warranty).toBe('2 years')
-    expect(ad.description).toBe('Test ad description')
-    expect(ad.adType).toBe('sale')
-    expect(ad.createdAt).toBeInstanceOf(Date)
-    expect(ad.updatedAt).toBeInstanceOf(Date)
-  })
-})
+        expect(ad).not.toBeNull();
+        expect(ad.id.toString()).toBe(adId.toString());
+        expect(ad.name).toBe('Test Ad');
+        expect(ad.authorId).toBe('123456789012345678');
+        expect(ad.channelId).toBe('987654321098765432');
+        expect(ad.messageId).toBe('123987456654789321');
+        expect(ad.state).toBe('active');
+        expect(ad.price).toBe('100€');
+        expect(ad.zone).toBe('Porto');
+        expect(ad.dispatch).toBe('Included');
+        expect(ad.warranty).toBe('2 years');
+        expect(ad.description).toBe('Test ad description');
+        expect(ad.adType).toBe('sale');
+        expect(ad.createdAt).toBeInstanceOf(Date);
+        expect(ad.updatedAt).toBeInstanceOf(Date);
+    });
+});

--- a/discord-bot/tests/Integration/Application/Write/Marketplace/DeleteAd/DeleteAdHandler.test.ts
+++ b/discord-bot/tests/Integration/Application/Write/Marketplace/DeleteAd/DeleteAdHandler.test.ts
@@ -1,70 +1,64 @@
-import { describe, expect, beforeEach, it, afterEach } from 'bun:test'
-import { myContainer } from '../../../../../../src/Infrastructure/DependencyInjection/inversify.config'
-import { TYPES } from '../../../../../../src/Infrastructure/DependencyInjection/types'
-import { DeleteAd } from '../../../../../../src/Application/Write/Marketplace/DeleteAd/DeleteAd'
-import { AdId } from '../../../../../../src/Domain/Marketplace/AdId'
-import DatabaseUtil from "../../../../../Helper/DatabaseUtil"
-import { PrismaClient } from "@prisma/client"
-import CommandHandlerManager from "../../../../../../src/Infrastructure/CommandHandler/CommandHandlerManager"
-import { createAd } from '../../../../../Helper/StaticFixtures'
-import type { AdRepository } from '../../../../../../src/Domain/Marketplace/AdRepository'
-import { UnauthorizedAdDeletion } from '../../../../../../src/Domain/Marketplace/UnauthorizedAdDeletion'
-import RecordNotFound from "../../../../../../src/Domain/RecordNotFound.ts";
+import { describe, expect, beforeEach, it, afterEach } from 'bun:test';
+import { myContainer } from '../../../../../../src/Infrastructure/DependencyInjection/inversify.config';
+import { TYPES } from '../../../../../../src/Infrastructure/DependencyInjection/types';
+import { DeleteAd } from '../../../../../../src/Application/Write/Marketplace/DeleteAd/DeleteAd';
+import { AdId } from '../../../../../../src/Domain/Marketplace/AdId';
+import DatabaseUtil from '../../../../../Helper/DatabaseUtil';
+import { PrismaClient } from '@prisma/client';
+import CommandHandlerManager from '../../../../../../src/Infrastructure/CommandHandler/CommandHandlerManager';
+import { createAd } from '../../../../../Helper/StaticFixtures';
+import type { AdRepository } from '../../../../../../src/Domain/Marketplace/AdRepository';
+import { UnauthorizedAdDeletion } from '../../../../../../src/Domain/Marketplace/UnauthorizedAdDeletion';
+import RecordNotFound from '../../../../../../src/Domain/RecordNotFound.ts';
 
 describe('DeleteAdHandler Integration Test', () => {
-  let commandHandlerManager: CommandHandlerManager
-  let ormClient: PrismaClient
-  let adRepository: AdRepository
+    let commandHandlerManager: CommandHandlerManager;
+    let ormClient: PrismaClient;
+    let adRepository: AdRepository;
 
-  beforeEach(async () => {
-    commandHandlerManager = myContainer.get<CommandHandlerManager>(CommandHandlerManager)
-    ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient)
-    adRepository = myContainer.get<AdRepository>(TYPES.AdRepository)
+    beforeEach(async () => {
+        commandHandlerManager = myContainer.get<CommandHandlerManager>(CommandHandlerManager);
+        ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
+        adRepository = myContainer.get<AdRepository>(TYPES.AdRepository);
 
-    await DatabaseUtil.truncateAllTables()
-  })
+        await DatabaseUtil.truncateAllTables();
+    });
 
-  afterEach(async () => {
-    await ormClient.$disconnect()
-  })
+    afterEach(async () => {
+        await ormClient.$disconnect();
+    });
 
-  it('should delete an ad when user is the owner', async () => {
-    // Arrange
-    const userId = '123456789012345678'
-    const ad = await createAd(undefined, 'Test Ad', userId)
-    const command = new DeleteAd(ad.id, userId)
+    it('should delete an ad when user is the owner', async () => {
+        // Arrange
+        const userId = '123456789012345678';
+        const ad = await createAd(undefined, 'Test Ad', userId);
+        const command = new DeleteAd(ad.id, userId);
 
-    // Act
-    await commandHandlerManager.handle(command)
+        // Act
+        await commandHandlerManager.handle(command);
 
-    // Assert
-    await expect(adRepository.get(ad.id))
-      .rejects
-      .toThrow(RecordNotFound)
-  })
+        // Assert
+        await expect(adRepository.get(ad.id)).rejects.toThrow(RecordNotFound);
+    });
 
-  it('should throw RecordNotFound when ad does not exist', async () => {
-    // Arrange
-    const adId = AdId.generate()
-    const userId = '123456789012345678'
-    const command = new DeleteAd(adId, userId)
+    it('should throw RecordNotFound when ad does not exist', async () => {
+        // Arrange
+        const adId = AdId.generate();
+        const userId = '123456789012345678';
+        const command = new DeleteAd(adId, userId);
 
-    // Act & Assert
-    await expect(commandHandlerManager.handle(command))
-      .rejects
-      .toThrow(RecordNotFound)
-  })
+        // Act & Assert
+        await expect(commandHandlerManager.handle(command)).rejects.toThrow(RecordNotFound);
+    });
 
-  it('should throw UnauthorizedAdDeletion when user is not the owner', async () => {
-    // Arrange
-    const ownerId = '123456789012345678'
-    const differentUserId = '987654321098765432'
-    const ad = await createAd(undefined, 'Test Ad', ownerId)
-    const command = new DeleteAd(ad.id, differentUserId)
+    it('should throw UnauthorizedAdDeletion when user is not the owner', async () => {
+        // Arrange
+        const ownerId = '123456789012345678';
+        const differentUserId = '987654321098765432';
+        const ad = await createAd(undefined, 'Test Ad', ownerId);
+        const command = new DeleteAd(ad.id, differentUserId);
 
-    // Act & Assert
-    await expect(commandHandlerManager.handle(command))
-      .rejects
-      .toThrow(UnauthorizedAdDeletion)
-  })
-})
+        // Act & Assert
+        await expect(commandHandlerManager.handle(command)).rejects.toThrow(UnauthorizedAdDeletion);
+    });
+});

--- a/discord-bot/tests/Integration/Application/Write/Screenshot/CreateScreenshot/CreateScreenshotHandler.test.ts
+++ b/discord-bot/tests/Integration/Application/Write/Screenshot/CreateScreenshot/CreateScreenshotHandler.test.ts
@@ -5,93 +5,93 @@ import { ScreenshotAlreadyExist } from '../../../../../../src/Application/Write/
 import { TYPES } from '../../../../../../src/Infrastructure/DependencyInjection/types';
 import CommandHandlerManager from '../../../../../../src/Infrastructure/CommandHandler/CommandHandlerManager';
 import { PrismaClient } from '@prisma/client';
-import { myContainer } from "../../../../../../src/Infrastructure/DependencyInjection/inversify.config";
-import DatabaseUtil from "../../../../../Helper/DatabaseUtil.ts";
+import { myContainer } from '../../../../../../src/Infrastructure/DependencyInjection/inversify.config';
+import DatabaseUtil from '../../../../../Helper/DatabaseUtil.ts';
 
 describe('CreateScreenshotHandler Integration Test', () => {
-  let commandHandlerManager: CommandHandlerManager;
-  let ormClient: PrismaClient;
+    let commandHandlerManager: CommandHandlerManager;
+    let ormClient: PrismaClient;
 
-  beforeEach(async () => {
-    commandHandlerManager = myContainer.get<CommandHandlerManager>(CommandHandlerManager);
-    ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
+    beforeEach(async () => {
+        commandHandlerManager = myContainer.get<CommandHandlerManager>(CommandHandlerManager);
+        ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
 
-    await DatabaseUtil.truncateAllTables();
-  });
-
-  afterEach(async () => {
-    await ormClient.$disconnect();
-  });
-
-  test('should create a new screenshot successfully', async () => {
-    // Arrange
-    const screenshotId = ScreenshotId.generate();
-    const name = 'Test Screenshot';
-    const authorId = 'user123';
-    const channelId = 'channel123';
-    const messageId = 'message123';
-    const platform = 'PS5';
-    const imageUrl = 'https://placehold.co/600x400/png';
-
-    const command = new CreateScreenshot(
-      screenshotId,
-      name,
-      authorId,
-      channelId,
-      messageId,
-      platform,
-      imageUrl
-    );
-
-    // Act
-    const result = await commandHandlerManager.handle(command);
-
-    // Assert
-    const createdScreenshot = await ormClient.screenshot.findUnique({
-      where: { id: screenshotId.toString() }
+        await DatabaseUtil.truncateAllTables();
     });
 
-    expect(createdScreenshot).not.toBeNull();
-    expect(createdScreenshot?.name).toBe(name);
-    expect(createdScreenshot?.author_id).toBe(authorId);
-    expect(createdScreenshot?.channel_id).toBe(channelId);
-    expect(createdScreenshot?.message_id).toBe(messageId);
-    expect(createdScreenshot?.plataform).toBe(platform);
-    expect(createdScreenshot?.image).toBe(imageUrl);
-    expect(createdScreenshot?.image_md5).toBeTruthy(); // MD5 should be generated
-    expect(result.id.toString()).toBe(screenshotId.toString());
-  });
+    afterEach(async () => {
+        await ormClient.$disconnect();
+    });
 
-  test('should throw ScreenshotAlreadyExist when screenshot with same MD5 exists', async () => {
-    // Arrange
-    const imageUrl = 'https://placehold.co/600x400/png';
+    test('should create a new screenshot successfully', async () => {
+        // Arrange
+        const screenshotId = ScreenshotId.generate();
+        const name = 'Test Screenshot';
+        const authorId = 'user123';
+        const channelId = 'channel123';
+        const messageId = 'message123';
+        const platform = 'PS5';
+        const imageUrl = 'https://placehold.co/600x400/png';
 
-    // Create first screenshot
-    const command1 = new CreateScreenshot(
-      ScreenshotId.generate(),
-      'First Screenshot',
-      'user123',
-      'channel123',
-      'message123',
-      'PS5',
-      imageUrl
-    );
-    await commandHandlerManager.handle(command1);
+        const command = new CreateScreenshot(
+            screenshotId,
+            name,
+            authorId,
+            channelId,
+            messageId,
+            platform,
+            imageUrl,
+        );
 
-    // Try to create second screenshot with same image
-    const command2 = new CreateScreenshot(
-      ScreenshotId.generate(),
-      'Second Screenshot',
-      'user456',
-      'channel456',
-      'message456',
-      'PS5',
-      imageUrl
-    );
+        // Act
+        const result = await commandHandlerManager.handle(command);
 
-    // Act & Assert
-    await expect(commandHandlerManager.handle(command2))
-      .rejects
-      .toThrow(ScreenshotAlreadyExist);
-  });
+        // Assert
+        const createdScreenshot = await ormClient.screenshot.findUnique({
+            where: { id: screenshotId.toString() },
+        });
+
+        expect(createdScreenshot).not.toBeNull();
+        expect(createdScreenshot?.name).toBe(name);
+        expect(createdScreenshot?.author_id).toBe(authorId);
+        expect(createdScreenshot?.channel_id).toBe(channelId);
+        expect(createdScreenshot?.message_id).toBe(messageId);
+        expect(createdScreenshot?.plataform).toBe(platform);
+        expect(createdScreenshot?.image).toBe(imageUrl);
+        expect(createdScreenshot?.image_md5).toBeTruthy(); // MD5 should be generated
+        expect(result.id.toString()).toBe(screenshotId.toString());
+    });
+
+    test('should throw ScreenshotAlreadyExist when screenshot with same MD5 exists', async () => {
+        // Arrange
+        const imageUrl = 'https://placehold.co/600x400/png';
+
+        // Create first screenshot
+        const command1 = new CreateScreenshot(
+            ScreenshotId.generate(),
+            'First Screenshot',
+            'user123',
+            'channel123',
+            'message123',
+            'PS5',
+            imageUrl,
+        );
+        await commandHandlerManager.handle(command1);
+
+        // Try to create second screenshot with same image
+        const command2 = new CreateScreenshot(
+            ScreenshotId.generate(),
+            'Second Screenshot',
+            'user456',
+            'channel456',
+            'message456',
+            'PS5',
+            imageUrl,
+        );
+
+        // Act & Assert
+        await expect(commandHandlerManager.handle(command2)).rejects.toThrow(
+            ScreenshotAlreadyExist,
+        );
+    });
 });

--- a/discord-bot/tests/Integration/Application/Write/Screenshot/DeleteScreenshot/DeleteScreenshotHandler.test.ts
+++ b/discord-bot/tests/Integration/Application/Write/Screenshot/DeleteScreenshot/DeleteScreenshotHandler.test.ts
@@ -4,82 +4,69 @@ import { NotAuthorized } from '../../../../../../src/Application/Write/Screensho
 import { TYPES } from '../../../../../../src/Infrastructure/DependencyInjection/types';
 import CommandHandlerManager from '../../../../../../src/Infrastructure/CommandHandler/CommandHandlerManager';
 import { PrismaClient } from '@prisma/client';
-import { myContainer } from "../../../../../../src/Infrastructure/DependencyInjection/inversify.config";
-import DatabaseUtil from "../../../../../Helper/DatabaseUtil";
-import { createScreenshot } from "../../../../../Helper/StaticFixtures";
-import { ScreenshotId } from "../../../../../../src/Domain/Screenshot/ScreenshotId";
+import { myContainer } from '../../../../../../src/Infrastructure/DependencyInjection/inversify.config';
+import DatabaseUtil from '../../../../../Helper/DatabaseUtil';
+import { createScreenshot } from '../../../../../Helper/StaticFixtures';
+import { ScreenshotId } from '../../../../../../src/Domain/Screenshot/ScreenshotId';
 
 describe('DeleteScreenshotHandler Integration Test', () => {
-  let commandHandlerManager: CommandHandlerManager;
-  let ormClient: PrismaClient;
+    let commandHandlerManager: CommandHandlerManager;
+    let ormClient: PrismaClient;
 
-  beforeEach(async () => {
-    commandHandlerManager = myContainer.get<CommandHandlerManager>(CommandHandlerManager);
-    ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
+    beforeEach(async () => {
+        commandHandlerManager = myContainer.get<CommandHandlerManager>(CommandHandlerManager);
+        ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
 
-    await DatabaseUtil.truncateAllTables();
-  });
-
-  afterEach(async () => {
-    await ormClient.$disconnect();
-  });
-
-  test('should delete a screenshot successfully when user is the author', async () => {
-    // Arrange
-    const authorId = '123456789012345678';
-    const screenshotId = ScreenshotId.generate();
-    
-    // Create a screenshot using the fixture
-    await createScreenshot(
-      screenshotId,
-      'Test Screenshot',
-      authorId
-    );
-
-    const command = new DeleteScreenshot(
-      screenshotId,
-      authorId
-    );
-
-    // Act
-    await commandHandlerManager.handle(command);
-
-    // Assert
-    const deletedScreenshot = await ormClient.screenshot.findUnique({
-      where: { id: screenshotId.toString() }
+        await DatabaseUtil.truncateAllTables();
     });
 
-    expect(deletedScreenshot).toBeNull();
-  });
-
-  test('should throw NotAuthorized when user is not the author', async () => {
-    // Arrange
-    const authorId = '123456789012345678';
-    const differentUserId = '987654321098765432';
-    const screenshotId = ScreenshotId.generate();
-    
-    // Create a screenshot using the fixture
-    await createScreenshot(
-      screenshotId,
-      'Test Screenshot',
-      authorId
-    );
-
-    const command = new DeleteScreenshot(
-      screenshotId,
-      differentUserId // Different user trying to delete
-    );
-
-    // Act & Assert
-    await expect(commandHandlerManager.handle(command))
-      .rejects
-      .toThrow(NotAuthorized);
-
-    // Verify screenshot still exists
-    const screenshot = await ormClient.screenshot.findUnique({
-      where: { id: screenshotId.toString() }
+    afterEach(async () => {
+        await ormClient.$disconnect();
     });
 
-    expect(screenshot).not.toBeNull();
-  });
+    test('should delete a screenshot successfully when user is the author', async () => {
+        // Arrange
+        const authorId = '123456789012345678';
+        const screenshotId = ScreenshotId.generate();
+
+        // Create a screenshot using the fixture
+        await createScreenshot(screenshotId, 'Test Screenshot', authorId);
+
+        const command = new DeleteScreenshot(screenshotId, authorId);
+
+        // Act
+        await commandHandlerManager.handle(command);
+
+        // Assert
+        const deletedScreenshot = await ormClient.screenshot.findUnique({
+            where: { id: screenshotId.toString() },
+        });
+
+        expect(deletedScreenshot).toBeNull();
+    });
+
+    test('should throw NotAuthorized when user is not the author', async () => {
+        // Arrange
+        const authorId = '123456789012345678';
+        const differentUserId = '987654321098765432';
+        const screenshotId = ScreenshotId.generate();
+
+        // Create a screenshot using the fixture
+        await createScreenshot(screenshotId, 'Test Screenshot', authorId);
+
+        const command = new DeleteScreenshot(
+            screenshotId,
+            differentUserId, // Different user trying to delete
+        );
+
+        // Act & Assert
+        await expect(commandHandlerManager.handle(command)).rejects.toThrow(NotAuthorized);
+
+        // Verify screenshot still exists
+        const screenshot = await ormClient.screenshot.findUnique({
+            where: { id: screenshotId.toString() },
+        });
+
+        expect(screenshot).not.toBeNull();
+    });
 });

--- a/discord-bot/tests/Integration/Application/Write/Trophy/CreateProfile/CreateProfileHandler.test.ts
+++ b/discord-bot/tests/Integration/Application/Write/Trophy/CreateProfile/CreateProfileHandler.test.ts
@@ -5,86 +5,82 @@ import { ProfileAlreadyExists } from '../../../../../../src/Application/Write/Tr
 import { TYPES } from '../../../../../../src/Infrastructure/DependencyInjection/types';
 import CommandHandlerManager from '../../../../../../src/Infrastructure/CommandHandler/CommandHandlerManager';
 import { PrismaClient } from '@prisma/client';
-import {myContainer} from "../../../../../../src/Infrastructure/DependencyInjection/inversify.config.ts";
-import DatabaseUtil from "../../../../../Helper/DatabaseUtil.ts";
+import { myContainer } from '../../../../../../src/Infrastructure/DependencyInjection/inversify.config.ts';
+import DatabaseUtil from '../../../../../Helper/DatabaseUtil.ts';
 
 describe('CreateProfileHandler Integration Test', () => {
-  let commandHandlerManager: CommandHandlerManager;
-  let ormClient: PrismaClient;
+    let commandHandlerManager: CommandHandlerManager;
+    let ormClient: PrismaClient;
 
-  beforeEach(async () => {
-    commandHandlerManager = myContainer.get<CommandHandlerManager>(CommandHandlerManager);
-    ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
+    beforeEach(async () => {
+        commandHandlerManager = myContainer.get<CommandHandlerManager>(CommandHandlerManager);
+        ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
 
-    await DatabaseUtil.truncateAllTables();
-  });
-
-  afterEach(async () => {
-    await ormClient.$disconnect();
-  });
-
-  test('should create a new trophy profile successfully', async () => {
-    // Arrange
-    const profileId = TrophyProfileId.generate();
-    const userId = 'user123';
-    const psnProfile = 'testPsnProfile';
-    const command = new CreateProfile(profileId, userId, psnProfile);
-
-    // Act
-    await commandHandlerManager.handle(command);
-
-    // Assert
-    const createdProfile = await ormClient.trophyProfile.findUnique({
-      where: { id: profileId.toString() }
+        await DatabaseUtil.truncateAllTables();
     });
 
-    expect(createdProfile).not.toBeNull();
-    expect(createdProfile?.userId).toBe(userId);
-    expect(createdProfile?.psnProfile).toBe(psnProfile);
-    expect(createdProfile?.isBanned).toBe(false);
-    expect(createdProfile?.hasLeft).toBe(false);
-    expect(createdProfile?.isExcluded).toBe(false);
-  });
+    afterEach(async () => {
+        await ormClient.$disconnect();
+    });
 
-  test('should throw ProfileAlreadyExists when user already has a profile', async () => {
-    // Arrange
-    const profileId1 = TrophyProfileId.generate();
-    const profileId2 = TrophyProfileId.generate();
-    const userId = 'user123';
-    const psnProfile1 = 'testPsnProfile1';
-    const psnProfile2 = 'testPsnProfile2';
+    test('should create a new trophy profile successfully', async () => {
+        // Arrange
+        const profileId = TrophyProfileId.generate();
+        const userId = 'user123';
+        const psnProfile = 'testPsnProfile';
+        const command = new CreateProfile(profileId, userId, psnProfile);
 
-    // Create first profile
-    const command1 = new CreateProfile(profileId1, userId, psnProfile1);
-    await commandHandlerManager.handle(command1);
+        // Act
+        await commandHandlerManager.handle(command);
 
-    // Try to create second profile for same user
-    const command2 = new CreateProfile(profileId2, userId, psnProfile2);
+        // Assert
+        const createdProfile = await ormClient.trophyProfile.findUnique({
+            where: { id: profileId.toString() },
+        });
 
-    // Act & Assert
-    await expect(commandHandlerManager.handle(command2))
-      .rejects
-      .toThrow(ProfileAlreadyExists);
-  });
+        expect(createdProfile).not.toBeNull();
+        expect(createdProfile?.userId).toBe(userId);
+        expect(createdProfile?.psnProfile).toBe(psnProfile);
+        expect(createdProfile?.isBanned).toBe(false);
+        expect(createdProfile?.hasLeft).toBe(false);
+        expect(createdProfile?.isExcluded).toBe(false);
+    });
 
-  test('should throw ProfileAlreadyExists when PSN profile already exists', async () => {
-    // Arrange
-    const profileId1 = TrophyProfileId.generate();
-    const profileId2 = TrophyProfileId.generate();
-    const userId1 = 'user123';
-    const userId2 = 'user456';
-    const psnProfile = 'testPsnProfile';
+    test('should throw ProfileAlreadyExists when user already has a profile', async () => {
+        // Arrange
+        const profileId1 = TrophyProfileId.generate();
+        const profileId2 = TrophyProfileId.generate();
+        const userId = 'user123';
+        const psnProfile1 = 'testPsnProfile1';
+        const psnProfile2 = 'testPsnProfile2';
 
-    // Create first profile
-    const command1 = new CreateProfile(profileId1, userId1, psnProfile);
-    await commandHandlerManager.handle(command1);
+        // Create first profile
+        const command1 = new CreateProfile(profileId1, userId, psnProfile1);
+        await commandHandlerManager.handle(command1);
 
-    // Try to create second profile with same PSN profile
-    const command2 = new CreateProfile(profileId2, userId2, psnProfile);
+        // Try to create second profile for same user
+        const command2 = new CreateProfile(profileId2, userId, psnProfile2);
 
-    // Act & Assert
-    await expect(commandHandlerManager.handle(command2))
-      .rejects
-      .toThrow(ProfileAlreadyExists);
-  });
+        // Act & Assert
+        await expect(commandHandlerManager.handle(command2)).rejects.toThrow(ProfileAlreadyExists);
+    });
+
+    test('should throw ProfileAlreadyExists when PSN profile already exists', async () => {
+        // Arrange
+        const profileId1 = TrophyProfileId.generate();
+        const profileId2 = TrophyProfileId.generate();
+        const userId1 = 'user123';
+        const userId2 = 'user456';
+        const psnProfile = 'testPsnProfile';
+
+        // Create first profile
+        const command1 = new CreateProfile(profileId1, userId1, psnProfile);
+        await commandHandlerManager.handle(command1);
+
+        // Try to create second profile with same PSN profile
+        const command2 = new CreateProfile(profileId2, userId2, psnProfile);
+
+        // Act & Assert
+        await expect(commandHandlerManager.handle(command2)).rejects.toThrow(ProfileAlreadyExists);
+    });
 });

--- a/discord-bot/tsconfig.json
+++ b/discord-bot/tsconfig.json
@@ -25,5 +25,9 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
-  }
+  },
+  // Tooling config lives at the repo root and isn't part of the app build;
+  // it also imports untyped packages (e.g. eslint-config-prettier) that
+  // would otherwise trip `allowJs`.
+  "exclude": ["node_modules", "eslint.config.js"]
 }

--- a/discord-bot/tsconfig.json
+++ b/discord-bot/tsconfig.json
@@ -1,33 +1,33 @@
 {
-  "compilerOptions": {
-    // Environment setup & latest features
-    "lib": ["esnext"],
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleDetection": "force",
-    "jsx": "react-jsx",
-    "allowJs": true,
+    "compilerOptions": {
+        // Environment setup & latest features
+        "lib": ["esnext"],
+        "target": "ESNext",
+        "module": "ESNext",
+        "moduleDetection": "force",
+        "jsx": "react-jsx",
+        "allowJs": true,
 
-    // Bundler mode
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
-    "noEmit": true,
-    "experimentalDecorators": true,
+        // Bundler mode
+        "moduleResolution": "bundler",
+        "allowImportingTsExtensions": true,
+        "verbatimModuleSyntax": true,
+        "noEmit": true,
+        "experimentalDecorators": true,
 
-    // Best practices
-    "strict": true,
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true,
+        // Best practices
+        "strict": true,
+        "skipLibCheck": true,
+        "noFallthroughCasesInSwitch": true,
+        "noUncheckedIndexedAccess": true,
 
-    // Some stricter flags (disabled by default)
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noPropertyAccessFromIndexSignature": false
-  },
-  // Tooling config lives at the repo root and isn't part of the app build;
-  // it also imports untyped packages (e.g. eslint-config-prettier) that
-  // would otherwise trip `allowJs`.
-  "exclude": ["node_modules", "eslint.config.js"]
+        // Some stricter flags (disabled by default)
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "noPropertyAccessFromIndexSignature": false
+    },
+    // Tooling config lives at the repo root and isn't part of the app build;
+    // it also imports untyped packages (e.g. eslint-config-prettier) that
+    // would otherwise trip `allowJs`.
+    "exclude": ["node_modules", "eslint.config.js"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "Europe/Lisbon",
+  "schedule": ["before 6am on monday"],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  },
+  "packageRules": [
+    {
+      "description": "All patch/minor updates land together in one weekly PR. Majors are deliberately left out of this rule — with no group of their own, Renovate opens one PR per major bump so each can be reviewed in isolation.",
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "all non-major dependencies",
+      "matchPackageNames": ["*"]
+    },
+    {
+      "description": "discord.js and its @discordjs/* satellite packages must move together.",
+      "groupName": "discord.js",
+      "matchPackageNames": ["discord.js", "@discordjs/**"]
+    },
+    {
+      "description": "Prisma CLI and client must stay on the same version — they refuse to work otherwise.",
+      "groupName": "prisma",
+      "matchPackageNames": ["prisma", "@prisma/**"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements work items **M1.1**, **M1.5**, **M1.9** and **M3.7** from `docs/plans/GLOBAL-PLAN.md` in one PR, plus the CI wiring to make all of it a required check.

### M1.1 — ESLint + Prettier
- Flat-config ESLint (`discord-bot/eslint.config.js`, `typescript-eslint` recommended, non-type-checked) + Prettier (`discord-bot/.prettierrc.json`).
- **House style**: 4-space indent, semicolons, single quotes, trailing commas, print width 100 — chosen because `Domain/`/`Infrastructure/` were already mostly 4-space; `Application/`'s 2-space lost the coin flip.
- Rules are pragmatic, not maximalist: ESLint + typescript-eslint recommended, with `no-explicit-any` and `no-unused-vars` downgraded to `warn` so the pass is clean without a refactor. `reportUnusedDisableDirectives` is on.
- Whole tree reformatted in its own commit (`style(bot): format the tree with Prettier`). `docker-compose*.yml` is deliberately excluded (see `.prettierignore`) — infra config isn't part of the mixed-JS-style problem this exists to fix.
- Removed 5 `eslint-disable` comments that guarded rules no linter ever enforced (own commit, found via `--report-unused-disable-directives`).
- Scripts: `lint`, `lint:fix`, `format`, `format:check`. New `quality` job in CI runs lint + format:check and feeds the required `ci` check.

### M1.5 — Schema-drift gate
- New "Check schema drift" CI step: `prisma migrate diff --from-migrations prisma/migrations --to-schema-datamodel prisma/schema.prisma --shadow-database-url ... --exit-code`, using the CI MariaDB (brought up empty) as scratch space for the shadow database before the Test step applies real migrations to it. New `db:drift` package script for local use (needs `SHADOW_DATABASE_URL`).
- Verified locally: no drift on the current tree (`schema.prisma` already matches the migrations, per known-issues #1).
- Switched `test:setup` from `prisma db push` to `prisma migrate deploy` (`test:db:migrate`) so tests take the same path as production's entrypoint. All 32 tests still pass.

### M1.9 — Supply-chain gates
- `bun run audit` (`bun audit --audit-level=high`) added as a CI step and package script.
- **Deliberately non-blocking today** (`continue-on-error: true` on the step): `bun audit` finds 26 advisories (2 critical, 24 high) in the current dependency tree, in four packages: `axios` (direct, needs `>=1.15.2`), `protobufjs` (via `winston-loki`), `lodash` and `ws`/`undici` (both via `discord.js`). A hard-blocking gate would leave `main` red on merge — the exact "pipeline everyone learns to ignore" failure mode this work exists to prevent. The gate still reports every advisory in the job output on every run; it just doesn't fail the build.
- Fixing these is **M3.2–M3.5**, which is blocked on M1 landing first, so the gate has to land ahead of the fix. **The PR that clears the last of the four packages below must flip `continue-on-error` back off** — this is called out explicitly in the step comment in `ci.yml` so it isn't forgotten.
- `undici` is pinned exactly by `discord.js`/`@discordjs/rest`, so that advisory cannot be patched with an override — bumping `discord.js` (M3.2) is the only supported remedy.
- `renovate.json` at the repo root: `config:recommended` base, weekly schedule, `prConcurrentLimit`/`prHourlyLimit` caps, lockfile maintenance on the same schedule. All patch/minor updates group into one weekly PR; majors are left ungrouped (one PR each); `discord.js`/`@discordjs/*` and `prisma`/`@prisma/*` each get their own dedicated group so they move in lockstep.

#### M3 definition of done (clearing the audit gate)
26 advisories (2 critical, 24 high) across 4 packages — flip `continue-on-error: true` off on the "Audit dependencies" step in `.github/workflows/ci.yml` once all four are checked off:
- [ ] `axios` — direct dependency, needs `>=1.15.2` (M3.3)
- [ ] `protobufjs` (via `winston-loki`) (M3.5)
- [ ] `lodash` (via `discord.js` → `@discordjs/builders` → `@sapphire/shapeshift`) (M3.2)
- [ ] `ws` / `undici` (via `discord.js` → `@discordjs/ws` / `@discordjs/rest`) — pinned exactly, only fixable by bumping `discord.js` (M3.2)

### M3.7 — `::set-output` sweep
- Grepped the whole repo (not just `.github/`) for `::set-output`. **Nothing found** — no workflow ever used it. No changes made for this item.

## House style
4-space indent, semicolons, single quotes, trailing commas (all), print width 100. Applied to `.ts`/`.js`/`.json`/embedded code fences in Markdown. YAML is explicitly excluded.

## Deliberately left out / known follow-ups
- The `bun audit` step is non-blocking today — see M1.9 above and the definition-of-done checklist. Flipping it back to blocking is part of the M3 PR that clears the last advisory, not this PR's job.
- `no-explicit-any`/`no-unused-vars` are warnings, not errors — tightening them is a separate refactor, not this PR's job.
- Didn't touch `docker-compose*.yml` formatting — out of scope for a JS/TS style pass.

## Test plan
- [x] `bunx prisma generate && bunx tsc --noEmit` — clean
- [x] `bun run lint` — clean (0 errors, 84 pre-existing warnings, all `no-explicit-any`/`no-unused-vars` in code this PR didn't touch)
- [x] `bun run format:check` — clean
- [x] `bunx prisma migrate diff --exit-code` against a fresh shadow DB — no drift
- [x] Full integration suite via `docker-compose.ci.yml` (unique project name, torn down after): `test:setup` (now via `migrate deploy`) + `bun test` — **32 pass, 0 fail**
- [ ] `gh pr checks` on this PR — verifying now
- [ ] Not merging per instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
