### PR TITLE
ci(ci): wait on the MariaDB healthcheck in the schema-drift gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,14 @@ jobs:
       - name: Check schema drift
         working-directory: discord-bot
         run: |
-          docker compose -f docker-compose.ci.yml up -d mariadb
-          timeout 120 bash -c 'until docker compose -f docker-compose.ci.yml exec -T mariadb mariadb-admin ping -uroot -prootpassword --silent 2>/dev/null; do sleep 2; done'
+          # `--wait` blocks on the healthcheck the compose file already declares.
+          # Do NOT replace this with a hand-rolled `mariadb-admin ping` loop: during
+          # initialisation the MariaDB entrypoint runs a *temporary* server to apply
+          # setup, and that server answers ping before the root password exists — so
+          # the ping succeeds and the very next statement fails with
+          # `ERROR 1045 Access denied for user 'root'@'localhost'`. It is a race, so
+          # it passes most of the time, which is the worst way for a gate to be wrong.
+          docker compose -f docker-compose.ci.yml up -d --wait mariadb
           docker compose -f docker-compose.ci.yml exec -T mariadb mariadb -uroot -prootpassword -e "CREATE DATABASE IF NOT EXISTS discord_bot_shadow"
           bunx prisma migrate diff \
             --from-migrations prisma/migrations \


### PR DESCRIPTION
## The failure

PR #15 went red on the new schema-drift gate with:

```
ERROR 1045 (28000): Access denied for user 'root'@'localhost'
```

The same gate passed on #12, #13 and #14. It is a **race**, not a branch problem.

## Why

The step did this:

```bash
docker compose -f docker-compose.ci.yml up -d mariadb
timeout 120 bash -c 'until ... mariadb-admin ping -uroot -prootpassword --silent 2>/dev/null; do sleep 2; done'
docker compose ... exec -T mariadb mariadb -uroot -prootpassword -e "CREATE DATABASE IF NOT EXISTS discord_bot_shadow"
```

While initialising, the MariaDB entrypoint starts a **temporary server** to apply setup (create the database, set the root password, run init scripts). That temporary server answers `ping` *before* the root password has been applied. The ping loop therefore exits early and satisfied, and the `CREATE DATABASE` on the next line hits a server that does not yet know that password — hence `Access denied`.

Timings from the failed run bear this out: container `Started` at `20:51:34.80`, `Access denied` at `20:51:41.51` — under 7 seconds, far too fast for a real 120s timeout, and the ping loop had already been satisfied. Note the loop also swallows stderr (`2>/dev/null`), so it cannot distinguish "not up yet" from "up but rejecting me".

## The fix

`docker-compose.ci.yml` **already declares the right healthcheck**:

```yaml
healthcheck:
  test: [ "CMD", "/usr/local/bin/healthcheck.sh", "--su-mysql", "--connect", "--innodb_initialized" ]
```

`--innodb_initialized` is precisely the "initialisation is genuinely finished" signal the hand-rolled loop was trying and failing to approximate. So drop the loop and let Compose wait on it:

```bash
docker compose -f docker-compose.ci.yml up -d --wait mariadb
```

A comment on the step records why the ping loop must not come back.

## Why this matters beyond one red build

A required gate that fails a few percent of the time is worse than no gate: the honest reading of a red run stops being "my branch broke something" and becomes "try again". This gate is three PRs old and had already produced one spurious failure.