### PR TITLE
ci(ci): scope the secret scan to the PR and allowlist Discord snowflakes

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -88,5 +88,20 @@ jobs:
             | tar -xz -C "$RUNNER_TEMP" gitleaks
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
 
+      # On a pull request, scan only the commits the PR actually adds.
+      #
+      # `gitleaks detect` with a full clone scans every ref it can see, not just
+      # this branch's ancestry — so one contributor's branch reddens the secret
+      # scan on every *other* open PR, which is both confusing and trains people
+      # to ignore it. Scoping to `base..HEAD` makes a PR answerable for its own
+      # content. Pushes to main and the weekly schedule still scan all history,
+      # which is where a full sweep belongs.
       - name: Run Gitleaks
-        run: gitleaks detect --source . -v --no-banner --exit-code 1
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch --no-tags origin "${{ github.base_ref }}"
+            gitleaks detect --source . -v --no-banner --exit-code 1 \
+              --log-opts="--no-merges origin/${{ github.base_ref }}..HEAD"
+          else
+            gitleaks detect --source . -v --no-banner --exit-code 1
+          fi

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,27 @@
+# Gitleaks configuration for GameOnPortugal/monorepo.
+#
+# Extends the default rule set — this file only ever *narrows* false positives,
+# it never disables a rule wholesale. If you add an entry here, say why the
+# matched value is genuinely not a credential.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Discord channel and guild snowflakes are public identifiers, not credentials"
+
+# Gitleaks' built-in `discord-client-id` rule matches any 17-20 digit number.
+# Discord "snowflake" IDs for a guild or a channel are public: they appear in
+# every channel URL, in the client UI under Copy Link, and in any invite. They
+# identify a room; they do not authorise anything. Committing them is the entire
+# point of work item M1.7 — the alternative is hardcoding them in TypeScript,
+# which is the problem being fixed.
+#
+# Deliberately keyed on the variable name rather than on the file or on the
+# literal values, so that:
+#   - a real DISCORD_TOKEN or client *secret* still fails the scan, and
+#   - adding a new channel does not require editing this file again.
+regexTarget = "line"
+regexes = [
+  '''DISCORD_(GUILD_ID|CHANNEL_[A-Z0-9_]+)\s*=\s*[0-9]{17,20}''',
+]


### PR DESCRIPTION
The secret scan went red on **both #18 and #19** — reporting the *same three findings*, from a file (`discord-bot/.env.example`) that **#19 does not touch**. Two separate problems.

## 1. The scan was judging every PR by every branch

```
gitleaks detect --source . -v --no-banner --exit-code 1
```

With `fetch-depth: 0` that scans every ref in the clone, not the branch under test — hence #19 failing on #18's commit. So **any open branch with a finding reddens the secret scan on every other open PR.**

That is worse than confusing. A gate that goes red for reasons unrelated to your change is one people learn to click past — and this repo's whole problem was that nothing gated anything, so the gates that now exist have to be ones people will trust.

On `pull_request` the scan is now scoped to `base..HEAD`, so a PR answers for its own commits. Pushes to `main` and the weekly schedule still sweep the full history, which is where a full sweep belongs.

## 2. The finding itself was a false positive

```
RuleID:  discord-client-id
Secret:  818108848492773377
File:    discord-bot/.env.example
```

Gitleaks' built-in `discord-client-id` rule matches **any 17-20 digit number**. Those values are Discord **snowflakes** for a guild and two channels — public identifiers that appear in every channel URL and under *Copy Link* in the client. They name a room; they do not authorise anything.

Committing them is the *point* of **M1.7**: the alternative is leaving them hardcoded in TypeScript, which is the defect being fixed.

### The allowlist is deliberately narrow

`.gitleaks.toml` **extends** the default rules rather than replacing them, and keys the allowlist on the **variable name** — not on the file, and not on the literal values:

```toml
regexTarget = "line"
regexes = [
  '''DISCORD_(GUILD_ID|CHANNEL_[A-Z0-9_]+)\s*=\s*[0-9]{17,20}''',
]
```

So a real `DISCORD_TOKEN` or client **secret** still fails the scan; `.env.example` is not allowlisted wholesale (that is exactly where a real secret could hide); and adding a channel later needs no change to this file.

Unblocks #18 and #19.