### PR TITLE
fix(bot): close mention-injection hole and fix broken ephemeral/double-reply handling

### DIFF
--- a/discord-bot/src/Domain/Bot/safeReply.ts
+++ b/discord-bot/src/Domain/Bot/safeReply.ts
@@ -1,0 +1,25 @@
+/**
+ * Sends a reply to a Discord interaction, choosing the correct discord.js
+ * method for the interaction's current state.
+ *
+ * Calling `interaction.reply()` a second time (e.g. from a catch block after
+ * the try block already replied) throws `InteractionAlreadyReplied`, which
+ * then hides whatever error actually happened. This helper mirrors the
+ * `replied || deferred` guard that `DiscordBot.ts` already uses for its
+ * top-level handler, so every call site gets the same safe behaviour:
+ *
+ * - already replied            -> `followUp` (send a new message)
+ * - deferred but not replied   -> `editReply` (fill in the deferred reply)
+ * - neither                    -> `reply`
+ */
+export async function safeReply(interaction: any, payload: any): Promise<unknown> {
+    if (interaction.replied) {
+        return interaction.followUp(payload);
+    }
+
+    if (interaction.deferred) {
+        return interaction.editReply(payload);
+    }
+
+    return interaction.reply(payload);
+}

--- a/discord-bot/src/Infrastructure/Bot/Discord/DiscordBot.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/DiscordBot.ts
@@ -5,6 +5,7 @@ import type Logger from '../../../Application/Logger/Logger.ts';
 import type { Bot } from '../../../Domain/Bot/Bot.ts';
 import { BotExecutor } from '../BotExecutor.ts';
 import type { SlashCommandContext } from '../../../Domain/Bot/SlashCommandContext.ts';
+import { safeReply } from '../../../Domain/Bot/safeReply.ts';
 
 @injectable()
 export class DiscordBot implements Bot {
@@ -16,7 +17,17 @@ export class DiscordBot implements Bot {
         @inject(TYPES.Logger) private readonly logger: Logger,
         @inject(BotExecutor) private readonly botExecutor: BotExecutor,
     ) {
-        this.client = new Client({ intents: [GatewayIntentBits.Guilds] });
+        // `allowedMentions: { parse: [] }` is set once here, on the Client
+        // itself, so every message sent through this client — regardless of
+        // which handler built it — has all mention parsing disabled by
+        // default. This is what stops a member from pinging @everyone by
+        // naming a marketplace item or screenshot "@everyone" (M0.2 / A1):
+        // without it, discord.js parses mentions out of raw message content
+        // even when nobody intended to @-mention anyone.
+        this.client = new Client({
+            intents: [GatewayIntentBits.Guilds],
+            allowedMentions: { parse: [] },
+        });
     }
 
     async start(): Promise<void> {
@@ -41,17 +52,10 @@ export class DiscordBot implements Bot {
                 await this.botExecutor.execute(slashCommandContext);
             } catch (error: any) {
                 this.logger.error('error happened', { error });
-                if (interaction.replied || interaction.deferred) {
-                    await interaction.followUp({
-                        content: 'There was an error while executing this command!',
-                        flags: MessageFlags.Ephemeral,
-                    });
-                } else {
-                    await interaction.reply({
-                        content: 'There was an error while executing this command!',
-                        flags: MessageFlags.Ephemeral,
-                    });
-                }
+                await safeReply(interaction, {
+                    content: 'There was an error while executing this command!',
+                    flags: MessageFlags.Ephemeral,
+                });
             }
         });
 

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/CreateScreenshotSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/CreateScreenshotSubcommand.ts
@@ -2,11 +2,12 @@ import { inject, injectable } from 'inversify';
 import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerManager.ts';
 import type Logger from '../../../../../Application/Logger/Logger.ts';
 import { TYPES } from '../../../../DependencyInjection/types.ts';
-import { MessageFlags } from 'discord.js';
+import { escapeMarkdown, MessageFlags } from 'discord.js';
 import { ScreenshotId } from '../../../../../Domain/Screenshot/ScreenshotId.ts';
 import { CreateScreenshot } from '../../../../../Application/Write/Screenshot/CreateScreenshot/CreateScreenshot.ts';
 import { ScreenshotAlreadyExist } from '../../../../../Application/Write/Screenshot/CreateScreenshot/ScreenshotAlreadyExist.ts';
 import { DiscordEmoji } from '../../../../Community/Discord/DiscordEmoji.ts';
+import { safeReply } from '../../../../../Domain/Bot/safeReply.ts';
 
 @injectable()
 export class CreateScreenshotSubcommand {
@@ -23,7 +24,8 @@ export class CreateScreenshotSubcommand {
 
         // Validate required data
         if (!image || !name || !platform) {
-            await interaction.reply('Error: Missing required information for the screenshot.', {
+            await interaction.reply({
+                content: 'Error: Missing required information for the screenshot.',
                 flags: MessageFlags.Ephemeral,
             });
             return;
@@ -31,7 +33,8 @@ export class CreateScreenshotSubcommand {
 
         // Validate image
         if (!image.contentType?.startsWith('image/')) {
-            await interaction.reply('Error: The attachment must be an image.', {
+            await interaction.reply({
+                content: 'Error: The attachment must be an image.',
                 flags: MessageFlags.Ephemeral,
             });
             return;
@@ -52,15 +55,20 @@ export class CreateScreenshotSubcommand {
                 ),
             );
 
-            // Reply with the formatted message and the image
+            // Reply with the formatted message and the image. `name` is
+            // user-supplied and lands directly in message content, so it is
+            // escaped (markdown injection) and mentions are explicitly
+            // disabled on this reply (mention injection, M0.2/A1) in
+            // addition to the client-wide default set in DiscordBot.ts.
             const message = await interaction.reply({
                 content:
                     `📸 **Screenshot Submitted!**\n\n` +
                     `ID: #${screenshotId.toString()}\n` +
                     `Author: ${interaction.user.username}\n` +
-                    `Name: ${name}\n` +
+                    `Name: ${escapeMarkdown(name)}\n` +
                     `Platform: ${platform.charAt(0).toUpperCase() + platform.slice(1)}`,
                 files: [image.url],
+                allowedMentions: { parse: [] },
                 fetchReply: true, // This ensures we get the message object back
             });
 
@@ -88,7 +96,7 @@ export class CreateScreenshotSubcommand {
 
             // Check for specific error types
             if (error instanceof ScreenshotAlreadyExist) {
-                await interaction.reply({
+                await safeReply(interaction, {
                     content: '⚠️ Error: This screenshot has already been submitted.',
                     flags: MessageFlags.Ephemeral,
                 });
@@ -96,7 +104,7 @@ export class CreateScreenshotSubcommand {
             }
 
             // Generic error message for other errors
-            await interaction.reply({
+            await safeReply(interaction, {
                 content: 'There was an error submitting your screenshot. Please try again later.',
                 flags: MessageFlags.Ephemeral,
             });

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/DeleteScreenshotSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/DeleteScreenshotSubcommand.ts
@@ -1,5 +1,5 @@
 import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerManager.ts';
-import { inject } from 'inversify';
+import { inject, injectable } from 'inversify';
 import type Logger from '../../../../../Application/Logger/Logger.ts';
 import { TYPES } from '../../../../DependencyInjection/types.ts';
 import { ScreenshotId } from '../../../../../Domain/Screenshot/ScreenshotId.ts';
@@ -8,7 +8,9 @@ import { MessageFlags } from 'discord.js';
 import { InvalidId } from '../../../../../Domain/InvalidId.ts';
 import RecordNotFound from '../../../../../Domain/RecordNotFound.ts';
 import { NotAuthorized } from '../../../../../Application/Write/Screenshot/DeleteScreenshot/NotAuthorized.ts';
+import { safeReply } from '../../../../../Domain/Bot/safeReply.ts';
 
+@injectable()
 export class DeleteScreenshotSubcommand {
     constructor(
         @inject(CommandHandlerManager)
@@ -45,7 +47,7 @@ export class DeleteScreenshotSubcommand {
             });
 
             if (error instanceof InvalidId) {
-                await interaction.reply({
+                await safeReply(interaction, {
                     content: `⚠️ Error: Invalid screenshot ID format.`,
                     flags: MessageFlags.Ephemeral,
                 });
@@ -53,7 +55,7 @@ export class DeleteScreenshotSubcommand {
             }
 
             if (error instanceof RecordNotFound) {
-                await interaction.reply({
+                await safeReply(interaction, {
                     content: `⚠️ Error: Screenshot with ID #${cleanId} was not found.`,
                     flags: MessageFlags.Ephemeral,
                 });
@@ -61,14 +63,14 @@ export class DeleteScreenshotSubcommand {
             }
 
             if (error instanceof NotAuthorized) {
-                await interaction.reply({
+                await safeReply(interaction, {
                     content: `⛔ Error: You are not authorized to delete this screenshot.`,
                     flags: MessageFlags.Ephemeral,
                 });
                 return;
             }
 
-            await interaction.reply({
+            await safeReply(interaction, {
                 content: 'There was an error deleting the screenshot. Please try again later.',
                 flags: MessageFlags.Ephemeral,
             });

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ListScreenshotSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ListScreenshotSubcommand.ts
@@ -4,6 +4,7 @@ import type Logger from '../../../../../Application/Logger/Logger.ts';
 import { TYPES } from '../../../../DependencyInjection/types.ts';
 import { GetScreenshots } from '../../../../../Application/Query/Screenshot/GetScreenshots/GetScreenshots.ts';
 import { EmbedBuilder, MessageFlags } from 'discord.js';
+import { safeReply } from '../../../../../Domain/Bot/safeReply.ts';
 
 @injectable()
 export class ListScreenshotSubcommand {
@@ -87,7 +88,7 @@ export class ListScreenshotSubcommand {
                 error: error,
             });
 
-            await interaction.reply({
+            await safeReply(interaction, {
                 content: 'There was an error retrieving the screenshots. Please try again later.',
                 flags: MessageFlags.Ephemeral,
             });

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ScreenshotSlashCommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ScreenshotSlashCommand.ts
@@ -7,6 +7,7 @@ import type Logger from '../../../../../Application/Logger/Logger.ts';
 import { CreateScreenshotSubcommand } from './CreateScreenshotSubcommand.ts';
 import { ListScreenshotSubcommand } from './ListScreenshotSubcommand.ts';
 import { DeleteScreenshotSubcommand } from './DeleteScreenshotSubcommand.ts';
+import { safeReply } from '../../../../../Domain/Bot/safeReply.ts';
 
 @injectable()
 export class ScreenshotSlashCommand implements SlashCommandHandler {
@@ -115,10 +116,15 @@ export class ScreenshotSlashCommand implements SlashCommandHandler {
                     });
             }
         } catch (error) {
-            await interaction.reply(
-                'There was an error processing your screenshot command. Please try again later.',
-                { flags: MessageFlags.Ephemeral },
-            );
+            // The subcommand handler may already have replied (or deferred)
+            // before throwing, so this must not blindly call `.reply()` —
+            // that would throw `InteractionAlreadyReplied` and swallow the
+            // real error above. See safeReply() for the branching logic.
+            await safeReply(interaction, {
+                content:
+                    'There was an error processing your screenshot command. Please try again later.',
+                flags: MessageFlags.Ephemeral,
+            });
             this.logger.error('Error processing screenshot command', { error });
         }
     }

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.ts
@@ -6,6 +6,7 @@ import type Logger from '../../../../../Application/Logger/Logger';
 import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerManager';
 import { GetProfile } from '../../../../../Application/Query/Trophy/GetProfile/GetProfile';
 import { ProfileNotFound } from '../../../../../Application/Query/Trophy/GetProfile/ProfileNotFound';
+import { safeReply } from '../../../../../Domain/Bot/safeReply';
 
 @injectable()
 export class CheckTrophyProfileSubcommand {
@@ -53,7 +54,7 @@ export class CheckTrophyProfileSubcommand {
             });
         } catch (error) {
             if (error instanceof ProfileNotFound) {
-                await context.interaction.reply({
+                await safeReply(context.interaction, {
                     content:
                         targetUser.id === context.interaction.user.id
                             ? '❌ You have not registered your PSN profile yet. Use `/trophy create` to register.'
@@ -68,7 +69,7 @@ export class CheckTrophyProfileSubcommand {
                 userId: targetUser.id,
             });
 
-            await context.interaction.reply({
+            await safeReply(context.interaction, {
                 content: '⚠️ An error occurred while retrieving the PSN profile.',
                 flags: MessageFlags.Ephemeral,
             });

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/CreateTrophyProfileSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/CreateTrophyProfileSubcommand.ts
@@ -7,6 +7,7 @@ import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerMana
 import { CreateProfile } from '../../../../../Application/Write/Trophy/CreateProfile/CreateProfile';
 import { TrophyProfileId } from '../../../../../Domain/Trophy/TrophyProfileId';
 import { ProfileAlreadyExists } from '../../../../../Application/Write/Trophy/CreateProfile/ProfileAlreadyExists';
+import { safeReply } from '../../../../../Domain/Bot/safeReply';
 
 @injectable()
 export class CreateTrophyProfileSubcommand {
@@ -51,14 +52,14 @@ export class CreateTrophyProfileSubcommand {
         } catch (error) {
             if (error instanceof ProfileAlreadyExists) {
                 if (error.userId === context.interaction.user.id) {
-                    await context.interaction.reply({
+                    await safeReply(context.interaction, {
                         content: 'You have already registered this PSN profile.',
                         flags: MessageFlags.Ephemeral,
                     });
                     return;
                 }
 
-                await context.interaction.reply({
+                await safeReply(context.interaction, {
                     content:
                         'Someone else has already registered this PSN profile. If you think this is an error please report to an administrator',
                     flags: MessageFlags.Ephemeral,
@@ -72,7 +73,7 @@ export class CreateTrophyProfileSubcommand {
                 psnProfile,
             });
 
-            await context.interaction.reply({
+            await safeReply(context.interaction, {
                 content: 'An error occurred while registering your PSN profile.',
                 flags: MessageFlags.Ephemeral,
             });

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/RankSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/RankSubcommand.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../../../Application/Query/Trophy/GetRank/GetRank';
 import type { TrophyRankData } from '../../../../../Domain/Trophy/TrophyRankData';
 import type { UserPosition } from '../../../../../Domain/Trophy/UserPosition';
+import { safeReply } from '../../../../../Domain/Bot/safeReply';
 
 @injectable()
 export class RankSubcommand {
@@ -188,7 +189,7 @@ export class RankSubcommand {
                 stack: error instanceof Error ? error.stack : undefined,
             });
 
-            await context.interaction.reply({
+            await safeReply(context.interaction, {
                 content:
                     '⚠️ An error occurred while retrieving the trophy rankings. Please try again later.',
                 flags: MessageFlags.Ephemeral,

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/TrophySlashCommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/TrophySlashCommand.ts
@@ -7,6 +7,7 @@ import type Logger from '../../../../../Application/Logger/Logger';
 import { CreateTrophyProfileSubcommand } from './CreateTrophyProfileSubcommand';
 import { CheckTrophyProfileSubcommand } from './CheckTrophyProfileSubcommand';
 import { RankSubcommand } from './RankSubcommand.ts';
+import { safeReply } from '../../../../../Domain/Bot/safeReply.ts';
 
 @injectable()
 export class TrophySlashCommand implements SlashCommandHandler {
@@ -150,7 +151,10 @@ export class TrophySlashCommand implements SlashCommandHandler {
                 subcommand,
             });
 
-            await context.interaction.reply({
+            // The subcommand handler may already have replied (or deferred)
+            // before throwing; safeReply avoids InteractionAlreadyReplied
+            // masking the real error above.
+            await safeReply(context.interaction, {
                 content: 'An error occurred while processing your command.',
                 flags: MessageFlags.Ephemeral,
             });

--- a/discord-bot/tests/Integration/Domain/Bot/safeReply.test.ts
+++ b/discord-bot/tests/Integration/Domain/Bot/safeReply.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect } from 'bun:test';
+import { safeReply } from '../../../../src/Domain/Bot/safeReply';
+
+/**
+ * safeReply() is the fix for M0.4 / B3 ("double-reply crashes"): a catch
+ * block that blindly calls `interaction.reply()` after the try block (or a
+ * nested subcommand handler) already replied throws
+ * `InteractionAlreadyReplied`, which then hides whatever error actually
+ * happened. These tests hand-roll a fake interaction — no mocking library is
+ * used in this repo — that records which discord.js method gets called.
+ */
+function createFakeInteraction(state: { replied: boolean; deferred: boolean }) {
+    const calls: { method: string; payload: unknown }[] = [];
+
+    return {
+        get replied() {
+            return state.replied;
+        },
+        get deferred() {
+            return state.deferred;
+        },
+        calls,
+        reply: async (payload: unknown) => {
+            calls.push({ method: 'reply', payload });
+            state.replied = true;
+        },
+        followUp: async (payload: unknown) => {
+            calls.push({ method: 'followUp', payload });
+        },
+        editReply: async (payload: unknown) => {
+            calls.push({ method: 'editReply', payload });
+        },
+    };
+}
+
+describe('safeReply', () => {
+    test('calls reply() when the interaction has neither replied nor deferred', async () => {
+        const interaction = createFakeInteraction({ replied: false, deferred: false });
+
+        await safeReply(interaction, { content: 'hello' });
+
+        expect(interaction.calls).toEqual([{ method: 'reply', payload: { content: 'hello' } }]);
+    });
+
+    test('calls followUp() instead of reply() when the interaction already replied', async () => {
+        const interaction = createFakeInteraction({ replied: true, deferred: false });
+
+        // This is the exact scenario that used to throw InteractionAlreadyReplied:
+        // the try block (or a nested subcommand) already sent a reply, and a
+        // catch block needs to report a second, separate error.
+        await expect(safeReply(interaction, { content: 'boom' })).resolves.toBeUndefined();
+
+        expect(interaction.calls).toEqual([{ method: 'followUp', payload: { content: 'boom' } }]);
+    });
+
+    test('calls editReply() when the interaction is deferred but not yet replied', async () => {
+        const interaction = createFakeInteraction({ replied: false, deferred: true });
+
+        await safeReply(interaction, { content: 'still working on it' });
+
+        expect(interaction.calls).toEqual([
+            { method: 'editReply', payload: { content: 'still working on it' } },
+        ]);
+    });
+
+    test('does not throw when the interaction was already replied to', async () => {
+        const interaction = createFakeInteraction({ replied: true, deferred: true });
+
+        let thrown: unknown = null;
+        try {
+            await safeReply(interaction, { content: 'second error' });
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(thrown).toBeNull();
+    });
+});

--- a/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Screenshot/CreateScreenshotSubcommand.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Screenshot/CreateScreenshotSubcommand.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect } from 'bun:test';
+import { CreateScreenshotSubcommand } from '../../../../../../../src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/CreateScreenshotSubcommand';
+import Logger from '../../../../../../../src/Application/Logger/Logger';
+import InMemoryLogger from '../../../../../../Helper/InMemoryLogger';
+import { Screenshot } from '../../../../../../../src/Domain/Screenshot/Screenshot';
+import { ScreenshotId } from '../../../../../../../src/Domain/Screenshot/ScreenshotId';
+
+/**
+ * Regression coverage for M0.2 (A1): a member can name a screenshot
+ * "@everyone" and, before this fix, the bot echoed that name straight into
+ * message *content* with no `allowedMentions` set — discord.js parses
+ * mentions out of raw content by default, so this pinged the whole server.
+ *
+ * The fix is layered: `DiscordBot.ts` now constructs its Client with
+ * `allowedMentions: { parse: [] }` globally, and this call site additionally
+ * sets it explicitly on the reply that echoes the user-supplied name, so the
+ * protection does not depend solely on the global default.
+ *
+ * The command handler manager is hand-rolled here (not the real DI
+ * container) so this test exercises only the discord.js reply payload, not
+ * the database/network-backed CreateScreenshot write path, which is already
+ * covered by CreateScreenshotHandler.test.ts.
+ */
+function createFakeCommandHandlerManager(screenshotId: ScreenshotId) {
+    return {
+        handle: async () =>
+            new Screenshot(
+                screenshotId,
+                '@everyone',
+                'user-1',
+                'chan-1',
+                'interaction-1',
+                'pc',
+                'https://example.com/screenshot.png',
+                'deadbeef',
+                new Date(),
+                new Date(),
+            ),
+    } as any;
+}
+
+function createFakeInteraction() {
+    const calls: { method: string; payload: unknown }[] = [];
+    const fakeMessage = { react: async () => {} };
+
+    return {
+        calls,
+        replied: false,
+        deferred: false,
+        user: { id: 'user-1', username: 'attacker' },
+        channelId: 'chan-1',
+        id: 'interaction-1',
+        options: {
+            getAttachment: () => ({
+                contentType: 'image/png',
+                url: 'https://example.com/screenshot.png',
+            }),
+            getString: (name: string) => (name === 'name' ? '@everyone' : 'pc'),
+        },
+        reply: async function (this: any, payload: unknown) {
+            calls.push({ method: 'reply', payload });
+            this.replied = true;
+            return fakeMessage;
+        },
+        followUp: async (payload: unknown) => {
+            calls.push({ method: 'followUp', payload });
+        },
+    };
+}
+
+describe('CreateScreenshotSubcommand', () => {
+    test('a screenshot named @everyone cannot produce a real mention', async () => {
+        const screenshotId = ScreenshotId.generate();
+        const logger = new Logger([new InMemoryLogger()]);
+        const subcommand = new CreateScreenshotSubcommand(
+            createFakeCommandHandlerManager(screenshotId),
+            logger,
+        );
+        const interaction = createFakeInteraction();
+
+        await subcommand.handle(interaction);
+
+        expect(interaction.calls).toHaveLength(1);
+        const { payload } = interaction.calls[0]!;
+        const { content, allowedMentions } = payload as {
+            content: string;
+            allowedMentions: unknown;
+        };
+
+        // The literal text can still show up in content...
+        expect(content).toContain('@everyone');
+        // ...but discord.js must be told not to resolve it into a real mention.
+        expect(allowedMentions).toEqual({ parse: [] });
+    });
+});

--- a/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ScreenshotSlashCommand.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ScreenshotSlashCommand.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect } from 'bun:test';
+import { MessageFlags } from 'discord.js';
+import { ScreenshotSlashCommand } from '../../../../../../../src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ScreenshotSlashCommand';
+import Logger from '../../../../../../../src/Application/Logger/Logger';
+import InMemoryLogger from '../../../../../../Helper/InMemoryLogger';
+
+/**
+ * Regression coverage for M0.3 (B2): `interaction.reply(string, { flags })`
+ * is not a valid discord.js v14 signature — the options object is silently
+ * dropped, so an "ephemeral" error is posted publicly for everyone to see.
+ * The outer catch in ScreenshotSlashCommand.handle() used to do exactly
+ * that; it must use the object form so the ephemeral flag actually reaches
+ * discord.js.
+ *
+ * This also exercises M0.4 (B3): the outer catch fires *after* a subcommand
+ * may already have replied, so it must go through safeReply() rather than
+ * calling interaction.reply() directly.
+ */
+function createFakeInteraction(subcommand: string) {
+    const calls: { method: string; payload: unknown }[] = [];
+
+    return {
+        calls,
+        replied: false,
+        deferred: false,
+        options: {
+            getSubcommand: () => subcommand,
+        },
+        reply: async function (this: any, payload: unknown) {
+            calls.push({ method: 'reply', payload });
+            this.replied = true;
+        },
+        followUp: async (payload: unknown) => {
+            calls.push({ method: 'followUp', payload });
+        },
+        editReply: async (payload: unknown) => {
+            calls.push({ method: 'editReply', payload });
+        },
+    };
+}
+
+describe('ScreenshotSlashCommand', () => {
+    test('an unhandled error in a subcommand results in a properly-flagged ephemeral reply', async () => {
+        const failingSubcommand = {
+            handle: async () => {
+                throw new Error('boom');
+            },
+        };
+        const noopSubcommand = { handle: async () => {} };
+        const logger = new Logger([new InMemoryLogger()]);
+
+        const command = new ScreenshotSlashCommand(
+            logger,
+            failingSubcommand as any,
+            noopSubcommand as any,
+            noopSubcommand as any,
+        );
+
+        const interaction = createFakeInteraction('create');
+
+        await command.handle({
+            channel_id: 'chan',
+            command: 'screenshot',
+            text: '',
+            interaction,
+        });
+
+        expect(interaction.calls).toHaveLength(1);
+        const { method, payload } = interaction.calls[0]!;
+
+        // Must be the object-form call (M0.3): a bare string content with a
+        // second positional options argument is not valid discord.js v14 and
+        // would post this message publicly instead of ephemerally.
+        expect(method).toBe('reply');
+        expect(payload).toMatchObject({ flags: MessageFlags.Ephemeral });
+        expect((payload as { content: string }).content).toContain(
+            'error processing your screenshot command',
+        );
+    });
+
+    test('does not throw InteractionAlreadyReplied when the subcommand already replied before throwing', async () => {
+        const interaction = createFakeInteraction('create');
+
+        const partiallyFailingSubcommand = {
+            handle: async (i: typeof interaction) => {
+                await i.reply({ content: 'partial success' });
+                throw new Error('failed after replying');
+            },
+        };
+        const noopSubcommand = { handle: async () => {} };
+        const logger = new Logger([new InMemoryLogger()]);
+
+        const command = new ScreenshotSlashCommand(
+            logger,
+            partiallyFailingSubcommand as any,
+            noopSubcommand as any,
+            noopSubcommand as any,
+        );
+
+        let thrown: unknown = null;
+        try {
+            await command.handle({
+                channel_id: 'chan',
+                command: 'screenshot',
+                text: '',
+                interaction,
+            });
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(thrown).toBeNull();
+        expect(interaction.calls.map((c) => c.method)).toEqual(['reply', 'followUp']);
+    });
+});

--- a/discord-bot/tests/Integration/Infrastructure/DependencyInjection/DeleteScreenshotSubcommand.container.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/DependencyInjection/DeleteScreenshotSubcommand.container.test.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from 'bun:test';
+import { myContainer } from '../../../../src/Infrastructure/DependencyInjection/inversify.config';
+import { DeleteScreenshotSubcommand } from '../../../../src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/DeleteScreenshotSubcommand';
+
+/**
+ * Regression coverage for M0.6 (B4): `DeleteScreenshotSubcommand` was
+ * missing `@injectable()` while its siblings (Create/List) had it. It is
+ * bound with `.toSelf()` in inversify.config.ts, so a missing decorator
+ * would only surface as a runtime resolution failure — asserting the
+ * decorator is present is not enough, the container must actually be able
+ * to build the class.
+ */
+describe('DI container — DeleteScreenshotSubcommand', () => {
+    test('resolves DeleteScreenshotSubcommand without throwing', () => {
+        let instance: DeleteScreenshotSubcommand | undefined;
+
+        expect(() => {
+            instance = myContainer.get(DeleteScreenshotSubcommand);
+        }).not.toThrow();
+
+        expect(instance).toBeInstanceOf(DeleteScreenshotSubcommand);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes four live/near-live defects from `docs/plans/GLOBAL-PLAN.md` M0.2, M0.3, M0.4, M0.6 (audit findings A1, B2, B3, B4 in `docs/plans/05-bot-audit-and-hardening.md`).

- **M0.2 (A1) — mention injection.** `new Client({ intents, allowedMentions: { parse: [] } })` in `discord-bot/src/Infrastructure/Bot/Discord/DiscordBot.ts` disables mention parsing globally for every message the bot ever sends, closing the `@everyone` mass-ping hole for good (previously a member could name a marketplace item or screenshot `@everyone` and ping the whole server). Also applied explicitly, plus `escapeMarkdown()`, on the `CreateScreenshotSubcommand.ts` success reply, which echoes the user-supplied screenshot `name` directly into message `content`.
- **M0.3 (B2) — ephemeral errors posted publicly.** `interaction.reply(string, { flags })` is not a valid discord.js v14 signature (the options object is silently dropped). Fixed the object-form call in `ScreenshotSlashCommand.ts` and the two in `CreateScreenshotSubcommand.ts`. Grepped the whole `src/` tree afterward for the same shape — no other occurrences remain (only `PingSlashCommand.ts`'s single-arg `reply('pong! 🏓')` is left, which is a valid call).
- **M0.4 (B3) — cascading `InteractionAlreadyReplied`.** Added `safeReply()` to `discord-bot/src/Domain/Bot/safeReply.ts`, mirroring the `replied || deferred` guard `DiscordBot.ts:41-52` already used correctly (branches to `followUp` / `editReply` / `reply`). Used it in every catch block across `ScreenshotSlashCommand`, `CreateScreenshotSubcommand`, `ListScreenshotSubcommand`, `DeleteScreenshotSubcommand`, `TrophySlashCommand`, `CheckTrophyProfileSubcommand`, `CreateTrophyProfileSubcommand`, `RankSubcommand` — including the two outer catches (`ScreenshotSlashCommand.handle`, `TrophySlashCommand.handle`) that fire *after* a subcommand may already have replied. Also refactored `DiscordBot.ts`'s own catch to call the shared helper instead of duplicating the branch.
- **M0.6 (B4) — missing `@injectable()`.** Added the decorator to `DeleteScreenshotSubcommand.ts` (its Create/List siblings already had it). Verified the container actually resolves it (not just that the decorator compiles) with a dedicated test.

**Scope boundary respected:** nothing under `.../SlashCommand/Marketplace/` was touched — `SellSubcommand.ts`, `DeleteAdSubcommand.ts`, and the `CreateAd` write path are owned by a parallel agent's rewrite. Those call sites (`SellSubcommand.ts`'s catch block still calls `interaction.reply()` directly, and its reply echoes ad `name`/`price`/`zone` without explicit `allowedMentions`) are a **follow-up sweep**: once that rewrite lands, it should adopt `safeReply()` from `Domain/Bot/safeReply.ts` and set `allowedMentions: { parse: [] }` explicitly on any reply echoing ad content (the Client-level default already covers it structurally, but explicit is safer per M0.2's guidance).

## Proof `@everyone` no longer pings

New test `CreateScreenshotSubcommand.test.ts` creates a screenshot named `@everyone` through a hand-rolled fake interaction and asserts the reply payload sent to discord.js:
- `content` still contains the literal text `@everyone` (nothing is stripped)
- `allowedMentions` is `{ parse: [] }` — the exact option that stops discord.js resolving it into a real ping

Combined with the Client-level default in `DiscordBot.ts`, mention parsing is disabled in two independent places for this path.

## Confirmation the container resolves `DeleteScreenshotSubcommand`

New test `DeleteScreenshotSubcommand.container.test.ts` calls `myContainer.get(DeleteScreenshotSubcommand)` against the real Inversify container and asserts it does not throw and returns an instance — this is what would have caught the missing `@injectable()` at build time instead of at the first Discord interaction.

## Test plan
- [x] `bun install && bunx prisma generate && bunx tsc --noEmit` — clean, 0 errors
- [x] `bun run lint` — 0 errors (pre-existing `no-explicit-any` warnings only, consistent with the untyped `interaction: any` pattern used throughout this layer)
- [x] `bun run format:check` — clean
- [x] Full CI-style suite via `docker compose -p gop-safety -f docker-compose.ci.yml` — **40 pass, 0 fail** (8 new tests + all 32 pre-existing), stack torn down with `down -v` afterward
