### PR TITLE
ci: allow the media scope on PR titles, and publish the list the gate enforces

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -36,6 +36,7 @@ jobs:
             marketplace
             screenshots
             trophies
+            media
             scheduler
             portal
             portal-api

--- a/docs/plans/GLOBAL-PLAN.md
+++ b/docs/plans/GLOBAL-PLAN.md
@@ -38,9 +38,20 @@ bun test                      # must be green
 ```
 
 Plus: a test that would have caught the bug, a Conventional-Commit PR title with
-a scope (`fix(marketplace): …`, `feat(trophy): …` — **not** `chore:`, which cuts
+a scope (`fix(marketplace): …`, `feat(trophies): …` — **not** `chore:`, which cuts
 no release), and a migration (`make db.diff NAME=…`) if `schema.prisma` changed,
 because the production entrypoint runs `prisma migrate deploy` on every boot.
+
+The scope is **validated by CI** (`.github/workflows/pr-title.yml`) against a
+closed list, so a plausible-looking scope that is not on it fails the PR:
+
+```
+bot  marketplace  screenshots  trophies  media  scheduler
+portal  portal-api  portal-web  db  ci  docker  infra  deps  deps-dev
+```
+
+Note `trophies`, not `trophy`. If a genuinely new area appears, add it to that
+workflow in the same PR rather than picking the nearest existing scope.
 
 ### Where the evidence lives
 


### PR DESCRIPTION
Two small things that cost a round trip each time somebody hits them.

## `media` scope

`.github/workflows/pr-title.yml` validates the PR-title scope against a closed list. **M6.0** introduces a media-storage area (a `MediaStorage` domain port + S3/MinIO adapter) that has no scope on it — and it serves *both* the marketplace and the screenshots gallery, so neither existing scope is honest. Added `media`.

## The list was undiscoverable

It lives only in the workflow file. Meanwhile the "definition of done" section of `docs/plans/GLOBAL-PLAN.md` gave `feat(trophy): …` as its worked example — **a scope the gate rejects**, because the real one is `trophies`. The one place an agent looks for the convention was demonstrating a failing title. (Confirmed the hard way on #24.)

Fixed the example and inlined the authoritative list next to it, with a note to add genuinely new areas to the workflow in the same PR rather than picking the nearest existing scope.

## Scope

Workflow config + docs. No code, no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)