### PR TITLE
fix(trophies): aggregate and order trophy rankings in SQL

### DIFF
--- a/discord-bot/src/Infrastructure/Orm/OrmTrophyRepository.ts
+++ b/discord-bot/src/Infrastructure/Orm/OrmTrophyRepository.ts
@@ -1,5 +1,5 @@
 import { inject, injectable } from 'inversify';
-import { PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 import { TYPES } from '../DependencyInjection/types';
 import { Trophy, type TrophyArray } from '../../Domain/Trophy/Trophy';
 import { TrophyId } from '../../Domain/Trophy/TrophyId';
@@ -8,6 +8,30 @@ import type { TrophyRankData } from '../../Domain/Trophy/TrophyRankData';
 import type { UserPosition } from '../../Domain/Trophy/UserPosition';
 import RecordNotFound from '../../Domain/RecordNotFound';
 
+interface DateRange {
+    start: Date;
+    end: Date;
+}
+
+interface RankedHunterRow {
+    userId: string | null;
+    psnProfile: string | null;
+    points: number;
+    num_trophies: number;
+}
+
+interface UserRankRow {
+    position: number;
+    points: number;
+    num_trophies: number;
+}
+
+/**
+ * Points and trophy counts are aggregated and ordered in SQL (not fetched and
+ * sorted in application code) so that `LIMIT` truncates the ranking *after*
+ * it has been computed, not before. Ties are broken deterministically by
+ * trophy count, then by profile name, so repeated calls do not shuffle.
+ */
 @injectable()
 export class OrmTrophyRepository implements TrophyRepository {
     constructor(@inject(TYPES.OrmClient) private readonly prismaClient: PrismaClient) {}
@@ -65,188 +89,176 @@ export class OrmTrophyRepository implements TrophyRepository {
         const firstDayOfMonth = new Date(date.getFullYear(), date.getMonth(), 1);
         const lastDayOfMonth = new Date(date.getFullYear(), date.getMonth() + 1, 0, 23, 59, 59);
 
-        const result = await this.prismaClient.trophyProfile.findMany({
-            where: {
-                isExcluded: false,
-                trophies: {
-                    some: {
-                        completionDate: {
-                            gte: firstDayOfMonth,
-                            lte: lastDayOfMonth,
-                        },
-                    },
-                },
-            },
-            include: {
-                trophies: {
-                    where: {
-                        completionDate: {
-                            gte: firstDayOfMonth,
-                            lte: lastDayOfMonth,
-                        },
-                    },
-                },
-                _count: {
-                    select: {
-                        trophies: {
-                            where: {
-                                completionDate: {
-                                    gte: firstDayOfMonth,
-                                    lte: lastDayOfMonth,
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-            take: limit,
-        });
-
-        if (!result.length) {
-            return [];
-        }
-
-        const mappedResults = result.map((profile) => ({
-            userId: profile.userId ?? '',
-            psnProfile: profile.psnProfile ?? '',
-            points: profile.trophies.reduce((sum, trophy) => sum + (trophy.points ?? 0), 0),
-            num_trophies: profile._count.trophies,
-        }));
-
-        return mappedResults.sort((a, b) => b.points - a.points);
+        return this.queryRankedHunters(limit, { start: firstDayOfMonth, end: lastDayOfMonth });
     }
 
     async getTopSinceCreationHunters(limit: number): Promise<TrophyRankData[]> {
-        const result = await this.prismaClient.trophyProfile.findMany({
-            where: {
-                isExcluded: false,
-                trophies: {
-                    some: {},
-                },
-            },
-            include: {
-                trophies: true,
-                _count: {
-                    select: {
-                        trophies: true,
-                    },
-                },
-            },
-            take: limit,
-        });
-
-        if (!result.length) {
-            return [];
-        }
-
-        const mappedResults = result.map((profile) => ({
-            userId: profile.userId ?? '',
-            psnProfile: profile.psnProfile ?? '',
-            points: profile.trophies.reduce((sum, trophy) => sum + (trophy.points ?? 0), 0),
-            num_trophies: profile._count.trophies,
-        }));
-
-        return mappedResults.sort((a, b) => b.points - a.points);
+        return this.queryRankedHunters(limit);
     }
 
     async getTopLifetimeHunters(limit: number): Promise<TrophyRankData[]> {
-        const result = await this.prismaClient.trophyProfile.findMany({
-            where: {
-                isExcluded: false,
-                trophies: {
-                    some: {},
-                },
-            },
-            include: {
-                trophies: true,
-                _count: {
-                    select: {
-                        trophies: true,
-                    },
-                },
-            },
-            take: limit,
-        });
-
-        if (!result.length) {
-            return [];
-        }
-
-        const mappedResults = result.map((profile) => ({
-            userId: profile.userId ?? '',
-            psnProfile: profile.psnProfile ?? '',
-            points: profile.trophies.reduce((sum, trophy) => sum + (trophy.points ?? 0), 0),
-            num_trophies: profile._count.trophies,
-        }));
-
-        return mappedResults.sort((a, b) => b.points - a.points);
+        // Same query as `getTopSinceCreationHunters`: there is no "since
+        // creation" cutoff distinct from "lifetime" in the data we have, both
+        // are simply "all trophies, no date filter".
+        return this.queryRankedHunters(limit);
     }
 
     async findUserPosition(userId: string): Promise<UserPosition> {
-        const userProfile = await this.prismaClient.trophyProfile.findFirst({
-            where: {
-                userId,
-                isExcluded: false,
-            },
-            include: {
-                trophies: true,
-            },
-        });
+        const zeroPosition: UserPosition = {
+            totalPoints: 0,
+            totalTrophies: 0,
+            ranks: [
+                { name: 'monthly', position: 0, points: 0, trophies: 0 },
+                { name: 'creation', position: 0, points: 0, trophies: 0 },
+                { name: 'lifetime', position: 0, points: 0, trophies: 0 },
+            ],
+        };
 
-        if (!userProfile) {
-            return {
-                totalPoints: 0,
-                totalTrophies: 0,
-                ranks: [
-                    { name: 'monthly', position: 0, points: 0, trophies: 0 }, // Monthly
-                    { name: 'creation', position: 0, points: 0, trophies: 0 }, // Creation
-                    { name: 'lifetime', position: 0, points: 0, trophies: 0 }, // Lifetime
-                ],
-            };
+        // No date filter: identical to `getTopSinceCreationHunters` /
+        // `getTopLifetimeHunters`. `null` means the profile doesn't exist,
+        // is excluded, or has zero trophies — all of which map to the
+        // zero-position response, matching the previous behaviour.
+        const creation = await this.queryUserRank(userId);
+
+        if (creation === null) {
+            return zeroPosition;
         }
 
         const firstDayOfMonth = new Date();
         firstDayOfMonth.setDate(1);
         firstDayOfMonth.setHours(0, 0, 0, 0);
-
-        const monthlyTrophies = userProfile.trophies.filter(
-            (t) => t.completionDate && t.completionDate >= firstDayOfMonth,
+        const lastDayOfMonth = new Date(
+            firstDayOfMonth.getFullYear(),
+            firstDayOfMonth.getMonth() + 1,
+            0,
+            23,
+            59,
+            59,
         );
-        const monthlyPoints = monthlyTrophies.reduce((sum, t) => sum + (t.points ?? 0), 0);
 
-        const allMonthlyProfiles = await this.getTopMonthlyHunters(1000, new Date());
-        const monthlyRank =
-            monthlyPoints > 0 ? allMonthlyProfiles.findIndex((p) => p.userId === userId) + 1 : 0;
-
-        const totalPoints = userProfile.trophies.reduce((sum, t) => sum + (t.points ?? 0), 0);
-
-        const allCreationProfiles = await this.getTopSinceCreationHunters(1000);
-        const creationRank =
-            totalPoints > 0 ? allCreationProfiles.findIndex((p) => p.userId === userId) + 1 : 0;
+        const monthly = await this.queryUserRank(userId, {
+            start: firstDayOfMonth,
+            end: lastDayOfMonth,
+        });
 
         return {
-            totalPoints,
-            totalTrophies: userProfile.trophies.length,
+            totalPoints: creation.points,
+            totalTrophies: creation.trophies,
             ranks: [
                 {
                     name: 'monthly',
-                    position: monthlyRank,
-                    points: monthlyPoints,
-                    trophies: monthlyTrophies.length,
+                    position: monthly?.position ?? 0,
+                    points: monthly?.points ?? 0,
+                    trophies: monthly?.trophies ?? 0,
                 },
                 {
                     name: 'creation',
-                    position: creationRank,
-                    points: totalPoints,
-                    trophies: userProfile.trophies.length,
+                    position: creation.position,
+                    points: creation.points,
+                    trophies: creation.trophies,
                 },
                 {
                     name: 'lifetime',
-                    position: creationRank, // Same as creation rank for now
-                    points: totalPoints,
-                    trophies: userProfile.trophies.length,
+                    // Same underlying ranking as `creation` — see comment on
+                    // `getTopLifetimeHunters`.
+                    position: creation.position,
+                    points: creation.points,
+                    trophies: creation.trophies,
                 },
             ],
+        };
+    }
+
+    /**
+     * Builds the `trophies` join condition, optionally restricted to a date
+     * range. Values are always bound parameters — never string-interpolated.
+     */
+    private buildDateCondition(dateRange?: DateRange): Prisma.Sql {
+        if (!dateRange) {
+            return Prisma.empty;
+        }
+
+        return Prisma.sql`AND t.completionDate >= ${dateRange.start} AND t.completionDate <= ${dateRange.end}`;
+    }
+
+    /**
+     * Sums points and counts trophies per profile in SQL, orders by points
+     * (then trophy count, then profile name for a deterministic tiebreak),
+     * and only then applies `LIMIT` — so "top N" is genuinely the top N.
+     */
+    private async queryRankedHunters(
+        limit: number,
+        dateRange?: DateRange,
+    ): Promise<TrophyRankData[]> {
+        const safeLimit = Math.max(0, Math.trunc(limit));
+        const dateCondition = this.buildDateCondition(dateRange);
+
+        const rows = await this.prismaClient.$queryRaw<RankedHunterRow[]>(Prisma.sql`
+            SELECT
+                tp.userId AS userId,
+                tp.psnProfile AS psnProfile,
+                CAST(COALESCE(SUM(t.points), 0) AS SIGNED) AS points,
+                CAST(COUNT(t.id) AS SIGNED) AS num_trophies
+            FROM trophyprofiles tp
+            INNER JOIN trophies t ON t.trophyProfile = tp.id ${dateCondition}
+            WHERE tp.isExcluded = false
+            GROUP BY tp.id, tp.userId, tp.psnProfile
+            ORDER BY points DESC, num_trophies DESC, tp.psnProfile ASC
+            LIMIT ${safeLimit}
+        `);
+
+        return rows.map((row) => ({
+            userId: row.userId ?? '',
+            psnProfile: row.psnProfile ?? '',
+            points: Number(row.points ?? 0),
+            num_trophies: Number(row.num_trophies ?? 0),
+        }));
+    }
+
+    /**
+     * Computes one user's rank, points and trophy count directly in SQL
+     * using a window function, instead of pulling up to 1000 profiles
+     * (each with every trophy row) into memory and index-searching them.
+     */
+    private async queryUserRank(
+        userId: string,
+        dateRange?: DateRange,
+    ): Promise<{ position: number; points: number; trophies: number } | null> {
+        const dateCondition = this.buildDateCondition(dateRange);
+
+        const rows = await this.prismaClient.$queryRaw<UserRankRow[]>(Prisma.sql`
+            SELECT position, points, num_trophies
+            FROM (
+                SELECT
+                    tp.userId AS userId,
+                    CAST(COALESCE(SUM(t.points), 0) AS SIGNED) AS points,
+                    CAST(COUNT(t.id) AS SIGNED) AS num_trophies,
+                    RANK() OVER (
+                        ORDER BY
+                            CAST(COALESCE(SUM(t.points), 0) AS SIGNED) DESC,
+                            CAST(COUNT(t.id) AS SIGNED) DESC,
+                            tp.psnProfile ASC
+                    ) AS position
+                FROM trophyprofiles tp
+                INNER JOIN trophies t ON t.trophyProfile = tp.id ${dateCondition}
+                WHERE tp.isExcluded = false
+                GROUP BY tp.id, tp.userId, tp.psnProfile
+            ) ranked
+            WHERE userId = ${userId}
+            LIMIT 1
+        `);
+
+        // noUncheckedIndexedAccess: `rows[0]` is `UserRankRow | undefined`,
+        // guard rather than assume the user made the ranked set.
+        const row = rows[0];
+        if (row === undefined) {
+            return null;
+        }
+
+        return {
+            position: Number(row.position),
+            points: Number(row.points),
+            trophies: Number(row.num_trophies),
         };
     }
 }

--- a/discord-bot/tests/Integration/Infrastructure/Orm/OrmTrophyRepository.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Orm/OrmTrophyRepository.test.ts
@@ -1,0 +1,181 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { PrismaClient } from '@prisma/client';
+import { myContainer } from '../../../../src/Infrastructure/DependencyInjection/inversify.config';
+import { TYPES } from '../../../../src/Infrastructure/DependencyInjection/types';
+import type { TrophyRepository } from '../../../../src/Domain/Trophy/TrophyRepository';
+import DatabaseUtil from '../../../Helper/DatabaseUtil';
+import { createTrophyProfile, createTrophy } from '../../../Helper/StaticFixtures';
+
+describe('OrmTrophyRepository Integration Test', () => {
+    let trophyRepository: TrophyRepository;
+    let ormClient: PrismaClient;
+
+    beforeEach(async () => {
+        trophyRepository = myContainer.get<TrophyRepository>(TYPES.TrophyRepository);
+        ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
+
+        await DatabaseUtil.truncateAllTables();
+    });
+
+    afterEach(async () => {
+        await ormClient.$disconnect();
+    });
+
+    test('getTopLifetimeHunters returns the true top N in points order, regardless of insertion order', async () => {
+        // Arrange — insert profiles so the highest scorers come LAST. If the
+        // repository truncated with `take` before summing/sorting (the bug),
+        // the best profiles inserted after the limit would never appear.
+        const low1 = await createTrophyProfile(undefined, 'user-low-1', 'Low1');
+        await createTrophy(undefined, low1.id.toString(), undefined, 10);
+
+        const low2 = await createTrophyProfile(undefined, 'user-low-2', 'Low2');
+        await createTrophy(undefined, low2.id.toString(), undefined, 20);
+
+        const low3 = await createTrophyProfile(undefined, 'user-low-3', 'Low3');
+        await createTrophy(undefined, low3.id.toString(), undefined, 30);
+
+        const low4 = await createTrophyProfile(undefined, 'user-low-4', 'Low4');
+        await createTrophy(undefined, low4.id.toString(), undefined, 40);
+
+        // These are inserted LAST but score highest — they must still win.
+        const top1 = await createTrophyProfile(undefined, 'user-top-1', 'Top1');
+        await createTrophy(undefined, top1.id.toString(), undefined, 500);
+
+        const top2 = await createTrophyProfile(undefined, 'user-top-2', 'Top2');
+        await createTrophy(undefined, top2.id.toString(), undefined, 300);
+
+        // Act
+        const result = await trophyRepository.getTopLifetimeHunters(3);
+
+        // Assert
+        expect(result).toHaveLength(3);
+        expect(result[0]?.userId).toBe('user-top-1');
+        expect(result[0]?.points).toBe(500);
+        expect(result[1]?.userId).toBe('user-top-2');
+        expect(result[1]?.points).toBe(300);
+        expect(result[2]?.userId).toBe('user-low-4');
+        expect(result[2]?.points).toBe(40);
+    });
+
+    test('getTopSinceCreationHunters returns the true top N in points order, regardless of insertion order', async () => {
+        const low = await createTrophyProfile(undefined, 'user-low', 'Low');
+        await createTrophy(undefined, low.id.toString(), undefined, 5);
+
+        const mid = await createTrophyProfile(undefined, 'user-mid', 'Mid');
+        await createTrophy(undefined, mid.id.toString(), undefined, 50);
+
+        const high = await createTrophyProfile(undefined, 'user-high', 'High');
+        await createTrophy(undefined, high.id.toString(), undefined, 5000);
+
+        const result = await trophyRepository.getTopSinceCreationHunters(2);
+
+        expect(result).toHaveLength(2);
+        expect(result[0]?.userId).toBe('user-high');
+        expect(result[1]?.userId).toBe('user-mid');
+    });
+
+    test('getTopMonthlyHunters only sums trophies inside the requested month window', async () => {
+        const now = new Date();
+        const lastMonth = new Date(now);
+        lastMonth.setMonth(lastMonth.getMonth() - 1);
+
+        const profile = await createTrophyProfile(undefined, 'user-mixed', 'Mixed');
+        // Inside the current month.
+        await createTrophy(undefined, profile.id.toString(), undefined, 100, now);
+        // Outside the window — must not be counted.
+        await createTrophy(undefined, profile.id.toString(), undefined, 9000, lastMonth);
+
+        const outsideOnly = await createTrophyProfile(undefined, 'user-outside', 'Outside');
+        await createTrophy(undefined, outsideOnly.id.toString(), undefined, 100, lastMonth);
+
+        const result = await trophyRepository.getTopMonthlyHunters(10, now);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]?.userId).toBe('user-mixed');
+        expect(result[0]?.points).toBe(100);
+        expect(result[0]?.num_trophies).toBe(1);
+    });
+
+    test('ties are broken deterministically by trophy count, then profile name', async () => {
+        // Same points (100), different trophy counts: 2 trophies should rank
+        // above 1 trophy.
+        const fewerTrophies = await createTrophyProfile(undefined, 'user-fewer', 'ZFewer');
+        await createTrophy(undefined, fewerTrophies.id.toString(), undefined, 100);
+
+        const moreTrophies = await createTrophyProfile(undefined, 'user-more', 'AMore');
+        await createTrophy(undefined, moreTrophies.id.toString(), undefined, 60);
+        await createTrophy(undefined, moreTrophies.id.toString(), undefined, 40);
+
+        // Same points AND same trophy count: alphabetical profile name wins.
+        const alice = await createTrophyProfile(undefined, 'user-alice', 'Alice');
+        await createTrophy(undefined, alice.id.toString(), undefined, 20);
+
+        const bob = await createTrophyProfile(undefined, 'user-bob', 'Bob');
+        await createTrophy(undefined, bob.id.toString(), undefined, 20);
+
+        const result = await trophyRepository.getTopLifetimeHunters(10);
+
+        expect(result.map((r) => r.userId)).toEqual([
+            'user-more', // 100 pts, 2 trophies
+            'user-fewer', // 100 pts, 1 trophy
+            'user-alice', // 20 pts, "Alice" < "Bob"
+            'user-bob', // 20 pts
+        ]);
+
+        // Repeated calls must be stable, not shuffle.
+        const secondCall = await trophyRepository.getTopLifetimeHunters(10);
+        expect(secondCall.map((r) => r.userId)).toEqual(result.map((r) => r.userId));
+    });
+
+    test('findUserPosition returns the correct rank among more profiles than a naive top-N would show', async () => {
+        // Six profiles with distinct points; the target user is 4th place —
+        // outside a `limit: 3`-style truncation, proving the rank is computed
+        // over the full ranked set, not a truncated one.
+        const points = [500, 400, 300, 200, 100, 50];
+        const userIds = points.map((_, i) => `user-rank-${i}`);
+
+        for (let i = 0; i < points.length; i++) {
+            const profile = await createTrophyProfile(undefined, userIds[i], `Profile${i}`);
+            await createTrophy(undefined, profile.id.toString(), undefined, points[i]);
+        }
+
+        const targetUserId = userIds[3]; // 200 points -> 4th place
+        const position = await trophyRepository.findUserPosition(targetUserId as string);
+
+        expect(position.totalPoints).toBe(200);
+        expect(position.totalTrophies).toBe(1);
+        expect(position.ranks[1].name).toBe('creation');
+        expect(position.ranks[1].position).toBe(4);
+        expect(position.ranks[2].name).toBe('lifetime');
+        expect(position.ranks[2].position).toBe(4);
+    });
+
+    test('findUserPosition returns zero ranks for a user with no trophies', async () => {
+        const position = await trophyRepository.findUserPosition('user-with-nothing');
+
+        expect(position.totalPoints).toBe(0);
+        expect(position.totalTrophies).toBe(0);
+        expect(position.ranks).toEqual([
+            { name: 'monthly', position: 0, points: 0, trophies: 0 },
+            { name: 'creation', position: 0, points: 0, trophies: 0 },
+            { name: 'lifetime', position: 0, points: 0, trophies: 0 },
+        ]);
+    });
+
+    test('findUserPosition excludes profiles flagged isExcluded from the ranking', async () => {
+        const excluded = await createTrophyProfile(
+            undefined,
+            'user-excluded',
+            'Excluded',
+            false,
+            false,
+            true,
+        );
+        await createTrophy(undefined, excluded.id.toString(), undefined, 999999);
+
+        const position = await trophyRepository.findUserPosition('user-excluded');
+
+        expect(position.totalPoints).toBe(0);
+        expect(position.ranks[1].position).toBe(0);
+    });
+});


### PR DESCRIPTION
## The bug

`OrmTrophyRepository.getTopMonthlyHunters`, `getTopSinceCreationHunters` and `getTopLifetimeHunters` all applied `take: limit` in the Prisma query **before** points were summed and sorted in JavaScript, with no `orderBy` on the query at all. So "top 10" meant "10 arbitrary profiles, sorted among themselves" — not the top 10.

Measured against production data before this fix, the bot's "Top 10 lifetime" versus reality:

| Bot's list (rank, profile, points) | Reality |
| --- | --- |
| 1. Redenpt — 18,800 | actually 8th |
| 2. Z3_VAR3LA_ — 18,150 | not in the top 10 |
| … Josh_Lopes — 400 pts (3 trophies) | not remotely top 10 |
| … GTJ2004 — 100 pts (1 trophy) | not remotely top 10 |

The genuine #1, **Zephyr-pt with 58,050 points across 193 trophies, never appeared at all**. Only one of the ten displayed belonged in the real top ten.

Real top 5 lifetime: Zephyr-pt 58,050 (193) · sabathian> 45,950 (165) · SergioDaly 41,050 (109) · DSCStrife 40,950 (168) · JFTMG 27,250 (144).

`findUserPosition` had the same class of problem in a different shape: it pulled up to 1000 `trophyProfile` rows, each with *every* related `trophies` row, into memory just to `findIndex` one user's rank.

## The fix

Aggregate and order in SQL instead of JavaScript, via parameterised `$queryRaw` (the limit and all filter values are always bound parameters, never string-interpolated):

```sql
SELECT
    tp.userId AS userId,
    tp.psnProfile AS psnProfile,
    CAST(COALESCE(SUM(t.points), 0) AS SIGNED) AS points,
    CAST(COUNT(t.id) AS SIGNED) AS num_trophies
FROM trophyprofiles tp
INNER JOIN trophies t ON t.trophyProfile = tp.id -- [AND t.completionDate BETWEEN ? AND ? for monthly]
WHERE tp.isExcluded = false
GROUP BY tp.id, tp.userId, tp.psnProfile
ORDER BY points DESC, num_trophies DESC, tp.psnProfile ASC
LIMIT ?
```

Applied to all three rank modes (`getTopMonthlyHunters`, `getTopSinceCreationHunters`, `getTopLifetimeHunters` — the latter two were already byte-identical queries, so they share one private helper). The `isExcluded` filter and the monthly `completionDate` window are preserved exactly; `TrophyRankData`'s shape (`userId`, `psnProfile`, `points`, `num_trophies`) is unchanged so callers don't need to change. Ties break deterministically: points → trophy count → profile name, so repeated calls don't shuffle.

`findUserPosition` now runs a single windowed-rank query per period (monthly / all-time) using `RANK() OVER (...)`, instead of loading up to 1000 profiles with all their trophies:

- **Before**: `findMany` up to 1000 `trophyProfile` rows with a nested `trophies: true` include (i.e. every trophy row for every one of those profiles), then `Array.prototype.findIndex` in JS.
- **After**: one `$queryRaw` per period that computes the rank in the database and returns a single row (or none). No trophy rows ever cross into application memory for this call.

Also addresses **B9** (unchecked rank indexing): the raw query result (`rows[0]`) is typed as possibly `undefined` under `noUncheckedIndexedAccess`, so the code explicitly checks for it rather than assuming a row exists.

## Tests

Added `discord-bot/tests/Integration/Infrastructure/Orm/OrmTrophyRepository.test.ts`. The decisive one seeds more profiles than the limit with the highest scorers inserted **last**, then asserts the top-N comes back in true points order — this fails against the pre-fix code (verified locally: 3 of 7 new tests failed against the old implementation, including this one and the tie-break test) and passes against the fix. Also covers: the monthly window excludes trophies outside the month, `findUserPosition` returns the correct rank for a user outside a small `limit`, zero-state for a user with no trophies, and that `isExcluded` profiles are kept out of the ranking.

## Verification

- `bun install && bunx prisma generate && bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors (84 pre-existing warnings, unrelated to this change)
- `bun run format:check` — clean
- Full integration suite via `docker-compose.ci.yml` (project `gop-trophy`): **39 pass, 0 fail**
- Confirmed regression coverage: temporarily reverted the repository change and reran the new test file — 3/7 tests failed as expected, including the insertion-order and tie-break tests; restored the fix and reran the full suite (39/39 pass) before pushing.

Out of scope (per M7, noted but not touched): the leaderboard has been frozen since 2024-12-02 because the crawler that produces new trophy rows was never ported. This PR fixes the *read* side so it tells the truth about the data that already exists.