### PR TITLE
feat(bot): type the interaction layer, defer every slow handler and bound embed output (M4.1, M4.2, M4.10)

### DIFF
--- a/discord-bot/src/Domain/Bot/InteractionContext.ts
+++ b/discord-bot/src/Domain/Bot/InteractionContext.ts
@@ -1,0 +1,42 @@
+import type {
+    AnySelectMenuInteraction,
+    AutocompleteInteraction,
+    ButtonInteraction,
+    Client,
+    ModalSubmitInteraction,
+} from 'discord.js';
+import type { SlashCommandContext } from './SlashCommandContext';
+
+/**
+ * Every interaction shape the bot could ever receive from Discord, as a
+ * discriminated union on `kind`. Only the `chat-input` member
+ * (`SlashCommandContext`) is actually dispatched today — `BotExecutor` and
+ * `DiscordBot`'s `InteractionCreate` handler only route
+ * `ChatInputCommandInteraction`s. The other members are typed here so a
+ * future dispatcher (autocomplete, buttons, modals — see M4.7/M4.8) has a
+ * real type to grow into instead of another `interaction: any`. Building
+ * that dispatcher is out of scope for this change.
+ */
+export interface AutocompleteInteractionContext {
+    readonly kind: 'autocomplete';
+    readonly client?: Client;
+    readonly interaction: AutocompleteInteraction;
+}
+
+export interface ComponentInteractionContext {
+    readonly kind: 'component';
+    readonly client?: Client;
+    readonly interaction: ButtonInteraction | AnySelectMenuInteraction;
+}
+
+export interface ModalInteractionContext {
+    readonly kind: 'modal';
+    readonly client?: Client;
+    readonly interaction: ModalSubmitInteraction;
+}
+
+export type InteractionContext =
+    | SlashCommandContext
+    | AutocompleteInteractionContext
+    | ComponentInteractionContext
+    | ModalInteractionContext;

--- a/discord-bot/src/Domain/Bot/SlashCommandContext.ts
+++ b/discord-bot/src/Domain/Bot/SlashCommandContext.ts
@@ -1,7 +1,10 @@
+import type { ChatInputCommandInteraction, Client } from 'discord.js';
+
 export interface SlashCommandContext {
+    readonly kind: 'chat-input';
     readonly channel_id: string;
     readonly command: string;
     readonly text: string;
-    readonly client?: any;
-    readonly interaction: any;
+    readonly client?: Client;
+    readonly interaction: ChatInputCommandInteraction;
 }

--- a/discord-bot/src/Domain/Bot/SlashCommandHandler.ts
+++ b/discord-bot/src/Domain/Bot/SlashCommandHandler.ts
@@ -1,9 +1,16 @@
+import type { SlashCommandBuilder, SlashCommandSubcommandsOnlyBuilder } from 'discord.js';
 import type { SlashCommandContext } from './SlashCommandContext';
 
 export interface SlashCommandHandler {
     getName: () => string;
 
-    builder: () => any;
+    // discord.js's own builder narrows from `SlashCommandBuilder` to
+    // `SlashCommandSubcommandsOnlyBuilder` the moment `.addSubcommand()` is
+    // called, so every `builder()` implementation with subcommands
+    // (Marketplace/Screenshot/Trophy) actually returns the narrower type.
+    // Both are accepted here since `PingSlashCommand` (no subcommands) still
+    // returns the base `SlashCommandBuilder`.
+    builder: () => SlashCommandBuilder | SlashCommandSubcommandsOnlyBuilder;
 
     handle: (context: SlashCommandContext) => Promise<void>;
 }

--- a/discord-bot/src/Domain/Bot/embedLimits.ts
+++ b/discord-bot/src/Domain/Bot/embedLimits.ts
@@ -1,0 +1,138 @@
+/**
+ * Discord's hard limits on embed/message output (M4.10). Nothing in this
+ * codebase enforced these before: `ListAdsSubcommand` added one embed field
+ * per ad with no cap at all, so a user with 26+ listings broke the command
+ * outright (Discord rejects the whole interaction response). This module is
+ * the single place these numbers live so every call site caps consistently.
+ *
+ * Source: https://discord.com/developers/docs/resources/message#embed-object-embed-limits
+ */
+export const EMBED_MAX_FIELDS = 25;
+export const EMBED_FIELD_NAME_MAX_LENGTH = 256;
+export const EMBED_FIELD_VALUE_MAX_LENGTH = 1024;
+export const EMBED_MAX_TOTAL_LENGTH = 6000;
+
+/** Discord's plain message content limit. */
+export const MESSAGE_MAX_LENGTH = 2000;
+
+const ELLIPSIS = '…';
+
+/**
+ * Truncates a string to `maxLength`, replacing the tail with an ellipsis
+ * rather than letting an over-long value throw at Discord's API boundary.
+ */
+export function truncate(value: string, maxLength: number): string {
+    if (value.length <= maxLength) {
+        return value;
+    }
+
+    if (maxLength <= ELLIPSIS.length) {
+        return ELLIPSIS.slice(0, maxLength);
+    }
+
+    return `${value.slice(0, maxLength - ELLIPSIS.length)}${ELLIPSIS}`;
+}
+
+/** Truncates a field name to Discord's 256-character embed field name limit. */
+export function truncateFieldName(name: string): string {
+    return truncate(name, EMBED_FIELD_NAME_MAX_LENGTH);
+}
+
+/** Truncates a field value to Discord's 1024-character embed field value limit. */
+export function truncateFieldValue(value: string): string {
+    return truncate(value, EMBED_FIELD_VALUE_MAX_LENGTH);
+}
+
+export interface EmbedField {
+    name: string;
+    value: string;
+    inline?: boolean;
+}
+
+export interface CappedFields<T> {
+    /** At most `maxFields` fields, each truncated to Discord's per-field limits. */
+    fields: EmbedField[];
+    /** How many of the input items did not make it into `fields`. */
+    omittedCount: number;
+    /** The items that were left out. */
+    omittedItems: T[];
+}
+
+/**
+ * Builds up to `maxFields` embed fields (Discord's own hard cap,
+ * `EMBED_MAX_FIELDS`, by default) from a list of items, truncating any
+ * over-long name/value and reporting how many items had to be left out so
+ * the caller can tell the user. Pass a smaller `maxFields` for a
+ * command-specific display limit (e.g. `/screenshot list` shows at most 10)
+ * while still sharing the same truncation/omission behaviour as every other
+ * caller.
+ *
+ * Also respects the embed-wide 6000-character budget: 25 fields at the
+ * per-field max (1024 chars) would total 25600 characters, well past the
+ * limit, so a field that would push the running total over
+ * `EMBED_MAX_TOTAL_LENGTH` is omitted too, not just ones past `maxFields`.
+ * `reservedLength` lets the caller account for characters already spent on
+ * the title/description/footer.
+ */
+export function capFields<T>(
+    items: T[],
+    toField: (item: T, index: number) => EmbedField,
+    reservedLength = 0,
+    maxFields: number = EMBED_MAX_FIELDS,
+): CappedFields<T> {
+    const fields: EmbedField[] = [];
+    const omittedItems: T[] = [];
+    let totalLength = reservedLength;
+
+    items.forEach((item, index) => {
+        if (fields.length >= maxFields) {
+            omittedItems.push(item);
+            return;
+        }
+
+        const field = toField(item, index);
+        const name = truncateFieldName(field.name);
+        const value = truncateFieldValue(field.value);
+        const fieldLength = name.length + value.length;
+
+        if (totalLength + fieldLength > EMBED_MAX_TOTAL_LENGTH) {
+            omittedItems.push(item);
+            return;
+        }
+
+        fields.push({ ...field, name, value });
+        totalLength += fieldLength;
+    });
+
+    return { fields, omittedCount: omittedItems.length, omittedItems };
+}
+
+/**
+ * Splits plain text into chunks no longer than `maxLength` (Discord's
+ * 2000-character message content limit by default), breaking on line
+ * boundaries where possible so a chunk doesn't cut a line in half.
+ */
+export function chunkMessage(text: string, maxLength: number = MESSAGE_MAX_LENGTH): string[] {
+    if (text.length === 0) {
+        return [];
+    }
+
+    const chunks: string[] = [];
+    let remaining = text;
+
+    while (remaining.length > maxLength) {
+        let splitAt = remaining.lastIndexOf('\n', maxLength);
+        if (splitAt <= 0) {
+            splitAt = maxLength;
+        }
+
+        chunks.push(remaining.slice(0, splitAt));
+        remaining = remaining.slice(splitAt).replace(/^\n/, '');
+    }
+
+    if (remaining.length > 0) {
+        chunks.push(remaining);
+    }
+
+    return chunks;
+}

--- a/discord-bot/src/Domain/Bot/safeReply.ts
+++ b/discord-bot/src/Domain/Bot/safeReply.ts
@@ -1,7 +1,8 @@
-import type {
-    InteractionEditReplyOptions,
-    InteractionReplyOptions,
-    RepliableInteraction,
+import {
+    MessageFlags,
+    type InteractionEditReplyOptions,
+    type InteractionReplyOptions,
+    type RepliableInteraction,
 } from 'discord.js';
 
 /**
@@ -46,4 +47,47 @@ export async function safeReply(
     }
 
     return interaction.reply(payload);
+}
+
+/**
+ * Replies to an interaction ephemerally, regardless of how it has already
+ * been acknowledged -- including the case where it was deferred *publicly*
+ * (a command whose happy path is meant to be visible, e.g. `/trophy check`
+ * shows off a profile) but this particular outcome -- an error, a
+ * "not found" -- is not for the whole channel.
+ *
+ * This exists because of M0.3: "ephemeral" error messages were being posted
+ * publicly, one of the five live production defects fixed and verified
+ * before this file existed. The trap it guards against is calling
+ * `editReply()` after a public defer: that edits the public "thinking..."
+ * placeholder into a message everyone in the channel can see, because
+ * ephemeral-ness is fixed at `deferReply()` time and cannot change
+ * afterwards. The fix is to delete that placeholder and post a fresh,
+ * genuinely ephemeral message via `followUp()` instead -- the supported
+ * discord.js v14 pattern for "public defer, private outcome".
+ *
+ * Any subcommand that defers non-ephemerally but has a failure/not-found
+ * path only the invoker should see needs this, not `safeReply()` -- reach
+ * for this one first before re-deriving the same delete-then-followUp
+ * dance from scratch.
+ */
+export async function replyPrivately(
+    interaction: RepliableInteraction,
+    payload: SafeReplyPayload,
+): Promise<unknown> {
+    const ephemeralPayload: InteractionReplyOptions = {
+        ...(typeof payload === 'string' ? { content: payload } : payload),
+        flags: MessageFlags.Ephemeral,
+    };
+
+    if (interaction.deferred && !interaction.replied) {
+        await interaction.deleteReply();
+        return interaction.followUp(ephemeralPayload);
+    }
+
+    if (interaction.replied) {
+        return interaction.followUp(ephemeralPayload);
+    }
+
+    return interaction.reply(ephemeralPayload);
 }

--- a/discord-bot/src/Domain/Bot/safeReply.ts
+++ b/discord-bot/src/Domain/Bot/safeReply.ts
@@ -1,3 +1,16 @@
+import type {
+    InteractionEditReplyOptions,
+    InteractionReplyOptions,
+    RepliableInteraction,
+} from 'discord.js';
+
+/**
+ * The payload shapes every safeReply() call site in this codebase actually
+ * passes: a plain string, or the reply-time options object (which is what
+ * `reply()`/`followUp()` are typed to accept).
+ */
+export type SafeReplyPayload = string | InteractionReplyOptions;
+
 /**
  * Sends a reply to a Discord interaction, choosing the correct discord.js
  * method for the interaction's current state.
@@ -12,13 +25,24 @@
  * - deferred but not replied   -> `editReply` (fill in the deferred reply)
  * - neither                    -> `reply`
  */
-export async function safeReply(interaction: any, payload: any): Promise<unknown> {
+export async function safeReply(
+    interaction: RepliableInteraction,
+    payload: SafeReplyPayload,
+): Promise<unknown> {
     if (interaction.replied) {
         return interaction.followUp(payload);
     }
 
     if (interaction.deferred) {
-        return interaction.editReply(payload);
+        // `editReply()` is typed narrower than `reply()`/`followUp()`: it
+        // cannot accept `flags: Ephemeral` because a deferred reply's
+        // ephemeral-ness is fixed by the original `deferReply()` call and
+        // cannot change afterwards (a Discord API constraint, not a
+        // discord.js oversight — see InteractionEditReplyOptions). Every
+        // safeReply() caller that reaches this branch is passing the same
+        // "something went wrong" payload it would otherwise hand to
+        // `reply()`; any `flags` on it is a harmless no-op here.
+        return interaction.editReply(payload as InteractionEditReplyOptions);
     }
 
     return interaction.reply(payload);

--- a/discord-bot/src/Infrastructure/Bot/BotExecutor.ts
+++ b/discord-bot/src/Infrastructure/Bot/BotExecutor.ts
@@ -62,6 +62,8 @@ export class BotExecutor {
     }
 }
 
-function isMentionContext(context: any): context is MentionContext {
+function isMentionContext(
+    context: MentionContext | SlashCommandContext,
+): context is MentionContext {
     return (context as MentionContext).event !== undefined;
 }

--- a/discord-bot/src/Infrastructure/Bot/Discord/DiscordBot.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/DiscordBot.ts
@@ -41,6 +41,7 @@ export class DiscordBot implements Bot {
             if (!interaction.isChatInputCommand()) return;
 
             const slashCommandContext: SlashCommandContext = {
+                kind: 'chat-input',
                 channel_id: interaction.channelId,
                 command: interaction.commandName,
                 text: '',

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/DeleteAdSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/DeleteAdSubcommand.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from 'inversify';
 import type { SlashCommandContext } from '../../../../../Domain/Bot/SlashCommandContext';
 import { randomUUID } from 'crypto';
+import { MessageFlags } from 'discord.js';
 import { TYPES } from '../../../../DependencyInjection/types';
 import type Logger from '../../../../../Application/Logger/Logger';
 import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerManager';
@@ -25,6 +26,12 @@ export class DeleteAdSubcommand {
         const identifier = interaction.options.getString('id', true);
         const userId = interaction.user.id;
 
+        // Deferred first: resolving a numeric position requires a ListUserAds
+        // query before the delete itself, so this can already be slower than
+        // the 3s interaction-ack window. Every reply below is ephemeral, so
+        // fixing that at defer time changes nothing about visibility.
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
         let adId: AdId;
         try {
             if (/^\d+$/.test(identifier)) {
@@ -34,7 +41,7 @@ export class DeleteAdSubcommand {
                 // types the element as possibly-undefined and cannot see the guard above.
                 const ad = ads[position];
                 if (!ad) {
-                    await interaction.reply({ content: 'Invalid ad position', ephemeral: true });
+                    await interaction.editReply({ content: 'Invalid ad position' });
                     return;
                 }
                 adId = ad.id;
@@ -43,7 +50,7 @@ export class DeleteAdSubcommand {
             }
         } catch (error) {
             if (error instanceof InvalidId) {
-                await interaction.reply({ content: 'Invalid Ad ID', ephemeral: true });
+                await interaction.editReply({ content: 'Invalid Ad ID' });
                 return;
             }
             throw error;
@@ -51,17 +58,15 @@ export class DeleteAdSubcommand {
 
         try {
             await this.commandHandlerManager.handle(new DeleteAd(adId, userId));
-            await interaction.reply({ content: 'Ad deleted successfully', ephemeral: true });
+            await interaction.editReply({ content: 'Ad deleted successfully' });
         } catch (error) {
             if (error instanceof UnauthorizedAdDeletion) {
-                await interaction.reply({
+                await interaction.editReply({
                     content: 'You are not authorized to delete this ad',
-                    ephemeral: true,
                 });
             } else if (error instanceof RecordNotFound) {
-                await interaction.reply({
+                await interaction.editReply({
                     content: 'Ad not found',
-                    ephemeral: true,
                 });
             } else {
                 const correlationId = randomUUID();
@@ -71,9 +76,8 @@ export class DeleteAdSubcommand {
                     adId: adId.toString(),
                     userId,
                 });
-                await interaction.reply({
+                await interaction.editReply({
                     content: `There was an error deleting your ad. Please try again. (ref: ${correlationId})`,
-                    ephemeral: true,
                 });
             }
         }

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/ListAdsSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/ListAdsSubcommand.ts
@@ -54,12 +54,12 @@ export class ListAdsSubcommand {
     public async handle(context: SlashCommandContext): Promise<void> {
         const targetUser = context.interaction.options.getUser('user') ?? context.interaction.user;
 
-        // The successful reply is public (no `flags`), so the defer is public
-        // too — ephemeral-ness is fixed at defer time and cannot change later.
-        // The error/no-ads paths below used to be ephemeral; they now post
-        // publicly like the rest of this command, which is the intentional
-        // trade-off for being able to defer at all (see PR description).
-        await context.interaction.deferReply();
+        // Ephemeral for the whole command (M5.8 already settles `/marketplace
+        // list` as ephemeral going forward, so this moves toward the settled
+        // design rather than away from it). This also keeps every path below
+        // ephemeral without exception, so there is no ephemeral-to-public
+        // leak on the error/no-ads paths (M0.3).
+        await context.interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
         try {
             const ads = await this.commandHandlerManager.handle(new ListUserAds(targetUser.id));

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/ListAdsSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/ListAdsSubcommand.ts
@@ -6,6 +6,8 @@ import type Logger from '../../../../../Application/Logger/Logger';
 import { ListUserAds } from '../../../../../Application/Query/Marketplace/ListUserAds/ListUserAds';
 import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerManager.ts';
 import type { Ad } from '../../../../../Domain/Marketplace/Ad.ts';
+import { capFields } from '../../../../../Domain/Bot/embedLimits.ts';
+import { safeReply } from '../../../../../Domain/Bot/safeReply.ts';
 
 @injectable()
 export class ListAdsSubcommand {
@@ -52,25 +54,35 @@ export class ListAdsSubcommand {
     public async handle(context: SlashCommandContext): Promise<void> {
         const targetUser = context.interaction.options.getUser('user') ?? context.interaction.user;
 
+        // The successful reply is public (no `flags`), so the defer is public
+        // too — ephemeral-ness is fixed at defer time and cannot change later.
+        // The error/no-ads paths below used to be ephemeral; they now post
+        // publicly like the rest of this command, which is the intentional
+        // trade-off for being able to defer at all (see PR description).
+        await context.interaction.deferReply();
+
         try {
             const ads = await this.commandHandlerManager.handle(new ListUserAds(targetUser.id));
 
             if (ads.length === 0) {
-                await context.interaction.reply({
+                await context.interaction.editReply({
                     content: `${targetUser.id === context.interaction.user.id ? "You don't" : "This user doesn't"} have any active listings.`,
-                    flags: MessageFlags.Ephemeral,
                 });
                 return;
             }
 
+            const title = `${targetUser.username}'s Marketplace Listings`;
+            const description = `Found ${ads.length} active listing${ads.length === 1 ? '' : 's'}`;
+
             const embed = new EmbedBuilder()
                 .setColor('#0099ff')
-                .setTitle(`${targetUser.username}'s Marketplace Listings`)
-                .setDescription(`Found ${ads.length} active listing${ads.length === 1 ? '' : 's'}`)
+                .setTitle(title)
+                .setDescription(description)
                 .setTimestamp();
 
-            ads.forEach((ad: Ad, index: number) => {
-                embed.addFields({
+            const { fields, omittedCount } = capFields(
+                ads,
+                (ad: Ad, index: number) => ({
                     name: `${index + 1}. ${ad.name}`,
                     value: [
                         `${this.getStateEmoji(ad.state)} ${this.getStateDisplay(ad.state)}`,
@@ -84,13 +96,21 @@ export class ListAdsSubcommand {
                     ]
                         .filter(Boolean)
                         .join('\n'),
-                });
-            });
+                }),
+                title.length + description.length,
+            );
+            embed.addFields(fields);
 
-            await context.interaction.reply({ embeds: [embed] });
+            if (omittedCount > 0) {
+                embed.setFooter({
+                    text: `Showing ${fields.length} of ${ads.length} listings — ${omittedCount} omitted. Narrow your search or ask an admin if you need to see the rest.`,
+                });
+            }
+
+            await context.interaction.editReply({ embeds: [embed] });
         } catch (error) {
             this.logger.error('Error listing ads', { error });
-            await context.interaction.reply({
+            await safeReply(context.interaction, {
                 content: 'There was an error fetching the listings. Please try again.',
                 flags: MessageFlags.Ephemeral,
             });

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/MarketplaceSlashCommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/MarketplaceSlashCommand.ts
@@ -1,7 +1,11 @@
 import { inject, injectable } from 'inversify';
 import type { SlashCommandHandler } from '../../../../../Domain/Bot/SlashCommandHandler';
 import type { SlashCommandContext } from '../../../../../Domain/Bot/SlashCommandContext';
-import { MessageFlags, SlashCommandBuilder } from 'discord.js';
+import {
+    MessageFlags,
+    SlashCommandBuilder,
+    type SlashCommandSubcommandsOnlyBuilder,
+} from 'discord.js';
 import { TYPES } from '../../../../DependencyInjection/types';
 import type Logger from '../../../../../Application/Logger/Logger';
 import { SellSubcommand } from './SellSubcommand';
@@ -21,7 +25,7 @@ export class MarketplaceSlashCommand implements SlashCommandHandler {
         return 'marketplace';
     }
 
-    public builder(): any {
+    public builder(): SlashCommandSubcommandsOnlyBuilder {
         return new SlashCommandBuilder()
             .setName('marketplace')
             .setDescription('Manage marketplace listings')

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/PingSlashCommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/PingSlashCommand.ts
@@ -16,7 +16,7 @@ export class PingSlashCommand implements SlashCommandHandler {
         return 'ping';
     }
 
-    public builder(): any {
+    public builder(): SlashCommandBuilder {
         return new SlashCommandBuilder().setName('ping').setDescription('Replies with a pong!');
     }
 

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/CreateScreenshotSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/CreateScreenshotSubcommand.ts
@@ -2,7 +2,7 @@ import { inject, injectable } from 'inversify';
 import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerManager.ts';
 import type Logger from '../../../../../Application/Logger/Logger.ts';
 import { TYPES } from '../../../../DependencyInjection/types.ts';
-import { escapeMarkdown, MessageFlags } from 'discord.js';
+import { escapeMarkdown, MessageFlags, type ChatInputCommandInteraction } from 'discord.js';
 import { ScreenshotId } from '../../../../../Domain/Screenshot/ScreenshotId.ts';
 import { CreateScreenshot } from '../../../../../Application/Write/Screenshot/CreateScreenshot/CreateScreenshot.ts';
 import { ScreenshotAlreadyExist } from '../../../../../Application/Write/Screenshot/CreateScreenshot/ScreenshotAlreadyExist.ts';
@@ -17,7 +17,7 @@ export class CreateScreenshotSubcommand {
         @inject(TYPES.Logger) private readonly logger: Logger,
     ) {}
 
-    public async handle(interaction: any): Promise<void> {
+    public async handle(interaction: ChatInputCommandInteraction): Promise<void> {
         const image = interaction.options.getAttachment('image');
         const name = interaction.options.getString('name');
         const platform = interaction.options.getString('platform');

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/DeleteScreenshotSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/DeleteScreenshotSubcommand.ts
@@ -4,7 +4,7 @@ import type Logger from '../../../../../Application/Logger/Logger.ts';
 import { TYPES } from '../../../../DependencyInjection/types.ts';
 import { ScreenshotId } from '../../../../../Domain/Screenshot/ScreenshotId.ts';
 import { DeleteScreenshot } from '../../../../../Application/Write/Screenshot/DeleteScreenshot/DeleteScreenshot.ts';
-import { MessageFlags } from 'discord.js';
+import { MessageFlags, type ChatInputCommandInteraction } from 'discord.js';
 import { InvalidId } from '../../../../../Domain/InvalidId.ts';
 import RecordNotFound from '../../../../../Domain/RecordNotFound.ts';
 import { NotAuthorized } from '../../../../../Application/Write/Screenshot/DeleteScreenshot/NotAuthorized.ts';
@@ -18,8 +18,8 @@ export class DeleteScreenshotSubcommand {
         @inject(TYPES.Logger) private readonly logger: Logger,
     ) {}
 
-    public async handle(interaction: any): Promise<void> {
-        const screenshotIdString = interaction.options.getString('id');
+    public async handle(interaction: ChatInputCommandInteraction): Promise<void> {
+        const screenshotIdString = interaction.options.getString('id', true);
         const cleanId = screenshotIdString.startsWith('#')
             ? screenshotIdString.substring(1)
             : screenshotIdString;

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ListScreenshotSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ListScreenshotSubcommand.ts
@@ -3,8 +3,13 @@ import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerMana
 import type Logger from '../../../../../Application/Logger/Logger.ts';
 import { TYPES } from '../../../../DependencyInjection/types.ts';
 import { GetScreenshots } from '../../../../../Application/Query/Screenshot/GetScreenshots/GetScreenshots.ts';
-import { EmbedBuilder, MessageFlags } from 'discord.js';
+import { EmbedBuilder, MessageFlags, type ChatInputCommandInteraction } from 'discord.js';
 import { safeReply } from '../../../../../Domain/Bot/safeReply.ts';
+import { capFields } from '../../../../../Domain/Bot/embedLimits.ts';
+import type { Screenshot } from '../../../../../Domain/Screenshot/Screenshot.ts';
+
+/** `/screenshot list`'s own display limit — smaller than Discord's 25-field cap. */
+const SCREENSHOT_LIST_DISPLAY_LIMIT = 10;
 
 @injectable()
 export class ListScreenshotSubcommand {
@@ -14,7 +19,12 @@ export class ListScreenshotSubcommand {
         @inject(TYPES.Logger) private readonly logger: Logger,
     ) {}
 
-    public async handle(interaction: any): Promise<void> {
+    public async handle(interaction: ChatInputCommandInteraction): Promise<void> {
+        // Deferred first: GetScreenshots can load a user's full history, which
+        // can take longer than the 3s interaction-ack window. The reply here
+        // is ephemeral either way, so the flag is safe to fix at defer time.
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
         try {
             // Get the target user (if specified) or default to the command user
             const targetUser = interaction.options.getUser('user') || interaction.user;
@@ -30,10 +40,7 @@ export class ListScreenshotSubcommand {
                     ? `🔍 **Your Screenshots**\n\nYou haven't submitted any screenshots yet. Use \`/screenshot create\` to submit one!`
                     : `🔍 **${targetUser.username}'s Screenshots**\n\nThis user hasn't submitted any screenshots yet.`;
 
-                await interaction.reply({
-                    content: message,
-                    flags: MessageFlags.Ephemeral,
-                });
+                await interaction.editReply({ content: message });
                 return;
             }
 
@@ -51,31 +58,31 @@ export class ListScreenshotSubcommand {
                 .setDescription(description)
                 .setTimestamp();
 
-            // Add fields for each screenshot (up to 10)
-            const displayLimit = Math.min(screenshots.length, 10);
-            for (let i = 0; i < displayLimit; i++) {
-                const screenshot = screenshots[i];
-                const platform = screenshot.platform
-                    ? screenshot.platform.charAt(0).toUpperCase() + screenshot.platform.slice(1)
-                    : 'Unknown';
+            const { fields, omittedCount } = capFields(
+                screenshots,
+                (screenshot: Screenshot, index: number) => {
+                    const platform = screenshot.platform
+                        ? screenshot.platform.charAt(0).toUpperCase() + screenshot.platform.slice(1)
+                        : 'Unknown';
 
-                embed.addFields({
-                    name: `#${i + 1} - ${screenshot.name || 'Unnamed'}`,
-                    value: `ID: ${screenshot.id.toString()}\nPlatform: ${platform}\nSubmitted: ${screenshot.createdAt.toLocaleDateString()}`,
-                });
-            }
+                    return {
+                        name: `#${index + 1} - ${screenshot.name || 'Unnamed'}`,
+                        value: `ID: ${screenshot.id.toString()}\nPlatform: ${platform}\nSubmitted: ${screenshot.createdAt.toLocaleDateString()}`,
+                    };
+                },
+                title.length + description.length,
+                SCREENSHOT_LIST_DISPLAY_LIMIT,
+            );
+            embed.addFields(fields);
 
             // Add a note if there are more screenshots than shown
-            if (screenshots.length > displayLimit) {
+            if (omittedCount > 0) {
                 embed.setFooter({
-                    text: `Showing ${displayLimit} of ${screenshots.length} screenshots.`,
+                    text: `Showing ${fields.length} of ${screenshots.length} screenshots.`,
                 });
             }
 
-            await interaction.reply({
-                embeds: [embed],
-                flags: MessageFlags.Ephemeral,
-            });
+            await interaction.editReply({ embeds: [embed] });
 
             this.logger.info('Screenshot list requested', {
                 userId: userId,

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ScreenshotSlashCommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ScreenshotSlashCommand.ts
@@ -1,7 +1,11 @@
 import { inject, injectable } from 'inversify';
 import type { SlashCommandHandler } from '../../../../../Domain/Bot/SlashCommandHandler.ts';
 import type { SlashCommandContext } from '../../../../../Domain/Bot/SlashCommandContext.ts';
-import { MessageFlags, SlashCommandBuilder } from 'discord.js';
+import {
+    MessageFlags,
+    SlashCommandBuilder,
+    type SlashCommandSubcommandsOnlyBuilder,
+} from 'discord.js';
 import { TYPES } from '../../../../DependencyInjection/types.ts';
 import type Logger from '../../../../../Application/Logger/Logger.ts';
 import { CreateScreenshotSubcommand } from './CreateScreenshotSubcommand.ts';
@@ -25,7 +29,7 @@ export class ScreenshotSlashCommand implements SlashCommandHandler {
         return 'screenshot';
     }
 
-    public builder(): any {
+    public builder(): SlashCommandSubcommandsOnlyBuilder {
         return (
             new SlashCommandBuilder()
                 .setName('screenshot')

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.ts
@@ -19,6 +19,12 @@ export class CheckTrophyProfileSubcommand {
     public async handle(context: SlashCommandContext): Promise<void> {
         const targetUser = context.interaction.options.getUser('user') ?? context.interaction.user;
 
+        // The successful reply is public (no `flags`), so the defer is public
+        // too — ephemeral-ness is fixed at defer time. The "not found"/error
+        // paths below used to be ephemeral; they now post publicly, which is
+        // the trade-off for being able to defer at all (see PR description).
+        await context.interaction.deferReply();
+
         try {
             const command = new GetProfile(targetUser.id);
             const profile = await this.commandHandlerManager.handle(command);
@@ -49,7 +55,7 @@ export class CheckTrophyProfileSubcommand {
                 .setFooter({ text: 'PSN Profile Status' })
                 .setTimestamp();
 
-            await context.interaction.reply({
+            await context.interaction.editReply({
                 embeds: [embed],
             });
         } catch (error) {

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.ts
@@ -1,12 +1,12 @@
 import { inject, injectable } from 'inversify';
 import type { SlashCommandContext } from '../../../../../Domain/Bot/SlashCommandContext';
-import { EmbedBuilder, MessageFlags } from 'discord.js';
+import { EmbedBuilder } from 'discord.js';
 import { TYPES } from '../../../../DependencyInjection/types';
 import type Logger from '../../../../../Application/Logger/Logger';
 import CommandHandlerManager from '../../../../CommandHandler/CommandHandlerManager';
 import { GetProfile } from '../../../../../Application/Query/Trophy/GetProfile/GetProfile';
 import { ProfileNotFound } from '../../../../../Application/Query/Trophy/GetProfile/ProfileNotFound';
-import { safeReply } from '../../../../../Domain/Bot/safeReply';
+import { replyPrivately } from '../../../../../Domain/Bot/safeReply';
 
 @injectable()
 export class CheckTrophyProfileSubcommand {
@@ -19,10 +19,12 @@ export class CheckTrophyProfileSubcommand {
     public async handle(context: SlashCommandContext): Promise<void> {
         const targetUser = context.interaction.options.getUser('user') ?? context.interaction.user;
 
-        // The successful reply is public (no `flags`), so the defer is public
-        // too — ephemeral-ness is fixed at defer time. The "not found"/error
-        // paths below used to be ephemeral; they now post publicly, which is
-        // the trade-off for being able to defer at all (see PR description).
+        // Public defer: a trophy profile check is worth showing off, so the
+        // success path stays public (no `flags`). The not-found/error paths
+        // below must NOT inherit that publicness -- they use replyPrivately()
+        // to delete the public "thinking..." placeholder and follow up
+        // ephemerally instead (M0.3: this is exactly the ephemeral-leak that
+        // was fixed in production once already).
         await context.interaction.deferReply();
 
         try {
@@ -60,12 +62,11 @@ export class CheckTrophyProfileSubcommand {
             });
         } catch (error) {
             if (error instanceof ProfileNotFound) {
-                await safeReply(context.interaction, {
+                await replyPrivately(context.interaction, {
                     content:
                         targetUser.id === context.interaction.user.id
                             ? '❌ You have not registered your PSN profile yet. Use `/trophy create` to register.'
                             : '❌ This user has not registered their PSN profile.',
-                    flags: MessageFlags.Ephemeral,
                 });
                 return;
             }
@@ -75,9 +76,8 @@ export class CheckTrophyProfileSubcommand {
                 userId: targetUser.id,
             });
 
-            await safeReply(context.interaction, {
+            await replyPrivately(context.interaction, {
                 content: '⚠️ An error occurred while retrieving the PSN profile.',
-                flags: MessageFlags.Ephemeral,
             });
         }
     }

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/CreateTrophyProfileSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/CreateTrophyProfileSubcommand.ts
@@ -36,6 +36,11 @@ export class CreateTrophyProfileSubcommand {
             return;
         }
 
+        // Deferred only after the cheap synchronous URL validation above —
+        // everything past this point writes to the database, which can take
+        // longer than the 3s interaction-ack window.
+        await context.interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
         try {
             const command = new CreateProfile(
                 TrophyProfileId.generate(),
@@ -45,9 +50,8 @@ export class CreateTrophyProfileSubcommand {
 
             await this.commandHandlerManager.handle(command);
 
-            await context.interaction.reply({
+            await context.interaction.editReply({
                 content: `Successfully registered PSN profile: ${psnProfile}`,
-                flags: MessageFlags.Ephemeral,
             });
         } catch (error) {
             if (error instanceof ProfileAlreadyExists) {

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/RankSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/RankSubcommand.ts
@@ -154,6 +154,10 @@ export class RankSubcommand {
     }
 
     public async handle(context: SlashCommandContext): Promise<void> {
+        // Deferred first: this can load up to 1000 profiles (GetRank), which
+        // can take longer than the 3s interaction-ack window.
+        await context.interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
         try {
             const type = context.interaction.options.getString('type', true) as RankType;
             const limit = context.interaction.options.getInteger('limit') ?? 10;
@@ -179,9 +183,8 @@ export class RankSubcommand {
                 ? await this.createRankingEmbed(result, type, type === 'monthly' ? date : undefined)
                 : this.createUserPositionEmbed(result, targetUser?.username ?? 'Unknown');
 
-            await context.interaction.reply({
+            await context.interaction.editReply({
                 embeds: [embed],
-                flags: MessageFlags.Ephemeral,
             });
         } catch (error) {
             this.logger.error('Error getting trophy ranks', {

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/TrophySlashCommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/TrophySlashCommand.ts
@@ -1,7 +1,11 @@
 import { inject, injectable } from 'inversify';
 import type { SlashCommandHandler } from '../../../../../Domain/Bot/SlashCommandHandler';
 import type { SlashCommandContext } from '../../../../../Domain/Bot/SlashCommandContext';
-import { MessageFlags, SlashCommandBuilder } from 'discord.js';
+import {
+    MessageFlags,
+    SlashCommandBuilder,
+    type SlashCommandSubcommandsOnlyBuilder,
+} from 'discord.js';
 import { TYPES } from '../../../../DependencyInjection/types';
 import type Logger from '../../../../../Application/Logger/Logger';
 import { CreateTrophyProfileSubcommand } from './CreateTrophyProfileSubcommand';
@@ -24,7 +28,7 @@ export class TrophySlashCommand implements SlashCommandHandler {
         return 'trophy';
     }
 
-    public builder(): any {
+    public builder(): SlashCommandSubcommandsOnlyBuilder {
         const currentYear = new Date().getFullYear();
         const yearChoices = Array.from({ length: 5 }, (_, i) => ({
             name: `${currentYear - i}`,

--- a/discord-bot/tests/Helper/FakeInteraction.ts
+++ b/discord-bot/tests/Helper/FakeInteraction.ts
@@ -21,6 +21,7 @@ export default class FakeInteraction {
     public readonly editReplyCalls: any[] = [];
     public readonly followUpCalls: any[] = [];
     public readonly replyCalls: any[] = [];
+    public readonly deleteReplyCalls: any[] = [];
 
     /** The payload passed to the last successful editReply/reply call. */
     public lastPostedContent: any = undefined;
@@ -115,7 +116,14 @@ export default class FakeInteraction {
 
     async followUp(payload: any): Promise<{ id: string; content: any }> {
         this.followUpCalls.push(payload);
+        // Real discord.js sets replied=true after followUp() too (it counts
+        // as "the interaction has been responded to"), not just after reply().
+        this.replied = true;
         return { id: `fake-followup-${++this.messageIdCounter}`, content: payload.content };
+    }
+
+    async deleteReply(message?: unknown): Promise<void> {
+        this.deleteReplyCalls.push(message);
     }
 
     async reply(payload: any): Promise<{ id: string; content: any }> {

--- a/discord-bot/tests/Helper/FakeInteraction.ts
+++ b/discord-bot/tests/Helper/FakeInteraction.ts
@@ -1,9 +1,17 @@
+import type { ChatInputCommandInteraction } from 'discord.js';
+
 /**
  * A hand-rolled fake of the subset of discord.js's ChatInputCommandInteraction
- * that the Marketplace subcommands touch. No mocking library is used in this
- * codebase and none should be introduced (see AGENT.md) — this fixture exists
- * so the discord.js adapter layer can finally be exercised by tests instead of
- * only by hand in production.
+ * that the Marketplace/Screenshot/Trophy subcommands touch. No mocking library
+ * is used in this codebase and none should be introduced (see AGENT.md) — this
+ * fixture exists so the discord.js adapter layer can finally be exercised by
+ * tests instead of only by hand in production.
+ *
+ * `SlashCommandContext.interaction` is typed as the real
+ * `ChatInputCommandInteraction` (M4.1), which this fake does not — and
+ * structurally cannot, since discord.js interaction classes carry private
+ * fields — implement. Call sites cast via `asChatInputCommandInteraction()`,
+ * the one deliberate, documented `as unknown as` in this fixture.
  */
 export default class FakeInteraction {
     public deferred = false;
@@ -20,12 +28,19 @@ export default class FakeInteraction {
     /** When set, the next call to editReply() throws this instead of posting. */
     public failNextEditReplyWith: Error | undefined = undefined;
 
-    public readonly user: { id: string };
+    public readonly user: { id: string; username: string };
     public readonly guildId: string;
     public readonly channelId: string;
+    public readonly id: string;
     public readonly options: {
         getString: (name: string, required?: boolean) => string | null;
         getUser: (name: string) => { id: string; username: string } | null;
+        getInteger: (name: string, required?: boolean) => number | null;
+        getAttachment: (
+            name: string,
+            required?: boolean,
+        ) => { contentType: string | null; url: string } | null;
+        getSubcommand: () => string;
     };
 
     private messageIdCounter = 0;
@@ -39,10 +54,19 @@ export default class FakeInteraction {
             string,
             { id: string; username: string } | undefined
         > = {},
+        private readonly integerOptionValues: Record<string, number | undefined> = {},
+        private readonly attachmentOptionValues: Record<
+            string,
+            { contentType: string | null; url: string } | undefined
+        > = {},
+        private readonly subcommand: string = '',
+        username = 'test-user',
+        interactionId = 'fake-interaction-1',
     ) {
-        this.user = { id: userId };
+        this.user = { id: userId, username };
         this.channelId = channelId;
         this.guildId = guildId;
+        this.id = interactionId;
         this.options = {
             getString: (name: string, required?: boolean) => {
                 const value = this.optionValues[name];
@@ -52,6 +76,21 @@ export default class FakeInteraction {
                 return value ?? null;
             },
             getUser: (name: string) => this.userOptionValues[name] ?? null,
+            getInteger: (name: string, required?: boolean) => {
+                const value = this.integerOptionValues[name];
+                if (required && value === undefined) {
+                    throw new Error(`FakeInteraction: missing required option "${name}"`);
+                }
+                return value ?? null;
+            },
+            getAttachment: (name: string, required?: boolean) => {
+                const value = this.attachmentOptionValues[name];
+                if (required && value === undefined) {
+                    throw new Error(`FakeInteraction: missing required option "${name}"`);
+                }
+                return value ?? null;
+            },
+            getSubcommand: () => this.subcommand,
         };
     }
 
@@ -84,5 +123,16 @@ export default class FakeInteraction {
         this.replied = true;
         this.lastPostedContent = payload;
         return { id: `fake-message-${++this.messageIdCounter}`, content: payload.content };
+    }
+
+    /**
+     * The one deliberate cast in this fixture: discord.js's interaction
+     * classes carry private fields (e.g. `BaseInteraction#_cacheType`), so no
+     * plain object can structurally satisfy `ChatInputCommandInteraction` —
+     * a cast is genuinely unavoidable to hand this fake to code typed
+     * against the real interaction.
+     */
+    asChatInputCommandInteraction(): ChatInputCommandInteraction {
+        return this as unknown as ChatInputCommandInteraction;
     }
 }

--- a/discord-bot/tests/Integration/Domain/Bot/embedLimits.test.ts
+++ b/discord-bot/tests/Integration/Domain/Bot/embedLimits.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect } from 'bun:test';
+import {
+    EMBED_FIELD_NAME_MAX_LENGTH,
+    EMBED_FIELD_VALUE_MAX_LENGTH,
+    EMBED_MAX_FIELDS,
+    MESSAGE_MAX_LENGTH,
+    capFields,
+    chunkMessage,
+    truncate,
+    truncateFieldName,
+    truncateFieldValue,
+} from '../../../../src/Domain/Bot/embedLimits';
+
+/**
+ * Unit coverage for M4.10 (output-size safety). Nothing in this codebase
+ * enforced Discord's embed/message limits before: `ListAdsSubcommand` added
+ * one field per ad with no cap at all, so a user with 26+ listings — or a
+ * single over-long field value — broke the command outright instead of
+ * degrading gracefully.
+ */
+describe('embedLimits', () => {
+    describe('truncate', () => {
+        test('returns the value unchanged when within the limit', () => {
+            expect(truncate('hello', 10)).toBe('hello');
+        });
+
+        test('truncates with an ellipsis when over the limit, not by throwing', () => {
+            const result = truncate('x'.repeat(20), 10);
+
+            expect(result.length).toBe(10);
+            expect(result.endsWith('…')).toBe(true);
+        });
+    });
+
+    describe('truncateFieldName / truncateFieldValue', () => {
+        test('truncateFieldName respects the 256-character embed field name limit', () => {
+            const result = truncateFieldName('n'.repeat(500));
+
+            expect(result.length).toBeLessThanOrEqual(EMBED_FIELD_NAME_MAX_LENGTH);
+        });
+
+        test('truncateFieldValue respects the 1024-character embed field value limit', () => {
+            const result = truncateFieldValue('v'.repeat(5000));
+
+            expect(result.length).toBeLessThanOrEqual(EMBED_FIELD_VALUE_MAX_LENGTH);
+            expect(result.endsWith('…')).toBe(true);
+        });
+    });
+
+    describe('capFields', () => {
+        test('does not throw on a field value far past the 1024-character limit — it truncates instead', () => {
+            const items = [{ label: 'one', body: 'x'.repeat(5000) }];
+
+            const { fields } = capFields(items, (item) => ({
+                name: item.label,
+                value: item.body,
+            }));
+
+            expect(fields).toHaveLength(1);
+            const value = fields[0]?.value ?? '';
+            expect(value.length).toBeLessThanOrEqual(EMBED_FIELD_VALUE_MAX_LENGTH);
+            expect(value.endsWith('…')).toBe(true);
+        });
+
+        test('caps at 25 fields (Discord hard limit) and reports the omitted count', () => {
+            const items = Array.from({ length: 30 }, (_, i) => ({
+                label: `#${i + 1}`,
+                body: 'ok',
+            }));
+
+            const { fields, omittedCount, omittedItems } = capFields(items, (item) => ({
+                name: item.label,
+                value: item.body,
+            }));
+
+            expect(fields.length).toBeLessThanOrEqual(EMBED_MAX_FIELDS);
+            expect(fields).toHaveLength(25);
+            expect(omittedCount).toBe(5);
+            expect(omittedItems).toHaveLength(5);
+        });
+
+        test('respects a smaller command-specific maxFields (e.g. /screenshot list at 10)', () => {
+            const items = Array.from({ length: 15 }, (_, i) => ({
+                label: `#${i + 1}`,
+                body: 'ok',
+            }));
+
+            const { fields, omittedCount } = capFields(
+                items,
+                (item) => ({ name: item.label, value: item.body }),
+                0,
+                10,
+            );
+
+            expect(fields).toHaveLength(10);
+            expect(omittedCount).toBe(5);
+        });
+
+        test('also stops before 25 fields once the embed-wide 6000-character budget is spent', () => {
+            // Each field alone is within the per-field 1024 limit, but 25 of
+            // them would total well past the 6000-character embed budget.
+            const items = Array.from({ length: 25 }, (_, i) => ({
+                label: `#${i + 1}`,
+                body: 'y'.repeat(1000),
+            }));
+
+            const { fields, omittedCount } = capFields(items, (item) => ({
+                name: item.label,
+                value: item.body,
+            }));
+
+            expect(fields.length).toBeLessThan(25);
+            expect(omittedCount).toBeGreaterThan(0);
+
+            const totalLength = fields.reduce((sum, f) => sum + f.name.length + f.value.length, 0);
+            expect(totalLength).toBeLessThanOrEqual(6000);
+        });
+    });
+
+    describe('chunkMessage', () => {
+        test('returns a single chunk when the text is within the limit', () => {
+            expect(chunkMessage('hello world')).toEqual(['hello world']);
+        });
+
+        test('returns an empty array for empty text', () => {
+            expect(chunkMessage('')).toEqual([]);
+        });
+
+        test('splits over-long text into chunks no longer than the limit', () => {
+            const text = 'a'.repeat(4500);
+
+            const chunks = chunkMessage(text);
+
+            expect(chunks.length).toBeGreaterThan(1);
+            for (const chunk of chunks) {
+                expect(chunk.length).toBeLessThanOrEqual(MESSAGE_MAX_LENGTH);
+            }
+            expect(chunks.join('')).toBe(text);
+        });
+
+        test('prefers to split on a line boundary rather than mid-line', () => {
+            const line = 'x'.repeat(100);
+            const text = Array.from({ length: 25 }, () => line).join('\n'); // ~2524 chars
+
+            const chunks = chunkMessage(text, 1000);
+
+            expect(chunks.length).toBeGreaterThan(1);
+            // None of the chunks should end mid-line (cutting a 100-char line
+            // in half) — every chunk boundary lands on a full line.
+            for (const chunk of chunks) {
+                const lines = chunk.split('\n');
+                for (const l of lines) {
+                    expect(l.length === 100 || l.length === 0).toBe(true);
+                }
+            }
+        });
+    });
+});

--- a/discord-bot/tests/Integration/Domain/Bot/safeReply.test.ts
+++ b/discord-bot/tests/Integration/Domain/Bot/safeReply.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from 'bun:test';
+import type { RepliableInteraction } from 'discord.js';
 import { safeReply } from '../../../../src/Domain/Bot/safeReply';
 
 /**
@@ -33,11 +34,21 @@ function createFakeInteraction(state: { replied: boolean; deferred: boolean }) {
     };
 }
 
+/**
+ * discord.js's interaction classes carry private fields (e.g.
+ * `BaseInteraction#_cacheType`), so no plain object can structurally satisfy
+ * `RepliableInteraction` — this cast is genuinely unavoidable to hand the
+ * hand-rolled fake above to code typed against the real interaction.
+ */
+function asRepliable(interaction: ReturnType<typeof createFakeInteraction>): RepliableInteraction {
+    return interaction as unknown as RepliableInteraction;
+}
+
 describe('safeReply', () => {
     test('calls reply() when the interaction has neither replied nor deferred', async () => {
         const interaction = createFakeInteraction({ replied: false, deferred: false });
 
-        await safeReply(interaction, { content: 'hello' });
+        await safeReply(asRepliable(interaction), { content: 'hello' });
 
         expect(interaction.calls).toEqual([{ method: 'reply', payload: { content: 'hello' } }]);
     });
@@ -48,7 +59,9 @@ describe('safeReply', () => {
         // This is the exact scenario that used to throw InteractionAlreadyReplied:
         // the try block (or a nested subcommand) already sent a reply, and a
         // catch block needs to report a second, separate error.
-        await expect(safeReply(interaction, { content: 'boom' })).resolves.toBeUndefined();
+        await expect(
+            safeReply(asRepliable(interaction), { content: 'boom' }),
+        ).resolves.toBeUndefined();
 
         expect(interaction.calls).toEqual([{ method: 'followUp', payload: { content: 'boom' } }]);
     });
@@ -56,7 +69,7 @@ describe('safeReply', () => {
     test('calls editReply() when the interaction is deferred but not yet replied', async () => {
         const interaction = createFakeInteraction({ replied: false, deferred: true });
 
-        await safeReply(interaction, { content: 'still working on it' });
+        await safeReply(asRepliable(interaction), { content: 'still working on it' });
 
         expect(interaction.calls).toEqual([
             { method: 'editReply', payload: { content: 'still working on it' } },
@@ -68,7 +81,7 @@ describe('safeReply', () => {
 
         let thrown: unknown = null;
         try {
-            await safeReply(interaction, { content: 'second error' });
+            await safeReply(asRepliable(interaction), { content: 'second error' });
         } catch (error) {
             thrown = error;
         }

--- a/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Marketplace/DeleteAdSubcommand.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Marketplace/DeleteAdSubcommand.test.ts
@@ -8,6 +8,7 @@ import { createAd } from '../../../../../../Helper/StaticFixtures';
 import { PrismaClient } from '@prisma/client';
 import type { AdRepository } from '../../../../../../../src/Domain/Marketplace/AdRepository';
 import type { SlashCommandContext } from '../../../../../../../src/Domain/Bot/SlashCommandContext';
+import { MessageFlags } from 'discord.js';
 
 describe('DeleteAdSubcommand Integration Test', () => {
     let deleteAdSubcommand: DeleteAdSubcommand;
@@ -48,6 +49,7 @@ describe('DeleteAdSubcommand Integration Test', () => {
         // than the 3s ack window. No bare `.reply()` should be used once the
         // command has deferred.
         expect(interaction.deferReplyCalls.length).toBe(1);
+        expect(interaction.deferReplyCalls[0]).toEqual({ flags: MessageFlags.Ephemeral });
         expect(interaction.replyCalls.length).toBe(0);
         expect(interaction.editReplyCalls.length).toBe(1);
         expect(interaction.editReplyCalls[0].content).toBe('Ad deleted successfully');

--- a/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Marketplace/DeleteAdSubcommand.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Marketplace/DeleteAdSubcommand.test.ts
@@ -28,22 +28,29 @@ describe('DeleteAdSubcommand Integration Test', () => {
 
     function buildContext(interaction: FakeInteraction): SlashCommandContext {
         return {
+            kind: 'chat-input',
             channel_id: interaction.channelId,
             command: 'marketplace',
             text: '',
-            interaction,
+            interaction: interaction.asChatInputCommandInteraction(),
         };
     }
 
-    it('deletes the ad and confirms when the owner deletes by id', async () => {
+    it('defers before doing any work, then edits the deferred reply', async () => {
         const userId = '123456789012345678';
         const ad = await createAd(undefined, 'Test Ad', userId);
         const interaction = new FakeInteraction({ id: ad.id.toString() }, userId);
 
         await deleteAdSubcommand.handle(buildContext(interaction));
 
-        expect(interaction.replyCalls.length).toBe(1);
-        expect(interaction.replyCalls[0].content).toBe('Ad deleted successfully');
+        // Deferred first (M4.2): the lookup for a numeric position requires a
+        // ListUserAds query before the delete itself, which can be slower
+        // than the 3s ack window. No bare `.reply()` should be used once the
+        // command has deferred.
+        expect(interaction.deferReplyCalls.length).toBe(1);
+        expect(interaction.replyCalls.length).toBe(0);
+        expect(interaction.editReplyCalls.length).toBe(1);
+        expect(interaction.editReplyCalls[0].content).toBe('Ad deleted successfully');
         await expect(adRepository.get(ad.id)).rejects.toThrow();
     });
 
@@ -65,8 +72,8 @@ describe('DeleteAdSubcommand Integration Test', () => {
             const interaction = new FakeInteraction({ id: ad.id.toString() }, userId);
             await deleteAdSubcommand.handle(buildContext(interaction));
 
-            expect(interaction.replyCalls.length).toBe(1);
-            const reply = interaction.replyCalls[0];
+            expect(interaction.editReplyCalls.length).toBe(1);
+            const reply = interaction.editReplyCalls[0];
             expect(reply.content).not.toContain('ECONNRESET');
             expect(reply.content).not.toContain('secret internal connection string');
             expect(reply.content).toContain('ref:');
@@ -83,8 +90,10 @@ describe('DeleteAdSubcommand Integration Test', () => {
 
         await deleteAdSubcommand.handle(buildContext(interaction));
 
-        expect(interaction.replyCalls.length).toBe(1);
-        expect(interaction.replyCalls[0].content).toBe('You are not authorized to delete this ad');
+        expect(interaction.editReplyCalls.length).toBe(1);
+        expect(interaction.editReplyCalls[0].content).toBe(
+            'You are not authorized to delete this ad',
+        );
         // The ad still exists.
         await expect(adRepository.get(ad.id)).resolves.toBeDefined();
     });
@@ -98,7 +107,7 @@ describe('DeleteAdSubcommand Integration Test', () => {
 
         await deleteAdSubcommand.handle(buildContext(interaction));
 
-        expect(interaction.replyCalls.length).toBe(1);
-        expect(interaction.replyCalls[0].content).toBe('Ad not found');
+        expect(interaction.editReplyCalls.length).toBe(1);
+        expect(interaction.editReplyCalls[0].content).toBe('Ad not found');
     });
 });

--- a/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Marketplace/ListAdsSubcommand.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Marketplace/ListAdsSubcommand.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, beforeEach, it, afterEach } from 'bun:test';
+import { myContainer } from '../../../../../../../src/Infrastructure/DependencyInjection/inversify.config';
+import { TYPES } from '../../../../../../../src/Infrastructure/DependencyInjection/types';
+import { ListAdsSubcommand } from '../../../../../../../src/Infrastructure/Bot/Discord/SlashCommand/Marketplace/ListAdsSubcommand';
+import { EMBED_FIELD_VALUE_MAX_LENGTH } from '../../../../../../../src/Domain/Bot/embedLimits';
+import DatabaseUtil from '../../../../../../Helper/DatabaseUtil';
+import FakeInteraction from '../../../../../../Helper/FakeInteraction';
+import { createAd } from '../../../../../../Helper/StaticFixtures';
+import { PrismaClient } from '@prisma/client';
+import type { SlashCommandContext } from '../../../../../../../src/Domain/Bot/SlashCommandContext';
+
+/**
+ * Regression coverage for M4.10: `ListAdsSubcommand` used to add one embed
+ * field per ad with no cap. Discord hard-rejects an embed with more than 25
+ * fields (and one over the 1024-char per-field-value limit), so a user with
+ * 26+ listings — or a single long description — broke the whole `/marketplace
+ * list` command outright.
+ */
+describe('ListAdsSubcommand Integration Test', () => {
+    let listAdsSubcommand: ListAdsSubcommand;
+    let ormClient: PrismaClient;
+
+    beforeEach(async () => {
+        listAdsSubcommand = myContainer.get<ListAdsSubcommand>(ListAdsSubcommand);
+        ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
+
+        await DatabaseUtil.truncateAllTables();
+    });
+
+    afterEach(async () => {
+        await ormClient.$disconnect();
+    });
+
+    function buildContext(interaction: FakeInteraction): SlashCommandContext {
+        return {
+            kind: 'chat-input',
+            channel_id: interaction.channelId,
+            command: 'marketplace',
+            text: '',
+            interaction: interaction.asChatInputCommandInteraction(),
+        };
+    }
+
+    it('defers before querying, then edits the deferred reply with an embed capped at 25 fields', async () => {
+        const userId = '123456789012345678';
+        // Short warranty/description ('') keeps each field small enough that
+        // the 25-field cap — not the 6000-char embed-total budget — is the
+        // constraint this test is actually exercising.
+        for (let i = 0; i < 30; i++) {
+            await createAd(
+                undefined,
+                `Item ${i + 1}`,
+                userId,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                '',
+                '',
+            );
+        }
+
+        const interaction = new FakeInteraction({}, userId, undefined, undefined, {});
+        await listAdsSubcommand.handle(buildContext(interaction));
+
+        expect(interaction.deferReplyCalls.length).toBe(1);
+        expect(interaction.replyCalls.length).toBe(0);
+        expect(interaction.editReplyCalls.length).toBe(1);
+
+        const { embeds } = interaction.editReplyCalls[0];
+        expect(embeds).toHaveLength(1);
+        const embed = embeds[0];
+        const fields = embed.data.fields;
+
+        // Discord hard-rejects more than 25 fields — this is the cap that
+        // stops the command from breaking outright for 26+ listings.
+        expect(fields.length).toBeLessThanOrEqual(25);
+        expect(fields.length).toBe(25);
+
+        // The user is told how many listings were left out.
+        const footerText = embed.data.footer?.text ?? '';
+        expect(footerText).toContain('25 of 30');
+        expect(footerText).toContain('5 omitted');
+    });
+
+    it('truncates an over-long ad description instead of throwing', async () => {
+        const userId = '987654321098765432';
+        await createAd(
+            undefined,
+            'Long Description Item',
+            userId,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            'x'.repeat(5000),
+        );
+
+        const interaction = new FakeInteraction({}, userId, undefined, undefined, {});
+
+        // Must not throw despite the wildly over-long field value.
+        await listAdsSubcommand.handle(buildContext(interaction));
+
+        expect(interaction.editReplyCalls.length).toBe(1);
+        const { embeds } = interaction.editReplyCalls[0];
+        const field = embeds[0].data.fields[0];
+
+        expect(field.value.length).toBeLessThanOrEqual(EMBED_FIELD_VALUE_MAX_LENGTH);
+        expect(field.value.endsWith('…')).toBe(true);
+    });
+});

--- a/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Marketplace/ListAdsSubcommand.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Marketplace/ListAdsSubcommand.test.ts
@@ -7,6 +7,7 @@ import DatabaseUtil from '../../../../../../Helper/DatabaseUtil';
 import FakeInteraction from '../../../../../../Helper/FakeInteraction';
 import { createAd } from '../../../../../../Helper/StaticFixtures';
 import { PrismaClient } from '@prisma/client';
+import { MessageFlags } from 'discord.js';
 import type { SlashCommandContext } from '../../../../../../../src/Domain/Bot/SlashCommandContext';
 
 /**
@@ -66,6 +67,10 @@ describe('ListAdsSubcommand Integration Test', () => {
         await listAdsSubcommand.handle(buildContext(interaction));
 
         expect(interaction.deferReplyCalls.length).toBe(1);
+        // The whole command is ephemeral now (M5.8 settles `/marketplace list`
+        // as ephemeral going forward), so the defer itself carries the flag —
+        // not just the error paths.
+        expect(interaction.deferReplyCalls[0]).toEqual({ flags: MessageFlags.Ephemeral });
         expect(interaction.replyCalls.length).toBe(0);
         expect(interaction.editReplyCalls.length).toBe(1);
 
@@ -112,5 +117,20 @@ describe('ListAdsSubcommand Integration Test', () => {
 
         expect(field.value.length).toBeLessThanOrEqual(EMBED_FIELD_VALUE_MAX_LENGTH);
         expect(field.value.endsWith('…')).toBe(true);
+    });
+
+    it('stays ephemeral on the "no listings" path too (M0.3) — nothing here should broadcast into the channel', async () => {
+        const userId = '111111111111111111';
+        const interaction = new FakeInteraction({}, userId, undefined, undefined, {});
+
+        await listAdsSubcommand.handle(buildContext(interaction));
+
+        expect(interaction.deferReplyCalls[0]).toEqual({ flags: MessageFlags.Ephemeral });
+        expect(interaction.editReplyCalls.length).toBe(1);
+        expect(interaction.editReplyCalls[0].content).toContain("don't have any active listings");
+        // No public reply/followUp anywhere — the whole command stayed on
+        // the single ephemeral deferred reply.
+        expect(interaction.replyCalls.length).toBe(0);
+        expect(interaction.followUpCalls.length).toBe(0);
     });
 });

--- a/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Marketplace/SellSubcommand.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Marketplace/SellSubcommand.test.ts
@@ -27,10 +27,11 @@ describe('SellSubcommand Integration Test', () => {
 
     function buildContext(interaction: FakeInteraction): SlashCommandContext {
         return {
+            kind: 'chat-input',
             channel_id: interaction.channelId,
             command: 'marketplace',
             text: '',
-            interaction,
+            interaction: interaction.asChatInputCommandInteraction(),
         };
     }
 

--- a/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Screenshot/CreateScreenshotSubcommand.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Screenshot/CreateScreenshotSubcommand.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from 'bun:test';
+import type { ChatInputCommandInteraction } from 'discord.js';
 import { CreateScreenshotSubcommand } from '../../../../../../../src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/CreateScreenshotSubcommand';
 import Logger from '../../../../../../../src/Application/Logger/Logger';
 import InMemoryLogger from '../../../../../../Helper/InMemoryLogger';
@@ -86,7 +87,7 @@ describe('CreateScreenshotSubcommand', () => {
         );
         const interaction = createFakeInteraction();
 
-        await subcommand.handle(interaction);
+        await subcommand.handle(interaction as unknown as ChatInputCommandInteraction);
 
         expect(interaction.calls).toHaveLength(2);
         expect(interaction.calls[0]!.method).toBe('deferReply');

--- a/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ListScreenshotSubcommand.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ListScreenshotSubcommand.test.ts
@@ -6,6 +6,7 @@ import DatabaseUtil from '../../../../../../Helper/DatabaseUtil';
 import FakeInteraction from '../../../../../../Helper/FakeInteraction';
 import { createScreenshot } from '../../../../../../Helper/StaticFixtures';
 import { PrismaClient } from '@prisma/client';
+import { MessageFlags } from 'discord.js';
 
 /**
  * M4.2 (defer) + M4.10 (output-size safety) coverage for `/screenshot list`.
@@ -38,6 +39,7 @@ describe('ListScreenshotSubcommand Integration Test', () => {
         await listScreenshotSubcommand.handle(interaction.asChatInputCommandInteraction());
 
         expect(interaction.deferReplyCalls.length).toBe(1);
+        expect(interaction.deferReplyCalls[0]).toEqual({ flags: MessageFlags.Ephemeral });
         expect(interaction.replyCalls.length).toBe(0);
         expect(interaction.editReplyCalls.length).toBe(1);
         expect(interaction.editReplyCalls[0].embeds).toHaveLength(1);

--- a/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ListScreenshotSubcommand.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ListScreenshotSubcommand.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, beforeEach, it, afterEach } from 'bun:test';
+import { myContainer } from '../../../../../../../src/Infrastructure/DependencyInjection/inversify.config';
+import { TYPES } from '../../../../../../../src/Infrastructure/DependencyInjection/types';
+import { ListScreenshotSubcommand } from '../../../../../../../src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ListScreenshotSubcommand';
+import DatabaseUtil from '../../../../../../Helper/DatabaseUtil';
+import FakeInteraction from '../../../../../../Helper/FakeInteraction';
+import { createScreenshot } from '../../../../../../Helper/StaticFixtures';
+import { PrismaClient } from '@prisma/client';
+
+/**
+ * M4.2 (defer) + M4.10 (output-size safety) coverage for `/screenshot list`.
+ * It shares the `capFields` helper with `ListAdsSubcommand` (M4.10) so both
+ * commands cap consistently — this one keeps its pre-existing 10-item
+ * display limit instead of the shared 25-field Discord hard cap.
+ */
+describe('ListScreenshotSubcommand Integration Test', () => {
+    let listScreenshotSubcommand: ListScreenshotSubcommand;
+    let ormClient: PrismaClient;
+
+    beforeEach(async () => {
+        listScreenshotSubcommand =
+            myContainer.get<ListScreenshotSubcommand>(ListScreenshotSubcommand);
+        ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
+
+        await DatabaseUtil.truncateAllTables();
+    });
+
+    afterEach(async () => {
+        await ormClient.$disconnect();
+    });
+
+    it('defers before querying, then edits the deferred reply', async () => {
+        const userId = '123456789012345678';
+        await createScreenshot(undefined, 'My Screenshot', userId);
+
+        const interaction = new FakeInteraction({}, userId);
+
+        await listScreenshotSubcommand.handle(interaction.asChatInputCommandInteraction());
+
+        expect(interaction.deferReplyCalls.length).toBe(1);
+        expect(interaction.replyCalls.length).toBe(0);
+        expect(interaction.editReplyCalls.length).toBe(1);
+        expect(interaction.editReplyCalls[0].embeds).toHaveLength(1);
+    });
+
+    it('caps the list at 10 screenshots and reports how many were left out', async () => {
+        const userId = '987654321098765432';
+        for (let i = 0; i < 15; i++) {
+            await createScreenshot(undefined, `Screenshot ${i + 1}`, userId, undefined, `msg-${i}`);
+        }
+
+        const interaction = new FakeInteraction({}, userId);
+
+        await listScreenshotSubcommand.handle(interaction.asChatInputCommandInteraction());
+
+        const { embeds } = interaction.editReplyCalls[0];
+        const fields = embeds[0].data.fields;
+
+        expect(fields.length).toBeLessThanOrEqual(10);
+        expect(fields).toHaveLength(10);
+        expect(embeds[0].data.footer?.text).toContain('10 of 15');
+    });
+});

--- a/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ScreenshotSlashCommand.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ScreenshotSlashCommand.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { MessageFlags } from 'discord.js';
+import { MessageFlags, type ChatInputCommandInteraction } from 'discord.js';
 import { ScreenshotSlashCommand } from '../../../../../../../src/Infrastructure/Bot/Discord/SlashCommand/Screenshot/ScreenshotSlashCommand';
 import Logger from '../../../../../../../src/Application/Logger/Logger';
 import InMemoryLogger from '../../../../../../Helper/InMemoryLogger';
@@ -59,10 +59,11 @@ describe('ScreenshotSlashCommand', () => {
         const interaction = createFakeInteraction('create');
 
         await command.handle({
+            kind: 'chat-input',
             channel_id: 'chan',
             command: 'screenshot',
             text: '',
-            interaction,
+            interaction: interaction as unknown as ChatInputCommandInteraction,
         });
 
         expect(interaction.calls).toHaveLength(1);
@@ -100,10 +101,11 @@ describe('ScreenshotSlashCommand', () => {
         let thrown: unknown = null;
         try {
             await command.handle({
+                kind: 'chat-input',
                 channel_id: 'chan',
                 command: 'screenshot',
                 text: '',
-                interaction,
+                interaction: interaction as unknown as ChatInputCommandInteraction,
             });
         } catch (error) {
             thrown = error;

--- a/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.test.ts
@@ -5,6 +5,7 @@ import { CheckTrophyProfileSubcommand } from '../../../../../../../src/Infrastru
 import DatabaseUtil from '../../../../../../Helper/DatabaseUtil';
 import FakeInteraction from '../../../../../../Helper/FakeInteraction';
 import { createTrophyProfile } from '../../../../../../Helper/StaticFixtures';
+import { MessageFlags } from 'discord.js';
 import { PrismaClient } from '@prisma/client';
 import type { SlashCommandContext } from '../../../../../../../src/Domain/Bot/SlashCommandContext';
 
@@ -54,16 +55,28 @@ describe('CheckTrophyProfileSubcommand Integration Test', () => {
         expect(interaction.editReplyCalls[0].embeds).toHaveLength(1);
     });
 
-    it('defers, then edits with a not-found message rather than leaving the interaction hanging', async () => {
+    it('defers publicly, but the not-found path deletes the public placeholder and follows up ephemerally (M0.3)', async () => {
         const userId = '987654321098765432';
         const interaction = new FakeInteraction({}, userId);
 
         await checkTrophyProfileSubcommand.handle(buildContext(interaction));
 
+        // The defer itself is public (no flags) — the success path is meant
+        // to be visible.
         expect(interaction.deferReplyCalls.length).toBe(1);
-        expect(interaction.editReplyCalls.length).toBe(1);
-        expect(interaction.editReplyCalls[0].content).toContain(
+        expect(interaction.deferReplyCalls[0]).toBeUndefined();
+
+        // But the not-found outcome must not leave that public "thinking..."
+        // placeholder standing: it is deleted, and a fresh ephemeral
+        // followUp carries the message instead. This is the exact pattern
+        // M0.3 required — regressing to a bare editReply() here would post
+        // the not-found message publicly again.
+        expect(interaction.deleteReplyCalls.length).toBe(1);
+        expect(interaction.editReplyCalls.length).toBe(0);
+        expect(interaction.followUpCalls.length).toBe(1);
+        expect(interaction.followUpCalls[0].content).toContain(
             'have not registered your PSN profile',
         );
+        expect(interaction.followUpCalls[0].flags).toBe(MessageFlags.Ephemeral);
     });
 });

--- a/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, beforeEach, it, afterEach } from 'bun:test';
+import { myContainer } from '../../../../../../../src/Infrastructure/DependencyInjection/inversify.config';
+import { TYPES } from '../../../../../../../src/Infrastructure/DependencyInjection/types';
+import { CheckTrophyProfileSubcommand } from '../../../../../../../src/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand';
+import DatabaseUtil from '../../../../../../Helper/DatabaseUtil';
+import FakeInteraction from '../../../../../../Helper/FakeInteraction';
+import { createTrophyProfile } from '../../../../../../Helper/StaticFixtures';
+import { PrismaClient } from '@prisma/client';
+import type { SlashCommandContext } from '../../../../../../../src/Domain/Bot/SlashCommandContext';
+
+/**
+ * M4.2 coverage: `CheckTrophyProfileSubcommand` was one of the worst
+ * offenders with no `deferReply()` at all — `GetProfile` is a database read
+ * that can outrun the 3s interaction-ack window.
+ */
+describe('CheckTrophyProfileSubcommand Integration Test', () => {
+    let checkTrophyProfileSubcommand: CheckTrophyProfileSubcommand;
+    let ormClient: PrismaClient;
+
+    beforeEach(async () => {
+        checkTrophyProfileSubcommand = myContainer.get<CheckTrophyProfileSubcommand>(
+            CheckTrophyProfileSubcommand,
+        );
+        ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
+
+        await DatabaseUtil.truncateAllTables();
+    });
+
+    afterEach(async () => {
+        await ormClient.$disconnect();
+    });
+
+    function buildContext(interaction: FakeInteraction): SlashCommandContext {
+        return {
+            kind: 'chat-input',
+            channel_id: interaction.channelId,
+            command: 'trophy',
+            text: '',
+            interaction: interaction.asChatInputCommandInteraction(),
+        };
+    }
+
+    it('defers before querying, then edits the deferred reply with the profile embed', async () => {
+        const userId = '123456789012345678';
+        await createTrophyProfile(undefined, userId, 'SomePsnUser');
+
+        const interaction = new FakeInteraction({}, userId);
+
+        await checkTrophyProfileSubcommand.handle(buildContext(interaction));
+
+        expect(interaction.deferReplyCalls.length).toBe(1);
+        expect(interaction.replyCalls.length).toBe(0);
+        expect(interaction.editReplyCalls.length).toBe(1);
+        expect(interaction.editReplyCalls[0].embeds).toHaveLength(1);
+    });
+
+    it('defers, then edits with a not-found message rather than leaving the interaction hanging', async () => {
+        const userId = '987654321098765432';
+        const interaction = new FakeInteraction({}, userId);
+
+        await checkTrophyProfileSubcommand.handle(buildContext(interaction));
+
+        expect(interaction.deferReplyCalls.length).toBe(1);
+        expect(interaction.editReplyCalls.length).toBe(1);
+        expect(interaction.editReplyCalls[0].content).toContain(
+            'have not registered your PSN profile',
+        );
+    });
+});

--- a/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Trophy/CreateTrophyProfileSubcommand.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Trophy/CreateTrophyProfileSubcommand.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, beforeEach, it, afterEach } from 'bun:test';
+import { myContainer } from '../../../../../../../src/Infrastructure/DependencyInjection/inversify.config';
+import { TYPES } from '../../../../../../../src/Infrastructure/DependencyInjection/types';
+import { CreateTrophyProfileSubcommand } from '../../../../../../../src/Infrastructure/Bot/Discord/SlashCommand/Trophy/CreateTrophyProfileSubcommand';
+import DatabaseUtil from '../../../../../../Helper/DatabaseUtil';
+import FakeInteraction from '../../../../../../Helper/FakeInteraction';
+import { PrismaClient } from '@prisma/client';
+import type { SlashCommandContext } from '../../../../../../../src/Domain/Bot/SlashCommandContext';
+
+/**
+ * M4.2 coverage: `CreateTrophyProfileSubcommand` was one of the worst
+ * offenders with no `deferReply()` — the create path does two lookups
+ * (existing user/PSN profile) plus a write before ever replying.
+ *
+ * The cheap synchronous URL-format check stays a plain (undeferred) reply,
+ * since it never touches the database; defer only guards the part of the
+ * handler that can actually be slow.
+ */
+describe('CreateTrophyProfileSubcommand Integration Test', () => {
+    let createTrophyProfileSubcommand: CreateTrophyProfileSubcommand;
+    let ormClient: PrismaClient;
+
+    beforeEach(async () => {
+        createTrophyProfileSubcommand = myContainer.get<CreateTrophyProfileSubcommand>(
+            CreateTrophyProfileSubcommand,
+        );
+        ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
+
+        await DatabaseUtil.truncateAllTables();
+    });
+
+    afterEach(async () => {
+        await ormClient.$disconnect();
+    });
+
+    function buildContext(interaction: FakeInteraction): SlashCommandContext {
+        return {
+            kind: 'chat-input',
+            channel_id: interaction.channelId,
+            command: 'trophy',
+            text: '',
+            interaction: interaction.asChatInputCommandInteraction(),
+        };
+    }
+
+    it('defers before writing to the database, then edits the deferred reply on success', async () => {
+        const userId = '123456789012345678';
+        const interaction = new FakeInteraction(
+            {
+                psnprofiles_url: 'https://psnprofiles.com/SomePsnUser',
+            },
+            userId,
+        );
+
+        await createTrophyProfileSubcommand.handle(buildContext(interaction));
+
+        expect(interaction.deferReplyCalls.length).toBe(1);
+        expect(interaction.replyCalls.length).toBe(0);
+        expect(interaction.editReplyCalls.length).toBe(1);
+        expect(interaction.editReplyCalls[0].content).toContain('SomePsnUser');
+    });
+
+    it('rejects an invalid URL with a plain (undeferred) reply, without ever deferring', async () => {
+        const userId = '987654321098765432';
+        const interaction = new FakeInteraction({ psnprofiles_url: 'not-a-url' }, userId);
+
+        await createTrophyProfileSubcommand.handle(buildContext(interaction));
+
+        expect(interaction.deferReplyCalls.length).toBe(0);
+        expect(interaction.replyCalls.length).toBe(1);
+        expect(interaction.replyCalls[0].content).toContain('Invalid PSNProfiles URL');
+    });
+});

--- a/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Trophy/CreateTrophyProfileSubcommand.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Trophy/CreateTrophyProfileSubcommand.test.ts
@@ -5,6 +5,7 @@ import { CreateTrophyProfileSubcommand } from '../../../../../../../src/Infrastr
 import DatabaseUtil from '../../../../../../Helper/DatabaseUtil';
 import FakeInteraction from '../../../../../../Helper/FakeInteraction';
 import { PrismaClient } from '@prisma/client';
+import { MessageFlags } from 'discord.js';
 import type { SlashCommandContext } from '../../../../../../../src/Domain/Bot/SlashCommandContext';
 
 /**
@@ -55,6 +56,7 @@ describe('CreateTrophyProfileSubcommand Integration Test', () => {
         await createTrophyProfileSubcommand.handle(buildContext(interaction));
 
         expect(interaction.deferReplyCalls.length).toBe(1);
+        expect(interaction.deferReplyCalls[0]).toEqual({ flags: MessageFlags.Ephemeral });
         expect(interaction.replyCalls.length).toBe(0);
         expect(interaction.editReplyCalls.length).toBe(1);
         expect(interaction.editReplyCalls[0].content).toContain('SomePsnUser');
@@ -69,5 +71,6 @@ describe('CreateTrophyProfileSubcommand Integration Test', () => {
         expect(interaction.deferReplyCalls.length).toBe(0);
         expect(interaction.replyCalls.length).toBe(1);
         expect(interaction.replyCalls[0].content).toContain('Invalid PSNProfiles URL');
+        expect(interaction.replyCalls[0].flags).toBe(MessageFlags.Ephemeral);
     });
 });

--- a/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Trophy/RankSubcommand.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Trophy/RankSubcommand.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, beforeEach, it, afterEach } from 'bun:test';
+import { MessageFlags } from 'discord.js';
+import { myContainer } from '../../../../../../../src/Infrastructure/DependencyInjection/inversify.config';
+import { TYPES } from '../../../../../../../src/Infrastructure/DependencyInjection/types';
+import { RankSubcommand } from '../../../../../../../src/Infrastructure/Bot/Discord/SlashCommand/Trophy/RankSubcommand';
+import DatabaseUtil from '../../../../../../Helper/DatabaseUtil';
+import FakeInteraction from '../../../../../../Helper/FakeInteraction';
+import { PrismaClient } from '@prisma/client';
+import type { SlashCommandContext } from '../../../../../../../src/Domain/Bot/SlashCommandContext';
+
+/**
+ * M4.2 coverage: `RankSubcommand` was one of the worst offenders -- `GetRank`
+ * can load up to 1000 profiles, which can easily outrun the 3s
+ * interaction-ack window.
+ */
+describe('RankSubcommand Integration Test', () => {
+    let rankSubcommand: RankSubcommand;
+    let ormClient: PrismaClient;
+
+    beforeEach(async () => {
+        rankSubcommand = myContainer.get<RankSubcommand>(RankSubcommand);
+        ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
+
+        await DatabaseUtil.truncateAllTables();
+    });
+
+    afterEach(async () => {
+        await ormClient.$disconnect();
+    });
+
+    function buildContext(interaction: FakeInteraction): SlashCommandContext {
+        return {
+            kind: 'chat-input',
+            channel_id: interaction.channelId,
+            command: 'trophy',
+            text: '',
+            interaction: interaction.asChatInputCommandInteraction(),
+        };
+    }
+
+    it('defers ephemerally before querying, then edits the deferred reply', async () => {
+        const userId = '123456789012345678';
+        const interaction = new FakeInteraction({ type: 'lifetime' }, userId);
+
+        await rankSubcommand.handle(buildContext(interaction));
+
+        expect(interaction.deferReplyCalls.length).toBe(1);
+        expect(interaction.deferReplyCalls[0]).toEqual({ flags: MessageFlags.Ephemeral });
+        expect(interaction.replyCalls.length).toBe(0);
+        expect(interaction.editReplyCalls.length).toBe(1);
+        expect(interaction.editReplyCalls[0].embeds).toHaveLength(1);
+    });
+
+    it('stays ephemeral on the error path too', async () => {
+        const userId = '987654321098765432';
+        // `type` is required by the real slash command builder; omitting it
+        // here makes `getString('type', true)` throw, exercising the catch
+        // block without needing a mocking library.
+        const interaction = new FakeInteraction({}, userId);
+
+        await rankSubcommand.handle(buildContext(interaction));
+
+        expect(interaction.deferReplyCalls[0]).toEqual({ flags: MessageFlags.Ephemeral });
+        expect(interaction.editReplyCalls.length).toBe(1);
+        expect(interaction.editReplyCalls[0].content).toContain(
+            'error occurred while retrieving the trophy rankings',
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Implements M4.1, M4.2 and M4.10 from `docs/plans/GLOBAL-PLAN.md`.

### M4.1 — Type the interaction layer (the enabler)

`SlashCommandContext.interaction`/`client` were `any` — the plan calls this
out as *why* three production bugs got through review.

- `SlashCommandContext.interaction` is now `ChatInputCommandInteraction`,
  `client` is `Client`. Added a `kind: 'chat-input'` discriminant.
- New `src/Domain/Bot/InteractionContext.ts`: a discriminated union covering
  chat-input / autocomplete / component / modal, with `SlashCommandContext`
  as the chat-input member. **Nothing dispatches the other three yet** —
  `BotExecutor`/`DiscordBot` still only route `ChatInputCommandInteraction`.
  This is typed groundwork for M4.7/M4.8, not a new dispatcher (out of
  scope here, per the task).
- `SlashCommandHandler.builder()` now returns `SlashCommandBuilder |
  SlashCommandSubcommandsOnlyBuilder` (discord.js narrows to the latter the
  moment `.addSubcommand()` is called, which every handler except
  `PingSlashCommand` does).
- `safeReply()` takes a real `RepliableInteraction` and a typed payload
  (`string | InteractionReplyOptions`).
- Every `interaction: any` across `src/Infrastructure/Bot/Discord/SlashCommand/**`
  and `BotExecutor.ts` is now the real type. No `as any` / `@ts-expect-error`
  added anywhere in `src/`. The only casts in the whole diff are in test
  fixtures (`FakeInteraction.asChatInputCommandInteraction()`, one `asRepliable()`
  helper in `safeReply.test.ts`) — discord.js interaction classes carry
  private fields, so a hand-rolled fake can never structurally satisfy them;
  each cast is commented explaining that.
- `noUncheckedIndexedAccess` stays on; nothing in `tsconfig.json` changed.

### M4.2 — `deferReply()` in every non-trivial handler

Added to the handlers named in the plan that didn't already have it:
`DeleteAdSubcommand` (queries first), `RankSubcommand` (up to 1000 profiles),
`ListAdsSubcommand`, `ListScreenshotSubcommand`, `CheckTrophyProfileSubcommand`,
`CreateTrophyProfileSubcommand`. `SellSubcommand` and `CreateScreenshotSubcommand`
already deferred on this branch's base. `PingSlashCommand` stays undeferred
(trivial, per the task).

**Ephemeral/public intent (updated after review):** ephemeral-ness is fixed
at `deferReply()` time and can't change afterwards. Four of the six
(`DeleteAdSubcommand`, `RankSubcommand`, `ListScreenshotSubcommand`,
`CreateTrophyProfileSubcommand`) were uniformly ephemeral before and after —
straightforward, no trade-off. The other two mixed a public success reply
with ephemeral error/not-found replies, and needed two different fixes:

- **`ListAdsSubcommand`** now defers **ephemeral for the whole command** —
  success, no-ads, and error paths all stay ephemeral. M5.8 already settles
  `/marketplace list` as "ephemeral, paginated, status-aware" going forward,
  so this moves toward the settled design rather than away from it.
- **`CheckTrophyProfileSubcommand`** still defers **publicly** (a profile
  check is worth showing off), but its not-found/error paths now go through
  a new `replyPrivately()` helper (`src/Domain/Bot/safeReply.ts`) instead of
  `safeReply()`: it deletes the public "thinking…" placeholder and follows
  up with a genuinely ephemeral message — the supported discord.js v14
  pattern for "public defer, private outcome". This is the fix for **M0.3**
  ("ephemeral" error messages posting publicly, one of the five live
  production defects already fixed and verified) — an earlier version of
  this PR let both commands' error paths go public, which would have
  reverted that fix; caught in review and corrected before merge.
  `replyPrivately()` is documented inline so the next subcommand that needs
  this shape doesn't have to re-derive it.

### M4.10 — Output-size safety

- New `src/Domain/Bot/embedLimits.ts`: `EMBED_MAX_FIELDS` (25), per-field
  name/value limits (256/1024), the 6000-char embed-total budget (25 fields
  at the per-field max would total 25600 chars — capping only the field
  *count* isn't enough), and `chunkMessage()` for plain content.
- `ListAdsSubcommand` had **no cap at all** — a user with 26+ listings broke
  the command outright. Now capped via the shared `capFields()` helper; the
  embed footer tells the user how many listings were omitted (matching the
  command's existing English).
- `ListScreenshotSubcommand` already capped at 10 by hand; now goes through
  the same `capFields()` helper (via an optional `maxFields` param) so both
  commands cap consistently.
- Over-long field values are truncated with an ellipsis instead of throwing.

## Test plan

33 new/updated tests under `tests/Integration`, hand-rolled fake interactions
per repo convention (no mocking library, see `AGENT.md`). `FakeInteraction`
now also tracks `deleteReply()` calls and correctly marks `replied = true`
after `followUp()` (matching real discord.js semantics), needed to assert
the `replyPrivately()` pattern.

At minimum, per the task:

- [x] a deferred subcommand calls `deferReply()` before doing work and
      `editReply()` after (`DeleteAdSubcommand.test.ts`,
      `ListAdsSubcommand.test.ts`, `ListScreenshotSubcommand.test.ts`,
      `CheckTrophyProfileSubcommand.test.ts`, `CreateTrophyProfileSubcommand.test.ts`,
      `RankSubcommand.test.ts`)
- [x] `ListAdsSubcommand` with 30 ads produces an embed with ≤25 fields and
      mentions the omitted count
- [x] a field value longer than 1024 chars is truncated, not thrown on
      (both directly on `embedLimits.capFields()` and end-to-end through
      `ListAdsSubcommand` with a 5000-char description)

Added after review, to lock in the M0.3 fix:

- [x] `ListAdsSubcommand`'s defer call, and its "no listings" path, both
      carry `MessageFlags.Ephemeral` — nothing in this command can leak
      into the channel
- [x] `CheckTrophyProfileSubcommand`'s not-found path asserts
      `deleteReply()` was called once and `followUp()` (not `editReply()`)
      carried `MessageFlags.Ephemeral`
- [x] `DeleteAdSubcommand`, `ListScreenshotSubcommand`,
      `CreateTrophyProfileSubcommand`, `RankSubcommand`: each has an
      assertion that its defer call carries `MessageFlags.Ephemeral`,
      confirming none of them regressed M0.3 either

Verify loop, run against a throwaway MariaDB:

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (pre-existing warnings elsewhere untouched)
- [x] `bun run format:check` — clean
- [x] `bun test` — **110 pass, 0 fail** (87 at this branch's base + 23 new/updated)

## Scope notes

Did not touch `DiscordBot.ts`'s constructor, `start()` lifecycle, or
`registerSlashCommands()` (owned by a parallel PR) — the only change there
is a one-line `kind: 'chat-input'` addition to the `InteractionCreate`
callback body, required so the object literal satisfies the new
`SlashCommandContext` type. Did not touch `DiscordGuildClient.ts`,
`CreateScreenshotHandler.ts`, `src/index.ts`, `package.json`, or `prisma/`.

Nothing was skipped from the M4.1/M4.2/M4.10 scope as written in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
