### PR TITLE
feat(trophies): port the PSNProfiles source and points ladder behind a domain port (M7.1, M7.2)

### DIFF
--- a/discord-bot/src/Domain/Trophy/TrophyAlreadyClaimed.ts
+++ b/discord-bot/src/Domain/Trophy/TrophyAlreadyClaimed.ts
@@ -1,0 +1,20 @@
+/**
+ * One claim per (profile, trophy URL) pair.
+ *
+ * Ported from `old-discord-bot/src/exception/trophy/trophyAlreadyClaimedException.js`
+ * (`TrophyAlreadyClaimedException`), thrown by
+ * `old-discord-bot/src/service/trophy/trophyManager.js#create` when a
+ * trophy row already exists for that profile + url. The sync job that
+ * throws this on write (M7.3, not built in this PR) is expected to catch
+ * it to implement catch-up mode: stop walking a profile's trophy pages the
+ * first time this fires, unless running with `--all --profile=X`.
+ */
+export class TrophyAlreadyClaimed extends Error {
+    constructor(
+        public readonly profileId: string,
+        public readonly trophyUrl: string,
+    ) {
+        super(`${trophyUrl} has already been claimed by profile ${profileId}`);
+        this.name = 'TrophyAlreadyClaimed';
+    }
+}

--- a/discord-bot/src/Domain/Trophy/TrophyNotEarnedYet.ts
+++ b/discord-bot/src/Domain/Trophy/TrophyNotEarnedYet.ts
@@ -1,0 +1,14 @@
+/**
+ * Thrown by a `TrophySource` when the profile's first (or blank-workaround
+ * second) trophy row exists but is not marked completed — i.e. the plat
+ * hasn't been earned yet.
+ *
+ * Ported from the plain `Error('User hasn't earned the plat trophy yet!')`
+ * thrown in `old-discord-bot/src/service/trophy/psnCrawlService.js#getPlatTrophyData`.
+ */
+export class TrophyNotEarnedYet extends Error {
+    constructor(public readonly trophyUrl: string) {
+        super(`Plat trophy at ${trophyUrl} hasn't been earned yet`);
+        this.name = 'TrophyNotEarnedYet';
+    }
+}

--- a/discord-bot/src/Domain/Trophy/TrophyPoints.ts
+++ b/discord-bot/src/Domain/Trophy/TrophyPoints.ts
@@ -1,0 +1,39 @@
+/**
+ * Rarity → TP ladder, copied verbatim (boundaries and order) from
+ * `old-discord-bot/src/service/trophy/trophyManager.js#transformPercentageIntoPoints`:
+ *
+ * | Platinum rarity | TP   |
+ * |------------------|------|
+ * | > 30.01%         | 50   |
+ * | > 15.01%         | 100  |
+ * | > 8.01%          | 250  |
+ * | > 5.01%          | 500  |
+ * | > 2.01%          | 800  |
+ * | > 0.6%           | 1250 |
+ * | <= 0.6%          | 2000 |
+ *
+ * Pure function, no I/O — this is the whole reason it lives in the Domain
+ * layer instead of next to the crawler.
+ */
+export function calculateTrophyPoints(percentage: number): number {
+    if (percentage > 30.01) {
+        return 50;
+    }
+    if (percentage > 15.01) {
+        return 100;
+    }
+    if (percentage > 8.01) {
+        return 250;
+    }
+    if (percentage > 5.01) {
+        return 500;
+    }
+    if (percentage > 2.01) {
+        return 800;
+    }
+    if (percentage > 0.6) {
+        return 1250;
+    }
+
+    return 2000;
+}

--- a/discord-bot/src/Domain/Trophy/TrophySource.ts
+++ b/discord-bot/src/Domain/Trophy/TrophySource.ts
@@ -1,0 +1,52 @@
+/**
+ * World rank + country rank for a PSN profile, as displayed on the
+ * profile's stats page. Both are `null` when the profile has no visible
+ * rank — the old bot used this to detect a banned PSNProfiles account
+ * (see `old-discord-bot/src/service/trophy/psnCrawlService.js#getProfileRank`
+ * and its caller in `scripts/parse-psn-profile.js`, which flags the local
+ * `TrophyProfile` as banned + excluded when both are null).
+ */
+export interface TrophyProfileRank {
+    worldRank: number | null;
+    countryRank: number | null;
+}
+
+/**
+ * Rarity + completion date for a single platinum trophy.
+ */
+export interface PlatinumTrophyData {
+    /** Platinum rarity, e.g. `52.03` for "52.03%". */
+    percentage: number;
+    completionDate: Date;
+}
+
+/**
+ * Port for the data source that produces trophy data — PSNProfiles today,
+ * ported behind this interface precisely so it doesn't have to stay
+ * PSNProfiles forever. Domain layer: describes what the bot needs, not how
+ * it's served, and has zero framework imports.
+ *
+ * See `PsnProfilesTrophySource` (Infrastructure/Trophy) for the concrete
+ * implementation, ported from `old-discord-bot/src/service/trophy/psnCrawlService.js`.
+ */
+export interface TrophySource {
+    /**
+     * World rank + country rank for a PSN profile.
+     */
+    getProfileRank(psnProfile: string): Promise<TrophyProfileRank>;
+
+    /**
+     * One page of platinum trophy URLs for a PSN profile, newest first.
+     * Returns an empty array once past the last page — callers page until
+     * they get an empty result (or hit an already-claimed trophy, in
+     * catch-up mode — see M7.3).
+     */
+    getProfileTrophies(psnProfile: string, page?: number): Promise<string[]>;
+
+    /**
+     * Rarity percentage + completion date for a single platinum trophy.
+     *
+     * @throws TrophyNotEarnedYet if the profile hasn't earned this trophy yet.
+     */
+    getPlatinumTrophyData(trophyUrl: string): Promise<PlatinumTrophyData>;
+}

--- a/discord-bot/src/Infrastructure/DependencyInjection/inversify.config.ts
+++ b/discord-bot/src/Infrastructure/DependencyInjection/inversify.config.ts
@@ -12,6 +12,8 @@ import EventDispatcher from '../../Application/Event/EventDispatcher/EventDispat
 import type { HttpClient } from '../../Domain/Http/HttpClient.ts';
 import RetryHttpClient from '../Http/RetryHttpClient.ts';
 import FetchHttpClient from '../Http/FetchHttpClient.ts';
+import type { TrophySource } from '../../Domain/Trophy/TrophySource.ts';
+import { PsnProfilesTrophySource } from '../Trophy/PsnProfilesTrophySource.ts';
 import { PingHandler } from '../../Application/Query/Ping/PingHandler.ts';
 import { DiscordBot } from '../Bot/Discord/DiscordBot.ts';
 import { BotExecutor } from '../Bot/BotExecutor.ts';
@@ -117,6 +119,7 @@ myContainer.bind<EventDispatcher>(EventDispatcher).toSelf();
 myContainer.bind(FetchHttpClient).toSelf();
 myContainer.bind(RetryHttpClient).toSelf();
 myContainer.bind<HttpClient>(TYPES.HttpClient).to(RetryHttpClient);
+myContainer.bind<TrophySource>(TYPES.TrophySource).to(PsnProfilesTrophySource);
 
 // Bot
 myContainer

--- a/discord-bot/src/Infrastructure/DependencyInjection/types.ts
+++ b/discord-bot/src/Infrastructure/DependencyInjection/types.ts
@@ -21,6 +21,7 @@ const TYPES = {
 
     // Clients
     HttpClient: Symbol.for('HttpClient'),
+    TrophySource: Symbol.for('TrophySource'),
     OrmClient: Symbol.for('OrmClient'),
     GuildClient: Symbol.for('GuildClient'),
 };

--- a/discord-bot/src/Infrastructure/Trophy/PsnProfilesTrophySource.ts
+++ b/discord-bot/src/Infrastructure/Trophy/PsnProfilesTrophySource.ts
@@ -1,0 +1,229 @@
+import { inject, injectable } from 'inversify';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+import { TYPES } from '../DependencyInjection/types';
+import type { HttpClient } from '../../Domain/Http/HttpClient';
+import type {
+    PlatinumTrophyData,
+    TrophyProfileRank,
+    TrophySource,
+} from '../../Domain/Trophy/TrophySource';
+import { TrophyNotEarnedYet } from '../../Domain/Trophy/TrophyNotEarnedYet';
+import { sleep } from '../../Application/Shared/sleep';
+
+dayjs.extend(customParseFormat);
+
+// PSN profile dates look like: 29th Jun 2021
+// https://day.js.org/docs/en/parse/string-format
+const PSN_PROFILE_DATE_FORMAT = 'Do MMM YYYY';
+
+// A real, descriptive UA — PSNProfiles has no public API and this is a
+// courtesy to whoever reads their access logs. Not the bare default
+// "node"/"bun" UA, and not spoofed as a browser.
+const USER_AGENT =
+    'GameOnPortugalBot/1.0 (+https://github.com/GameOnPortugal/monorepo; Discord community trophy tracker)';
+
+// PSNProfiles' robots.txt disallows a handful of paths (search, ajax
+// endpoints) but not profile/trophy pages; it carries no explicit
+// Crawl-delay. In the absence of one, one request per second per process is
+// a conservative, well-established default for a single-threaded crawler
+// against a site with no public API — enough to be a good citizen without
+// making the sync job (M7.3) impractically slow over ~118 profiles.
+const MIN_REQUEST_INTERVAL_MS = 1000;
+
+interface HtmlTag {
+    /** Raw attribute string, e.g. `class="rank" title="x"`. */
+    attrs: string;
+    /** Inner content between the opening and closing tag. */
+    inner: string;
+}
+
+/**
+ * Ported from `old-discord-bot/src/service/trophy/psnCrawlService.js`, which
+ * used JSDOM + jQuery. Neither is a dependency here (M3.3 removed axios; no
+ * HTML parser was ever a dependency of the rewrite) and the instruction for
+ * this port is to avoid adding one — so this parses with small, scoped
+ * regexes over specific known fragments of PSNProfiles' markup, the same
+ * way the old bot's CSS selectors targeted specific known fragments.
+ *
+ * This is deliberately not a general HTML parser: it assumes the fragments
+ * it scans (a stats block, a trophy table body, a games table) don't nest
+ * same-named tags inside themselves, which holds for the shapes PSNProfiles
+ * actually emits for these blocks. Fixtures for both shapes live under
+ * `tests/Integration/Infrastructure/Trophy/fixtures/`.
+ */
+@injectable()
+export class PsnProfilesTrophySource implements TrophySource {
+    private static readonly BASE_URL = 'https://psnprofiles.com';
+
+    private lastRequestAt = 0;
+
+    constructor(@inject(TYPES.HttpClient) private readonly httpClient: HttpClient) {}
+
+    public async getProfileRank(psnProfile: string): Promise<TrophyProfileRank> {
+        const html = await this.fetchHtml(`${PsnProfilesTrophySource.BASE_URL}/${psnProfile}`);
+        return this.parseProfileRank(html);
+    }
+
+    public async getProfileTrophies(psnProfile: string, page: number = 1): Promise<string[]> {
+        const html = await this.fetchHtml(
+            `${PsnProfilesTrophySource.BASE_URL}/${psnProfile}?completion=platinum&order=last-trophy&page=${page}`,
+        );
+        return this.parseProfileTrophies(html);
+    }
+
+    public async getPlatinumTrophyData(trophyUrl: string): Promise<PlatinumTrophyData> {
+        const html = await this.fetchHtml(trophyUrl);
+        return this.parsePlatinumTrophyData(html, trophyUrl);
+    }
+
+    // -- HTTP -----------------------------------------------------------
+    //
+    // TYPES.HttpClient already resolves to RetryHttpClient (wrapping
+    // FetchHttpClient), which retries with backoff on any thrown error —
+    // and FetchHttpClient throws on any non-2xx response, so 429s and 5xxs
+    // already get retried without anything extra here. What's left for a
+    // good citizen is a descriptive User-Agent and spacing requests out,
+    // both below.
+
+    private async fetchHtml(url: string): Promise<string> {
+        await this.throttle();
+
+        const response = await this.httpClient.get(url, {
+            headers: { 'User-Agent': USER_AGENT },
+        });
+
+        return typeof response === 'string' ? response : String(response);
+    }
+
+    private async throttle(): Promise<void> {
+        const elapsed = Date.now() - this.lastRequestAt;
+        if (elapsed < MIN_REQUEST_INTERVAL_MS) {
+            await sleep(MIN_REQUEST_INTERVAL_MS - elapsed);
+        }
+        this.lastRequestAt = Date.now();
+    }
+
+    // -- Parsing ----------------------------------------------------------
+
+    private parseProfileRank(html: string): TrophyProfileRank {
+        const worldRankText = this.findTagByClass(html, 'span', 'rank')?.inner.trim();
+        const countryRankText = this.findTagByClass(html, 'span', 'country-rank')?.inner.trim();
+
+        return {
+            worldRank: this.parseCommaSeparatedInt(worldRankText),
+            countryRank: this.parseCommaSeparatedInt(countryRankText),
+        };
+    }
+
+    private parseProfileTrophies(html: string): string[] {
+        const urls: string[] = [];
+
+        for (const row of this.findRowsByClass(html, 'platinum')) {
+            const hrefMatch = row.inner.match(/<a[^>]*\shref="([^"]*)"/);
+            if (hrefMatch?.[1]) {
+                urls.push(`${PsnProfilesTrophySource.BASE_URL}${hrefMatch[1]}`);
+            }
+        }
+
+        return urls;
+    }
+
+    private parsePlatinumTrophyData(html: string, trophyUrl: string): PlatinumTrophyData {
+        // Scope to the <tbody> so a <thead> row never gets mistaken for the
+        // (possibly blank) first data row below.
+        const tbodyHtml = this.extractFirstTagInner(html, 'tbody') ?? html;
+        const rows = this.extractRows(tbodyHtml);
+        if (rows.length === 0) {
+            throw new Error("Couldn't find trophy table body!");
+        }
+
+        // HACK, ported verbatim from the old bot: some trophy pages have a
+        // blank row in the first position. Jump to the second one if so.
+        let row = rows[0];
+        if (row !== undefined && row.inner.trim() === '') {
+            row = rows[1] as HtmlTag;
+        }
+
+        if (row === undefined) {
+            throw new Error("Couldn't find trophy table body!");
+        }
+
+        const rowClass = this.extractAttr(row.attrs, 'class') ?? '';
+        if (!this.hasClassToken(rowClass, 'completed')) {
+            throw new TrophyNotEarnedYet(trophyUrl);
+        }
+
+        const percentageText = this.findTagByClass(row.inner, 'span', 'typo-top')?.inner.trim();
+        if (!percentageText) {
+            throw new Error("Couldn't find trophy percentage!");
+        }
+        const percentage = parseFloat(percentageText);
+
+        const dateText = this.findTagByClass(row.inner, 'span', 'typo-top-date')?.inner.trim();
+        if (!dateText) {
+            throw new Error("Couldn't find completion date!");
+        }
+
+        const completionDate = dayjs(dateText, PSN_PROFILE_DATE_FORMAT);
+        if (!completionDate.isValid()) {
+            throw new Error(`Completion date "${dateText}" is invalid!`);
+        }
+
+        return { percentage, completionDate: completionDate.toDate() };
+    }
+
+    // -- Tiny regex HTML helpers ------------------------------------------
+
+    private extractRows(html: string): HtmlTag[] {
+        return this.matchTags(html, 'tr');
+    }
+
+    private findRowsByClass(html: string, classToken: string): HtmlTag[] {
+        return this.extractRows(html).filter((row) =>
+            this.hasClassToken(this.extractAttr(row.attrs, 'class') ?? '', classToken),
+        );
+    }
+
+    /** First `<tag ...>...</tag>` (no nested same-name tags) whose `class` list includes `classToken`. */
+    private findTagByClass(html: string, tag: string, classToken: string): HtmlTag | null {
+        return (
+            this.matchTags(html, tag).find((match) =>
+                this.hasClassToken(this.extractAttr(match.attrs, 'class') ?? '', classToken),
+            ) ?? null
+        );
+    }
+
+    /** Inner content of the first `<tag ...>...</tag>` (no nested same-name tags), or null if absent. */
+    private extractFirstTagInner(html: string, tag: string): string | null {
+        const match = html.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`));
+        return match?.[1] ?? null;
+    }
+
+    private matchTags(html: string, tag: string): HtmlTag[] {
+        const tags: HtmlTag[] = [];
+        const regex = new RegExp(`<${tag}([^>]*)>([\\s\\S]*?)<\\/${tag}>`, 'g');
+        let match: RegExpExecArray | null;
+        while ((match = regex.exec(html)) !== null) {
+            tags.push({ attrs: match[1] ?? '', inner: match[2] ?? '' });
+        }
+        return tags;
+    }
+
+    private extractAttr(attrs: string, name: string): string | null {
+        const match = attrs.match(new RegExp(`${name}="([^"]*)"`));
+        return match?.[1] ?? null;
+    }
+
+    private hasClassToken(classAttr: string, token: string): boolean {
+        return classAttr.split(/\s+/).includes(token);
+    }
+
+    private parseCommaSeparatedInt(text: string | undefined): number | null {
+        if (!text) {
+            return null;
+        }
+        const value = parseInt(text.replace(/,/g, ''), 10);
+        return isNaN(value) ? null : value;
+    }
+}

--- a/discord-bot/tests/Integration/Domain/Trophy/TrophyAlreadyClaimed.test.ts
+++ b/discord-bot/tests/Integration/Domain/Trophy/TrophyAlreadyClaimed.test.ts
@@ -1,0 +1,20 @@
+import { describe, test, expect } from 'bun:test';
+import { TrophyAlreadyClaimed } from '../../../../src/Domain/Trophy/TrophyAlreadyClaimed';
+
+describe('TrophyAlreadyClaimed', () => {
+    test('carries the profile id and trophy url that collided', () => {
+        const error = new TrophyAlreadyClaimed(
+            'profile-id-123',
+            'https://psnprofiles.com/trophies/11783-assassins-creed-valhalla/Josh_Lopes',
+        );
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error.name).toBe('TrophyAlreadyClaimed');
+        expect(error.profileId).toBe('profile-id-123');
+        expect(error.trophyUrl).toBe(
+            'https://psnprofiles.com/trophies/11783-assassins-creed-valhalla/Josh_Lopes',
+        );
+        expect(error.message).toContain(error.trophyUrl);
+        expect(error.message).toContain(error.profileId);
+    });
+});

--- a/discord-bot/tests/Integration/Domain/Trophy/TrophyPoints.test.ts
+++ b/discord-bot/tests/Integration/Domain/Trophy/TrophyPoints.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from 'bun:test';
+import { calculateTrophyPoints } from '../../../../src/Domain/Trophy/TrophyPoints';
+
+/**
+ * Table-driven test over every band boundary of the rarity → TP ladder,
+ * ported verbatim from
+ * old-discord-bot/src/service/trophy/trophyManager.js#transformPercentageIntoPoints:
+ *
+ *   > 30.01% -> 50, > 15.01% -> 100, > 8.01% -> 250, > 5.01% -> 500,
+ *   > 2.01% -> 800, > 0.6% -> 1250, <= 0.6% -> 2000.
+ *
+ * Every boundary is strictly "greater than", so the boundary value itself
+ * falls into the *lower* (rarer, higher-points) band — each pair below
+ * hits both sides of a boundary.
+ */
+describe('calculateTrophyPoints', () => {
+    const cases: Array<[number, number, string]> = [
+        [100, 50, 'well above the top boundary'],
+        [30.02, 50, 'just above the 30.01 boundary'],
+        [30.01, 100, 'exactly on the 30.01 boundary falls into the 100 band'],
+        [30.0, 100, 'just below the 30.01 boundary'],
+
+        [15.02, 100, 'just above the 15.01 boundary'],
+        [15.01, 250, 'exactly on the 15.01 boundary falls into the 250 band'],
+        [15.0, 250, 'just below the 15.01 boundary'],
+
+        [8.02, 250, 'just above the 8.01 boundary'],
+        [8.01, 500, 'exactly on the 8.01 boundary falls into the 500 band'],
+        [8.0, 500, 'just below the 8.01 boundary'],
+
+        [5.02, 500, 'just above the 5.01 boundary'],
+        [5.01, 800, 'exactly on the 5.01 boundary falls into the 800 band'],
+        [5.0, 800, 'just below the 5.01 boundary'],
+
+        [2.02, 800, 'just above the 2.01 boundary'],
+        [2.01, 1250, 'exactly on the 2.01 boundary falls into the 1250 band'],
+        [2.0, 1250, 'just below the 2.01 boundary'],
+
+        [0.61, 1250, 'just above the 0.6 boundary'],
+        [0.6, 2000, 'exactly on the 0.6 boundary falls into the 2000 band'],
+        [0.59, 2000, 'just below the 0.6 boundary'],
+        [0.01, 2000, 'the rarest possible band'],
+        [0, 2000, 'zero percent'],
+    ];
+
+    for (const [percentage, expectedPoints, description] of cases) {
+        test(`${percentage}% -> ${expectedPoints} TP (${description})`, () => {
+            expect(calculateTrophyPoints(percentage)).toBe(expectedPoints);
+        });
+    }
+});

--- a/discord-bot/tests/Integration/Infrastructure/DependencyInjection/TrophySource.container.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/DependencyInjection/TrophySource.container.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from 'bun:test';
+import { myContainer } from '../../../../src/Infrastructure/DependencyInjection/inversify.config';
+import { TYPES } from '../../../../src/Infrastructure/DependencyInjection/types';
+import { PsnProfilesTrophySource } from '../../../../src/Infrastructure/Trophy/PsnProfilesTrophySource';
+import type { TrophySource } from '../../../../src/Domain/Trophy/TrophySource';
+
+/**
+ * M7.1: TYPES.TrophySource -> PsnProfilesTrophySource. "Nothing is
+ * reachable until it is bound" (AGENT.md) — this asserts the container can
+ * actually build it, not just that the class carries `@injectable()`.
+ */
+describe('DI container — TrophySource', () => {
+    test('resolves TYPES.TrophySource to a PsnProfilesTrophySource without throwing', () => {
+        let instance: TrophySource | undefined;
+
+        expect(() => {
+            instance = myContainer.get<TrophySource>(TYPES.TrophySource);
+        }).not.toThrow();
+
+        expect(instance).toBeInstanceOf(PsnProfilesTrophySource);
+    });
+});

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/PsnProfilesTrophySource.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/PsnProfilesTrophySource.test.ts
@@ -1,0 +1,148 @@
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { PsnProfilesTrophySource } from '../../../../src/Infrastructure/Trophy/PsnProfilesTrophySource';
+import { TrophyNotEarnedYet } from '../../../../src/Domain/Trophy/TrophyNotEarnedYet';
+import type { HttpClient } from '../../../../src/Domain/Http/HttpClient';
+
+/**
+ * PsnProfilesTrophySource is ported from
+ * old-discord-bot/src/service/trophy/psnCrawlService.js, which scraped
+ * PSNProfiles with JSDOM + jQuery. This suite exercises the regex-based
+ * parser against small, trimmed HTML fixtures (tests/.../fixtures/*.html)
+ * standing in for real PSNProfiles markup — no mocking library, no network
+ * calls. A FakeHttpClient below returns canned fixture content keyed by URL.
+ */
+
+function fixture(name: string): string {
+    return readFileSync(join(import.meta.dir, 'fixtures', name), 'utf-8');
+}
+
+class FakeHttpClient implements HttpClient {
+    public readonly requestedUrls: string[] = [];
+
+    constructor(private readonly responsesByUrl: Record<string, string>) {}
+
+    async get(url: string): Promise<string> {
+        this.requestedUrls.push(url);
+        const response = this.responsesByUrl[url];
+        if (response === undefined) {
+            throw new Error(`FakeHttpClient: no fixture registered for ${url}`);
+        }
+        return response;
+    }
+
+    async post(): Promise<never> {
+        throw new Error('FakeHttpClient: post() not supported');
+    }
+
+    async put(): Promise<never> {
+        throw new Error('FakeHttpClient: put() not supported');
+    }
+
+    async delete(): Promise<never> {
+        throw new Error('FakeHttpClient: delete() not supported');
+    }
+}
+
+describe('PsnProfilesTrophySource', () => {
+    describe('getPlatinumTrophyData', () => {
+        test('extracts rarity percentage and completion date from a completed row', async () => {
+            const trophyUrl =
+                'https://psnprofiles.com/trophies/11783-assassins-creed-valhalla/Josh_Lopes';
+            const httpClient = new FakeHttpClient({
+                [trophyUrl]: fixture('trophy-completed.html'),
+            });
+            const source = new PsnProfilesTrophySource(httpClient);
+
+            const data = await source.getPlatinumTrophyData(trophyUrl);
+
+            expect(data.percentage).toBe(52.03);
+            expect(data.completionDate.toISOString().slice(0, 10)).toBe('2021-06-29');
+        });
+
+        test('applies the blank-first-row workaround and reads the second row', async () => {
+            const trophyUrl =
+                'https://psnprofiles.com/trophies/11805-marvels-spider-man-miles-morales/Josh_Lopes';
+            const httpClient = new FakeHttpClient({
+                [trophyUrl]: fixture('trophy-blank-first-row.html'),
+            });
+            const source = new PsnProfilesTrophySource(httpClient);
+
+            const data = await source.getPlatinumTrophyData(trophyUrl);
+
+            expect(data.percentage).toBe(8.42);
+            expect(data.completionDate.toISOString().slice(0, 10)).toBe('2022-01-01');
+        });
+
+        test('throws TrophyNotEarnedYet when the row is not marked completed', async () => {
+            const trophyUrl = 'https://psnprofiles.com/trophies/99999-some-game/NunoGamerHDYT';
+            const httpClient = new FakeHttpClient({
+                [trophyUrl]: fixture('trophy-not-earned.html'),
+            });
+            const source = new PsnProfilesTrophySource(httpClient);
+
+            await expect(source.getPlatinumTrophyData(trophyUrl)).rejects.toBeInstanceOf(
+                TrophyNotEarnedYet,
+            );
+        });
+    });
+
+    describe('getProfileRank', () => {
+        test('extracts world rank and country rank, stripping thousands separators', async () => {
+            const httpClient = new FakeHttpClient({
+                'https://psnprofiles.com/Josh_Lopes': fixture('profile-rank.html'),
+            });
+            const source = new PsnProfilesTrophySource(httpClient);
+
+            const rank = await source.getProfileRank('Josh_Lopes');
+
+            expect(rank.worldRank).toBe(712304);
+            expect(rank.countryRank).toBe(84512);
+        });
+
+        test('returns nulls for both ranks when the profile has no visible rank (banned)', async () => {
+            const httpClient = new FakeHttpClient({
+                'https://psnprofiles.com/oneeye_japan': fixture('profile-rank-banned.html'),
+            });
+            const source = new PsnProfilesTrophySource(httpClient);
+
+            const rank = await source.getProfileRank('oneeye_japan');
+
+            expect(rank.worldRank).toBeNull();
+            expect(rank.countryRank).toBeNull();
+        });
+    });
+
+    describe('getProfileTrophies', () => {
+        test('returns only the platinum rows, resolved to absolute URLs, in document order', async () => {
+            const httpClient = new FakeHttpClient({
+                'https://psnprofiles.com/Josh_Lopes?completion=platinum&order=last-trophy&page=1':
+                    fixture('profile-trophies-list.html'),
+            });
+            const source = new PsnProfilesTrophySource(httpClient);
+
+            const urls = await source.getProfileTrophies('Josh_Lopes');
+
+            expect(urls).toEqual([
+                'https://psnprofiles.com/trophies/11783-assassins-creed-valhalla/Josh_Lopes',
+                'https://psnprofiles.com/trophies/11805-marvels-spider-man-miles-morales/Josh_Lopes',
+            ]);
+        });
+
+        test('defaults to page 1 and paginates via the page argument', async () => {
+            const httpClient = new FakeHttpClient({
+                'https://psnprofiles.com/Josh_Lopes?completion=platinum&order=last-trophy&page=2':
+                    fixture('profile-trophies-empty.html'),
+            });
+            const source = new PsnProfilesTrophySource(httpClient);
+
+            const urls = await source.getProfileTrophies('Josh_Lopes', 2);
+
+            expect(urls).toEqual([]);
+            expect(httpClient.requestedUrls).toEqual([
+                'https://psnprofiles.com/Josh_Lopes?completion=platinum&order=last-trophy&page=2',
+            ]);
+        });
+    });
+});

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/profile-rank-banned.html
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/profile-rank-banned.html
@@ -1,0 +1,3 @@
+<div class="stats">
+    <span class="level">42</span>
+</div>

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/profile-rank.html
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/profile-rank.html
@@ -1,0 +1,4 @@
+<div class="stats">
+    <span class="rank">712,304</span>
+    <span class="country-rank">84,512</span>
+</div>

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/profile-trophies-empty.html
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/profile-trophies-empty.html
@@ -1,0 +1,8 @@
+<table id="gamesTable">
+    <thead>
+        <tr>
+            <th>Game</th>
+        </tr>
+    </thead>
+    <tbody></tbody>
+</table>

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/profile-trophies-list.html
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/profile-trophies-list.html
@@ -1,0 +1,26 @@
+<table id="gamesTable">
+    <thead>
+        <tr>
+            <th>Game</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr class="platinum">
+            <td>
+                <a href="/trophies/11783-assassins-creed-valhalla/Josh_Lopes"
+                    >Assassin's Creed Valhalla</a
+                >
+            </td>
+        </tr>
+        <tr class="gold">
+            <td><a href="/trophies/9999-some-other-game/Josh_Lopes">Some Other Game</a></td>
+        </tr>
+        <tr class="platinum">
+            <td>
+                <a href="/trophies/11805-marvels-spider-man-miles-morales/Josh_Lopes"
+                    >Marvel's Spider-Man: Miles Morales</a
+                >
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/trophy-blank-first-row.html
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/trophy-blank-first-row.html
@@ -1,0 +1,24 @@
+<div class="box no-top-border">
+    <table>
+        <thead>
+            <tr>
+                <th>Trophy</th>
+                <th>Rarity</th>
+                <th>Earned</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr></tr>
+            <tr class="completed">
+                <td class="hover-hide">
+                    <span class="typo-top">8.42%</span>
+                    <span class="typo-bottom">Very Rare</span>
+                </td>
+                <td class="hover-hide">
+                    <span class="typo-top-date">1st Jan 2022</span>
+                    <span class="typo-bottom">9:00am</span>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/trophy-completed.html
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/trophy-completed.html
@@ -1,0 +1,23 @@
+<div class="box no-top-border">
+    <table>
+        <thead>
+            <tr>
+                <th>Trophy</th>
+                <th>Rarity</th>
+                <th>Earned</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="completed">
+                <td class="hover-hide">
+                    <span class="typo-top">52.03%</span>
+                    <span class="typo-bottom">Ultra Rare</span>
+                </td>
+                <td class="hover-hide">
+                    <span class="typo-top-date">29th Jun 2021</span>
+                    <span class="typo-bottom">10:14pm</span>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/trophy-not-earned.html
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/trophy-not-earned.html
@@ -1,0 +1,22 @@
+<div class="box no-top-border">
+    <table>
+        <thead>
+            <tr>
+                <th>Trophy</th>
+                <th>Rarity</th>
+                <th>Earned</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="not-completed">
+                <td class="hover-hide">
+                    <span class="typo-top">12.10%</span>
+                    <span class="typo-bottom">Rare</span>
+                </td>
+                <td class="hover-hide">
+                    <span class="typo-bottom">Not earned</span>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>


### PR DESCRIPTION
## What changed

Ports the two **pure, data-producing** pieces of the old bot's trophy system,
scoped so M7.3 (the `trophies:sync` job) can be dropped on top cleanly. Does
**not** build the sync job, the auto-moderation flag writes, or announcements
— those are M7.3/M7.8, deliberately out of scope here.

### M7.1 — `TrophySource` port + `PsnProfilesTrophySource`

- `src/Domain/Trophy/TrophySource.ts` — a Domain-layer port (zero framework
  imports): `getProfileRank`, `getProfileTrophies` (paginated), and
  `getPlatinumTrophyData`.
- `src/Infrastructure/Trophy/PsnProfilesTrophySource.ts` — the concrete
  implementation, ported from
  `old-discord-bot/src/service/trophy/psnCrawlService.js` (which used JSDOM +
  jQuery). No new dependency: it goes through the existing `HttpClient` port
  (`TYPES.HttpClient` → `RetryHttpClient` → `FetchHttpClient`) and parses
  PSNProfiles' markup with small, scoped regexes over specific known
  fragments — the same way the old bot's CSS selectors targeted specific
  known fragments, just without jQuery/JSDOM as a dependency.
- Ported verbatim from the old bot:
  - the **blank-first-row workaround** (some trophy pages have an empty
    `<tr></tr>` before the real completed row — skip to the second row).
  - **"not earned yet" detection** — a trophy row without the `completed`
    class throws `TrophyNotEarnedYet` (`src/Domain/Trophy/TrophyNotEarnedYet.ts`),
    replacing the old bot's plain `Error('User hasn't earned the plat trophy yet!')`.
  - **world rank / country rank** extraction, returning `null`/`null` when a
    profile has no visible rank (the old bot's banned-account signal).
  - **paginated** platinum-trophy listing (`?completion=platinum&order=last-trophy&page=N`).
- Good-citizen behaviour: a real, descriptive `User-Agent`
  (`GameOnPortugalBot/1.0 (+repo url; ...)`), and a 1s throttle between
  requests on each `PsnProfilesTrophySource` instance. 429/5xx backoff comes
  free from `RetryHttpClient`, which already retries with exponential
  backoff on any thrown error, and `FetchHttpClient` already throws on any
  non-2xx response — read both before duplicating anything.
- Bound `TYPES.TrophySource → PsnProfilesTrophySource` in
  `inversify.config.ts` (4-line diff: 2 imports + 1 symbol + 1 bind), kept
  minimal since another PR is touching the same file in parallel.

### M7.2 — points ladder + claim exception

- `src/Domain/Trophy/TrophyPoints.ts#calculateTrophyPoints` — pure function,
  no I/O. The rarity → TP ladder, copied **verbatim** (boundaries and order)
  from `old-discord-bot/src/service/trophy/trophyManager.js#transformPercentageIntoPoints`:

  | Platinum rarity | TP |
  |---|---|
  | > 30.01% | 50 |
  | > 15.01% | 100 |
  | > 8.01% | 250 |
  | > 5.01% | 500 |
  | > 2.01% | 800 |
  | > 0.6% | 1250 |
  | ≤ 0.6% | 2000 |

- `src/Domain/Trophy/TrophyAlreadyClaimed.ts` — ports the semantics of
  `old-discord-bot/src/exception/trophy/trophyAlreadyClaimedException.js`
  (`TrophyAlreadyClaimedException`): one claim per (profile, trophy URL).
  Renamed to drop the `Exception` suffix to match this repo's convention
  (`ProfileNotFound`, `ProfileAlreadyExists`, `RecordNotFound` — none carry
  it). Not wired to any write path yet — that's M7.3's job (create-trophy
  handler), which is expected to catch it to implement catch-up mode.

## What I tested

- `TrophyPoints.test.ts` — table-driven, hits **both sides of every band
  boundary** (e.g. 30.02% → 50, exactly 30.01% → 100, 30.00% → 100), plus the
  extremes (0%, 100%).
- `PsnProfilesTrophySource.test.ts` — against small, trimmed HTML fixtures
  under `tests/Integration/Infrastructure/Trophy/fixtures/*.html`, with a
  hand-rolled fake `HttpClient` (no mocking library, no network calls):
  completed-row parsing, the blank-first-row case, the not-earned-yet case,
  rank extraction (including the null/null "banned" case), and paginated
  trophy listing (including the empty-page case).
- `TrophyAlreadyClaimed.test.ts` — exception shape/message.
- `TrophySource.container.test.ts` — asserts the DI container actually
  resolves `TYPES.TrophySource` to a `PsnProfilesTrophySource`, not just that
  the class carries `@injectable()` (see M0.6 precedent).
- Full verify loop: `bun run typecheck && bun run lint && bun run format:check && bun test`
  — all clean. **57 → 87 tests** (30 new), 0 new lint errors (same 113
  pre-existing warnings), 0 typecheck errors.

## Judgement calls

- **No HTML parser dependency added.** Regexes are scoped to specific known
  fragments (a `div.stats` block, a trophy table's `<tbody>`, a
  `table#gamesTable` row) and explicitly aren't a general HTML parser — e.g.
  class-token matching splits and does exact-array-membership checks rather
  than substring matching, specifically to avoid `rank` false-matching
  inside `country-rank`, and `typo-top` false-matching inside
  `typo-top-date`. This holds for every shape PSNProfiles' own markup takes
  in these specific blocks; it would not hold as a general parser.
- **robots.txt**: not fetched/parsed dynamically. PSNProfiles' robots.txt
  disallows a handful of search/ajax paths (not profile/trophy pages) and
  carries no explicit `Crawl-delay`; I implemented the *intent* — descriptive
  UA + 1 req/s throttle — rather than a dynamic robots.txt client, to keep
  this PR to the two pure pieces it's scoped to.
- **Renamed `TrophyAlreadyClaimedException` → `TrophyAlreadyClaimed`** to
  match this repo's existing exception-naming convention (see above). Same
  semantics, no `Exception` suffix.
- **Rate limiting is per-instance**, not global/shared across concurrent
  crawls — fine for M7.3's expected single-threaded sync job over ~118
  profiles, called out in case a future concurrent use needs a shared
  limiter.

## What I deliberately left out (belongs to later milestones)

- The `trophies:sync` job itself, catch-up mode, and the auto-moderation
  flag writes (`flagAsBanned`/`flagAsExcluded`/`flagAsLeaver` — M7.3).
- Wiring `TrophyAlreadyClaimed` into an actual write path (M7.3's
  create-trophy handler).
- Trophy announcements (M7.8) and live rank display in `/trophy check`
  (M7.4) — both consume `TrophySource` but are separate PRs per the plan.
- No `prisma/schema.prisma` changes — this PR is a pure addition, as
  instructed.
