### PR TITLE
feat(bot): validate env at boot, harden the client lifecycle and cap attachment ingest (M1.3, M1.4, M4.4, M4.5, M4.6, M4.9)

### DIFF
--- a/discord-bot/src/Application/Write/Screenshot/CreateScreenshot/AttachmentGuard.ts
+++ b/discord-bot/src/Application/Write/Screenshot/CreateScreenshot/AttachmentGuard.ts
@@ -1,0 +1,166 @@
+import { InvalidAttachment } from './InvalidAttachment.ts';
+
+/**
+ * M4.9 — attachment ingest safety.
+ *
+ * `CreateScreenshotHandler.generateMd5FromImageUrl()` used to fetch
+ * whatever URL Discord handed it into memory with no cap, no timeout, and
+ * no check on where the URL actually pointed. Split out of the handler so
+ * each guard is unit-testable on its own:
+ *   - `assertAllowedAttachmentHost` needs no network at all.
+ *   - `downloadWithLimit` needs a real HTTP response to stream against
+ *     (a local `Bun.serve()` in tests), but deliberately does not know
+ *     about the host allowlist — that is a separate, cheaper check the
+ *     caller runs first, so a bad host is rejected before any connection is
+ *     attempted.
+ */
+
+// A "sane cap" for a screenshot attachment. Discord's own default upload
+// limit is 10 MiB (25 MiB with server boosts); this sits above what a real
+// screenshot needs and well below what would meaningfully threaten the
+// process's memory.
+export const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024;
+
+export const ATTACHMENT_DOWNLOAD_TIMEOUT_MS = 10_000;
+
+// Discord's asset hosts. Attachment/CDN URLs come from `cdn.discordapp.com`;
+// `media.discordapp.net` is included because Discord also serves resized/
+// proxied attachment images from it. Nothing else is a legitimate source
+// for a Discord attachment URL — A4 in docs/plans/05-bot-audit-and-hardening.md.
+export const ALLOWED_ATTACHMENT_HOSTS: readonly string[] = [
+    'cdn.discordapp.com',
+    'media.discordapp.net',
+];
+
+/** No network — just parses the URL and checks its hostname against the allowlist. */
+export function assertAllowedAttachmentHost(
+    url: string,
+    allowedHosts: readonly string[] = ALLOWED_ATTACHMENT_HOSTS,
+): void {
+    let hostname: string;
+    try {
+        hostname = new URL(url).hostname;
+    } catch {
+        throw new InvalidAttachment(`Attachment URL is not a valid URL: ${url}`);
+    }
+
+    if (!allowedHosts.includes(hostname)) {
+        throw new InvalidAttachment(`Attachment host is not allowed: ${hostname}`);
+    }
+}
+
+/**
+ * Checks a client-reported size (e.g. Discord's `attachment.size`) before
+ * any network call is made. Callers should still enforce `downloadWithLimit`
+ * below regardless — a reported size cannot be trusted on its own to bound
+ * memory, only to reject the obviously-too-large case early.
+ */
+export function assertReportedSizeWithinLimit(
+    size: number,
+    maxBytes: number = MAX_ATTACHMENT_BYTES,
+): void {
+    if (size > maxBytes) {
+        throw new InvalidAttachment(
+            `Attachment reports ${size} bytes, over the ${maxBytes}-byte limit`,
+        );
+    }
+}
+
+/**
+ * Split out of `downloadWithLimit` so the "does the response's own
+ * Content-Length already exceed the cap" check is unit-testable without a
+ * real HTTP response — servers (Bun's included) tend to recompute
+ * Content-Length from the actual body they send, which makes it awkward to
+ * get a real response that both declares a small body and streams a large
+ * one purely for a test. The mid-stream cap (enforced in
+ * `downloadWithLimit` itself, independently of this) is what actually
+ * protects against a lying or absent Content-Length in production.
+ */
+export function assertContentLengthWithinLimit(
+    contentLength: string | null,
+    maxBytes: number = MAX_ATTACHMENT_BYTES,
+): void {
+    if (contentLength !== null && Number(contentLength) > maxBytes) {
+        throw new InvalidAttachment(
+            `Attachment reports Content-Length ${contentLength}, over the ${maxBytes}-byte limit`,
+        );
+    }
+}
+
+/**
+ * Downloads `url` with an explicit timeout and a hard cap enforced while
+ * streaming — so a `Content-Length` that lies (or is simply absent) cannot
+ * blow memory. Does not check the host; call `assertAllowedAttachmentHost`
+ * first.
+ */
+export async function downloadWithLimit(
+    url: string,
+    options: { maxBytes?: number; timeoutMs?: number } = {},
+): Promise<Buffer> {
+    const maxBytes = options.maxBytes ?? MAX_ATTACHMENT_BYTES;
+    const timeoutMs = options.timeoutMs ?? ATTACHMENT_DOWNLOAD_TIMEOUT_MS;
+
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+        let response: Response;
+        try {
+            response = await fetch(url, { signal: controller.signal });
+        } catch (error) {
+            if ((error as Error).name === 'AbortError') {
+                throw new InvalidAttachment(
+                    `Attachment download timed out after ${timeoutMs}ms: ${url}`,
+                );
+            }
+            throw error;
+        }
+
+        if (!response.ok) {
+            throw new Error(`Request to ${url} failed with status code ${response.status}`);
+        }
+
+        assertContentLengthWithinLimit(response.headers.get('content-length'), maxBytes);
+
+        if (!response.body) {
+            throw new Error(`Response body is empty for ${url}`);
+        }
+
+        const reader = response.body.getReader();
+        const chunks: Uint8Array[] = [];
+        let total = 0;
+
+        try {
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) {
+                    break;
+                }
+
+                total += value.byteLength;
+                if (total > maxBytes) {
+                    throw new InvalidAttachment(
+                        `Attachment exceeded the ${maxBytes}-byte limit while downloading`,
+                    );
+                }
+
+                chunks.push(value);
+            }
+        } finally {
+            // Best-effort: nothing further can be done if this fails, and
+            // the guard above already threw the error that matters.
+            await reader.cancel().catch(() => undefined);
+        }
+
+        return Buffer.concat(chunks);
+    } catch (error) {
+        if ((error as Error).name === 'AbortError') {
+            throw new InvalidAttachment(
+                `Attachment download timed out after ${timeoutMs}ms: ${url}`,
+            );
+        }
+        throw error;
+    } finally {
+        clearTimeout(timeoutHandle);
+    }
+}

--- a/discord-bot/src/Application/Write/Screenshot/CreateScreenshot/CreateScreenshot.ts
+++ b/discord-bot/src/Application/Write/Screenshot/CreateScreenshot/CreateScreenshot.ts
@@ -10,5 +10,12 @@ export class CreateScreenshot implements Command {
         public readonly messageId: string | null,
         public readonly platform: string,
         public readonly image: string,
+        // Optional, M4.9: Discord reports the attachment's byte size on the
+        // interaction (`attachment.size`), which lets the handler reject an
+        // oversized upload before making any network call at all. Optional
+        // and last so existing call sites (and the fixtures below) keep
+        // working unchanged; when absent the handler still enforces the cap
+        // while streaming, just without the pre-fetch short-circuit.
+        public readonly imageSize?: number,
     ) {}
 }

--- a/discord-bot/src/Application/Write/Screenshot/CreateScreenshot/CreateScreenshotHandler.ts
+++ b/discord-bot/src/Application/Write/Screenshot/CreateScreenshot/CreateScreenshotHandler.ts
@@ -5,21 +5,30 @@ import { Screenshot } from '../../../../Domain/Screenshot/Screenshot';
 import type { ScreenshotRepository } from '../../../../Domain/Screenshot/ScreenshotRepository';
 import { TYPES } from '../../../../Infrastructure/DependencyInjection/types';
 import type Logger from '../../../Logger/Logger';
-import type { HttpClient } from '../../../../Domain/Http/HttpClient.ts';
 import crypto from 'crypto';
 import { ScreenshotAlreadyExist } from './ScreenshotAlreadyExist';
+import {
+    assertAllowedAttachmentHost,
+    assertReportedSizeWithinLimit,
+    downloadWithLimit,
+} from './AttachmentGuard.ts';
 
+// M4.9: this used to go through the injected TYPES.HttpClient
+// (FetchHttpClient/RetryHttpClient), whose `get()` reads the whole response
+// into a string via `response.text()` before handing it back — fine for the
+// JSON APIs that abstraction was built for, wrong for a binary image that
+// needs to be capped, streamed and hashed as bytes. downloadWithLimit()
+// below is a dedicated path for that, not a general-purpose HttpClient.
 @injectable()
 export class CreateScreenshotHandler implements CommandHandler<CreateScreenshot> {
     constructor(
         @inject(TYPES.ScreenshotRepository)
         private readonly screenshotRepository: ScreenshotRepository,
         @inject(TYPES.Logger) private readonly logger: Logger,
-        @inject(TYPES.HttpClient) private readonly httpClient: HttpClient,
     ) {}
 
     async handle(command: CreateScreenshot): Promise<Screenshot> {
-        const md5 = await this.generateMd5FromImageUrl(command.image);
+        const md5 = await this.generateMd5FromImageUrl(command.image, command.imageSize);
 
         if ((await this.screenshotRepository.findByMd5(md5)) !== null) {
             throw new ScreenshotAlreadyExist(`Screenshot with MD5 hash ${md5} already exists`);
@@ -51,9 +60,24 @@ export class CreateScreenshotHandler implements CommandHandler<CreateScreenshot>
         return screenshot;
     }
 
-    private async generateMd5FromImageUrl(imageUrl: string): Promise<string> {
-        const imageData = await this.httpClient.get(imageUrl);
+    private async generateMd5FromImageUrl(imageUrl: string, imageSize?: number): Promise<string> {
+        // Order matters and all three are needed (M4.9 / A4):
+        //  1. Host allowlist — no network at all for a URL that isn't
+        //     Discord's CDN.
+        //  2. The size Discord reported on the attachment, if the caller
+        //     has it — rejects an obviously-oversized upload before any
+        //     request is made.
+        //  3. downloadWithLimit()'s own Content-Length check plus a hard
+        //     cap enforced while streaming — the real guard, since neither
+        //     of the above can be trusted alone (the attachment size is
+        //     client-reported, and Content-Length can be absent or wrong).
+        assertAllowedAttachmentHost(imageUrl);
+        if (imageSize !== undefined) {
+            assertReportedSizeWithinLimit(imageSize);
+        }
 
-        return crypto.createHash('md5').update(Buffer.from(imageData)).digest('hex');
+        const imageData = await downloadWithLimit(imageUrl);
+
+        return crypto.createHash('md5').update(imageData).digest('hex');
     }
 }

--- a/discord-bot/src/Application/Write/Screenshot/CreateScreenshot/InvalidAttachment.ts
+++ b/discord-bot/src/Application/Write/Screenshot/CreateScreenshot/InvalidAttachment.ts
@@ -1,0 +1,11 @@
+/**
+ * Raised by the M4.9 attachment ingest guards in CreateScreenshotHandler:
+ * a host outside the Discord CDN allowlist, a reported/streamed size over
+ * the cap, or a download that didn't finish inside the timeout.
+ */
+export class InvalidAttachment extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'InvalidAttachment';
+    }
+}

--- a/discord-bot/src/Infrastructure/Bot/Discord/DiscordBot.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/DiscordBot.ts
@@ -1,5 +1,15 @@
 import { inject, injectable } from 'inversify';
-import { Client, Events, GatewayIntentBits, MessageFlags, REST, Routes } from 'discord.js';
+import {
+    Client,
+    Events,
+    GatewayIntentBits,
+    MessageFlags,
+    Options,
+    REST,
+    RESTEvents,
+    Routes,
+} from 'discord.js';
+import type { InvalidRequestWarningData, RateLimitData } from 'discord.js';
 import { TYPES } from '../../DependencyInjection/types.ts';
 import type Logger from '../../../Application/Logger/Logger.ts';
 import type { Bot } from '../../../Domain/Bot/Bot.ts';
@@ -10,6 +20,8 @@ import { safeReply } from '../../../Domain/Bot/safeReply.ts';
 @injectable()
 export class DiscordBot implements Bot {
     private readonly client: Client;
+    private readonly rest: REST;
+    private destroyed = false;
 
     constructor(
         private readonly token: string,
@@ -24,14 +36,74 @@ export class DiscordBot implements Bot {
         // naming a marketplace item or screenshot "@everyone" (M0.2 / A1):
         // without it, discord.js parses mentions out of raw message content
         // even when nobody intended to @-mention anyone.
+        //
+        // M4.6 — cache limits + sweepers: this is a long-lived,
+        // single-guild bot with only the `Guilds` intent (no
+        // `GuildMembers`/`MessageContent` — keep it that way, see
+        // GLOBAL-PLAN M4.6), so the caches that grow unbounded over time are
+        // messages (one per interaction reply/announcement touched) and
+        // users (one per interaction author). Both are capped and swept.
         this.client = new Client({
             intents: [GatewayIntentBits.Guilds],
             allowedMentions: { parse: [] },
+            makeCache: Options.cacheWithLimits({
+                ...Options.DefaultMakeCacheSettings,
+                MessageManager: 200,
+                UserManager: 200,
+            }),
+            sweepers: {
+                ...Options.DefaultSweeperSettings,
+                messages: {
+                    interval: 3_600, // every hour
+                    lifetime: 1_800, // drop messages older than 30 minutes
+                },
+                users: {
+                    interval: 3_600, // every hour
+                    filter: () => (user) => user.id !== this.client.user?.id,
+                },
+            },
+        });
+
+        // Same REST client backs both slash-command registration and (once
+        // logged in) everything discord.js does over HTTP. Rate-limit and
+        // invalid-request events are wired into the injected Logger here —
+        // an invalid-request spike is how you find out you're heading for a
+        // Cloudflare ban before it happens (M4.6).
+        this.rest = new REST().setToken(this.token);
+        this.rest.on(RESTEvents.RateLimited, (info: RateLimitData) => {
+            this.logger.warn('Discord REST rate limit hit', {
+                route: info.route,
+                method: info.method,
+                timeToReset: info.timeToReset,
+                global: info.global,
+            });
+        });
+        this.rest.on(RESTEvents.InvalidRequestWarning, (info: InvalidRequestWarningData) => {
+            this.logger.warn('Discord REST invalid request warning', {
+                count: info.count,
+                remainingTime: info.remainingTime,
+            });
         });
     }
 
     async start(): Promise<void> {
+        // M1.4: registerSlashCommands() now throws on failure instead of
+        // swallowing to console.error — so a failed sync stops the bot here,
+        // before client.login(), rather than starting it with a stale
+        // command set. src/index.ts treats a thrown start() as fatal
+        // (process.exit(1)).
         await this.registerSlashCommands();
+
+        // M4.4 — lifecycle hardening: neither of these existed before, so a
+        // client-level error (e.g. a WebSocket failure) or a shard error was
+        // invisible — nothing logged it, and nothing distinguished it from
+        // a clean shutdown.
+        this.client.on(Events.Error, (error) => {
+            this.logger.error('Discord client error', { error });
+        });
+        this.client.on(Events.ShardError, (error, shardId) => {
+            this.logger.error('Discord shard error', { error, shardId });
+        });
 
         this.client.once(Events.ClientReady, (readyClient) => {
             this.logger.info(`Ready! Logged in as ${readyClient.user.tag}`);
@@ -62,25 +134,45 @@ export class DiscordBot implements Bot {
         await this.client.login(this.token);
     }
 
+    /**
+     * M4.4 — graceful shutdown: destroys the gateway connection so a
+     * redeploy doesn't leave a dangling session. Idempotent — SIGTERM
+     * followed by SIGINT (or an uncaughtException arriving mid-shutdown)
+     * must not double-destroy the client, which discord.js does not itself
+     * guard against.
+     */
+    async destroy(): Promise<void> {
+        if (this.destroyed) {
+            return;
+        }
+        this.destroyed = true;
+
+        this.logger.info('Destroying Discord client');
+        await this.client.destroy();
+    }
+
     private async registerSlashCommands(): Promise<void> {
-        const rest = new REST().setToken(this.token);
         const commands = [];
         for (const handler of this.botExecutor.slashCommandHandlers) {
             commands.push(handler.builder().toJSON());
         }
 
-        try {
-            this.logger.log(`Started refreshing ${commands.length} application (/) commands.`);
+        this.logger.log(`Started refreshing ${commands.length} application (/) commands.`);
 
+        try {
             // The put method is used to fully refresh all commands in the guild with the current set
-            const data = (await rest.put(Routes.applicationCommands(this.clientId), {
+            const data = (await this.rest.put(Routes.applicationCommands(this.clientId), {
                 body: commands,
-            })) as any;
+            })) as unknown[];
 
             this.logger.log(`Successfully reloaded ${data.length} application (/) commands.`);
         } catch (error) {
-            // And of course, make sure you catch and log any errors!
-            console.error(error);
+            // M1.4: through the injected Logger (not console.error, which
+            // bypassed it entirely), and rethrown — start() no longer
+            // catches this, so the bot never logs in with a command set
+            // that failed to register.
+            this.logger.error('Failed to register application (/) commands', { error });
+            throw error;
         }
     }
 }

--- a/discord-bot/src/Infrastructure/Bot/GracefulShutdown.ts
+++ b/discord-bot/src/Infrastructure/Bot/GracefulShutdown.ts
@@ -1,0 +1,51 @@
+/**
+ * M4.4 — lifecycle hardening: SIGTERM/SIGINT (and a fatal uncaughtException)
+ * need to destroy the Discord client and disconnect Prisma before the
+ * process exits, so a redeploy doesn't leave a gateway session dangling.
+ *
+ * Split out of src/index.ts as a small factory, rather than inlined there,
+ * specifically so the "a second signal must not double-destroy" idempotency
+ * requirement is unit-testable: src/index.ts wires real dependencies
+ * (the bot's destroy(), Prisma's $disconnect(), the injected Logger,
+ * process.exit), but nothing here talks to a real process, a real Discord
+ * client or a real database — it can be exercised directly with hand-rolled
+ * fakes, no mocking library, no environment variables.
+ */
+export interface GracefulShutdownDeps {
+    /** Destroys the live bot client, if any. Must be safe to call even when there is nothing to destroy. */
+    destroy: () => Promise<void>;
+    /** Disconnects the database client. */
+    disconnect: () => Promise<void>;
+    log: (message: string) => void;
+    logError: (message: string, error: unknown) => void;
+    exit: (code: number) => void;
+}
+
+export type ShutdownHandler = (reason: string, exitCode: number) => Promise<void>;
+
+export function createShutdown(deps: GracefulShutdownDeps): ShutdownHandler {
+    let shuttingDown = false;
+
+    return async function shutdown(reason: string, exitCode: number): Promise<void> {
+        if (shuttingDown) {
+            return;
+        }
+        shuttingDown = true;
+
+        deps.log(`Shutting down (${reason})`);
+
+        try {
+            await deps.destroy();
+        } catch (error) {
+            deps.logError('Error destroying bot client during shutdown', error);
+        }
+
+        try {
+            await deps.disconnect();
+        } catch (error) {
+            deps.logError('Error disconnecting Prisma during shutdown', error);
+        }
+
+        deps.exit(exitCode);
+    };
+}

--- a/discord-bot/src/Infrastructure/Community/Discord/DiscordGuildClient.ts
+++ b/discord-bot/src/Infrastructure/Community/Discord/DiscordGuildClient.ts
@@ -1,30 +1,74 @@
 import type { GuildClient } from '../../../Domain/Community/GuildClient.ts';
 import { injectable } from 'inversify';
-import { Client, type Message, TextChannel } from 'discord.js';
+import type { APIMessage, InvalidRequestWarningData, RateLimitData } from 'discord.js';
+import { REST, Routes, RESTEvents } from 'discord.js';
 import { CommunityChannels } from '../../../Domain/Community/CommunityChannels.ts';
 import { CustomEmoji } from '../../../Domain/Community/CustomEmoji.ts';
-import { convertChannel } from './DiscordChannels.ts';
+import { convertChannel, DISCORD_GUILD_ID } from './DiscordChannels.ts';
 import { convertEmoji } from './DiscordEmoji.ts';
 import { ClientError } from '../../../Domain/Community/ClientError.ts';
+import type Logger from '../../../Application/Logger/Logger.ts';
 
+// REST-only client (M4.5 / A5). The previous implementation lazily built and
+// `login()`-ed a *second whole gateway `Client`* on the same bot token and
+// never `destroy()`-ed it, so any process that touched GuildClient (the CLI,
+// most notably `week-screenshot-winner`) held an open gateway session for its
+// entire lifetime. Nothing here — fetching a message, reading its reactions,
+// posting a message — needs a gateway connection; it is plain REST, so
+// `@discordjs/rest` (re-exported by `discord.js`, no new dependency) is
+// enough. `REST`/`Routes`/`RESTEvents` and the `APIMessage` response shape
+// all come from that same re-export (`discord.js` does `export * from
+// '@discordjs/rest'` and `export * from 'discord-api-types/v10'`).
 @injectable()
 export class DiscordGuildClient implements GuildClient {
-    private client: Client | undefined = undefined;
+    private readonly rest: REST;
 
-    constructor(private readonly token: string) {}
+    constructor(
+        // `string | undefined`, not `string` with a `?? ''` fallback at the
+        // call site (A6): when DISCORD_TOKEN is unset (tests, bin/console.ts
+        // without a bot process) this is undefined, and every public method
+        // below fails loudly via `requireToken()` instead of silently
+        // making an unauthenticated request that would 401 deep inside
+        // discord.js with no context.
+        private readonly token: string | undefined,
+        private readonly logger?: Logger,
+    ) {
+        this.rest = new REST({ version: '10' }).setToken(this.token ?? '');
+
+        // M4.6: an invalid-request spike or a sustained rate limit is how
+        // you find out you're heading for a Cloudflare ban before it
+        // happens — wire both into the injected Logger instead of letting
+        // @discordjs/rest handle them silently.
+        if (this.logger) {
+            const logger = this.logger;
+            this.rest.on(RESTEvents.RateLimited, (info: RateLimitData) => {
+                logger.warn('Discord REST rate limit hit', {
+                    route: info.route,
+                    method: info.method,
+                    timeToReset: info.timeToReset,
+                    global: info.global,
+                });
+            });
+            this.rest.on(RESTEvents.InvalidRequestWarning, (info: InvalidRequestWarningData) => {
+                logger.warn('Discord REST invalid request warning', {
+                    count: info.count,
+                    remainingTime: info.remainingTime,
+                });
+            });
+        }
+    }
 
     async getTotalReactionsByEmoji(
         channel: CommunityChannels,
         messageId: string,
         emoji: CustomEmoji,
     ): Promise<number> {
-        const discordEmoji = convertEmoji(emoji);
+        const discordEmojiId = convertEmoji(emoji);
 
         const message = await this.getMessage(channel, messageId);
-        const reactions = message.reactions.cache.filter(
-            (reaction) => reaction.emoji.id === discordEmoji,
+        const reaction = (message.reactions ?? []).find(
+            (candidate) => candidate.emoji.id === discordEmojiId,
         );
-        const reaction = reactions.first();
         if (!reaction) {
             throw new ClientError('Reaction not found');
         }
@@ -33,43 +77,54 @@ export class DiscordGuildClient implements GuildClient {
     }
 
     async getMessageUrl(channel: CommunityChannels, messageId: string): Promise<string> {
-        const message = await this.getMessage(channel, messageId);
-        return message.url;
+        // Confirms the message actually exists (and surfaces a ClientError
+        // if not), matching the previous gateway-based behaviour, before
+        // building the URL. The URL shape itself
+        // (`/channels/{guild}/{channel}/{message}`) is exactly what
+        // discord.js's `Message#url` produces — this is a single-guild bot,
+        // so the guild ID is the configured one rather than something that
+        // needs to be read off the message.
+        await this.getMessage(channel, messageId);
+        return `https://discord.com/channels/${DISCORD_GUILD_ID}/${convertChannel(channel)}/${messageId}`;
     }
 
     async sendMessage(channel: CommunityChannels, message: string): Promise<string> {
-        const client = await this.getClient();
-        const discordChannel = await client.channels.fetch(convertChannel(channel));
+        this.requireToken();
+        const channelId = convertChannel(channel);
 
-        if (!discordChannel?.isTextBased()) {
-            throw new ClientError('Channel not found or is not a text channel');
+        try {
+            // No `allowed_mentions` override here: unlike DiscordBot.ts's
+            // gateway client (which sets `allowedMentions: { parse: [] }`
+            // globally to stop user-supplied text from mass-pinging), the
+            // one caller of this method — the weekly winner announcement —
+            // intentionally mentions the winning user. Matches the previous
+            // gateway-client behaviour, which also had no override.
+            const created = (await this.rest.post(Routes.channelMessages(channelId), {
+                body: { content: message },
+            })) as APIMessage;
+            return created.id;
+        } catch (error) {
+            throw new ClientError(`Failed to send message: ${(error as Error).message}`);
         }
-
-        const sentMessage = await (discordChannel as TextChannel).send(message);
-        return sentMessage.id;
     }
 
-    private async getMessage(channel: CommunityChannels, messageId: string): Promise<Message> {
-        const client = await this.getClient();
-        const discordChannel = await client.channels.fetch(convertChannel(channel));
+    private async getMessage(channel: CommunityChannels, messageId: string): Promise<APIMessage> {
+        this.requireToken();
+        const channelId = convertChannel(channel);
 
-        if (!discordChannel?.isTextBased()) {
-            throw new ClientError('Channel not found or is not a text channel');
+        try {
+            return (await this.rest.get(Routes.channelMessage(channelId, messageId))) as APIMessage;
+        } catch (error) {
+            throw new ClientError(`Message not found: ${(error as Error).message}`);
         }
-        const message = await discordChannel.messages.fetch(messageId);
-        if (!message) {
-            throw new ClientError('Message not found');
-        }
-
-        return message;
     }
 
-    private async getClient(): Promise<Client> {
-        if (this.client === undefined) {
-            this.client = new Client({ intents: [] });
-            await this.client.login(this.token);
+    private requireToken(): string {
+        if (!this.token) {
+            throw new ClientError(
+                'DISCORD_TOKEN is not configured; GuildClient cannot call the Discord API',
+            );
         }
-
-        return this.client;
+        return this.token;
     }
 }

--- a/discord-bot/src/Infrastructure/Config/env.ts
+++ b/discord-bot/src/Infrastructure/Config/env.ts
@@ -1,0 +1,109 @@
+/**
+ * Env validation at boot (GLOBAL-PLAN M1.3).
+ *
+ * Hand-rolled rather than zod/typebox: three required string vars is not
+ * enough surface to justify a new runtime dependency, and this stays well
+ * under the ~80-line budget for that call. Revisit if the schema grows
+ * enums/numbers/nested shapes.
+ *
+ * Two separate schemas, not one, because "required" is entry-point-specific:
+ *  - `validateBaseEnv` covers what every entry point needs (DATABASE_URL is
+ *    read by Prisma in all three: src/index.ts, bin/console.ts, and the test
+ *    suite).
+ *  - `validateBotEnv` covers what only the live bot process needs
+ *    (DISCORD_TOKEN / DISCORD_CLIENT_ID). It is deliberately NOT called from
+ *    inversify.config.ts, which is imported by bin/console.ts and by every
+ *    test file via `myContainer` — calling it there would process.exit(1)
+ *    the test suite and the console entry point, both of which run without
+ *    a Discord token on purpose (that absence is what makes InMemoryClient
+ *    bind instead of a real Discord.Client — see inversify.config.ts).
+ *    Only src/index.ts — the actual bot process — calls validateBotEnv().
+ */
+
+function collect(
+    env: NodeJS.ProcessEnv,
+    keys: readonly string[],
+): { values: Record<string, string>; errors: string[] } {
+    const values: Record<string, string> = {};
+    const errors: string[] = [];
+
+    for (const key of keys) {
+        const raw = env[key];
+        if (raw === undefined || raw.trim().length === 0) {
+            errors.push(`${key} is required but was not set`);
+            continue;
+        }
+        values[key] = raw;
+    }
+
+    return { values, errors };
+}
+
+export interface BaseEnv {
+    DATABASE_URL: string;
+    LOKI_HOST?: string;
+    LOKI_AUTH?: string;
+}
+
+export interface BotEnv {
+    DISCORD_TOKEN: string;
+    DISCORD_CLIENT_ID: string;
+}
+
+export interface EnvValidationResult<T> {
+    config: T | undefined;
+    errors: string[];
+}
+
+export function validateBaseEnv(
+    env: NodeJS.ProcessEnv = process.env,
+): EnvValidationResult<BaseEnv> {
+    const { values, errors } = collect(env, ['DATABASE_URL']);
+    if (errors.length > 0) {
+        return { config: undefined, errors };
+    }
+
+    return {
+        config: {
+            DATABASE_URL: values.DATABASE_URL as string,
+            LOKI_HOST: env.LOKI_HOST?.trim() || undefined,
+            LOKI_AUTH: env.LOKI_AUTH?.trim() || undefined,
+        },
+        errors: [],
+    };
+}
+
+export function validateBotEnv(env: NodeJS.ProcessEnv = process.env): EnvValidationResult<BotEnv> {
+    const { values, errors } = collect(env, ['DISCORD_TOKEN', 'DISCORD_CLIENT_ID']);
+    if (errors.length > 0) {
+        return { config: undefined, errors };
+    }
+
+    return {
+        config: {
+            DISCORD_TOKEN: values.DISCORD_TOKEN as string,
+            DISCORD_CLIENT_ID: values.DISCORD_CLIENT_ID as string,
+        },
+        errors: [],
+    };
+}
+
+/** Logs every problem at once, then exits — never a silent fallback, never a stack trace. */
+export function exitOnEnvErrors(errors: string[]): void {
+    if (errors.length === 0) {
+        return;
+    }
+
+    console.error('Invalid environment configuration:');
+    for (const error of errors) {
+        console.error(`  - ${error}`);
+    }
+    process.exit(1);
+}
+
+/** Validates and exits on failure in one call; narrows away the `| undefined` for callers that don't need the raw errors array. */
+export function requireEnv<T>(result: EnvValidationResult<T>): T {
+    exitOnEnvErrors(result.errors);
+    // Unreachable when errors is non-empty: exitOnEnvErrors always exits(1) above.
+    return result.config as T;
+}

--- a/discord-bot/src/Infrastructure/DependencyInjection/inversify.config.ts
+++ b/discord-bot/src/Infrastructure/DependencyInjection/inversify.config.ts
@@ -49,21 +49,26 @@ import type { GuildClient } from '../../Domain/Community/GuildClient.ts';
 import { DiscordGuildClient } from '../Community/Discord/DiscordGuildClient.ts';
 import WeekScreenshotWinner from '../../Ui/Cli/WeekScreenshotWinner.ts';
 import { InMemoryClient } from '../Bot/InMemory/InMemoryClient.ts';
+import { requireEnv, validateBaseEnv, validateBotEnv } from '../Config/env.ts';
 
 const myContainer = new Container();
+
+// Env (M1.3) — DATABASE_URL is required by every entry point that imports
+// this file (src/index.ts, bin/console.ts, the whole test suite via
+// myContainer), so it is validated eagerly here and the process exits(1)
+// with every problem listed if it is missing. DISCORD_TOKEN /
+// DISCORD_CLIENT_ID are deliberately NOT validated this way — see
+// src/Infrastructure/Config/env.ts for why, and src/index.ts for where that
+// validation actually happens.
+const baseEnv = requireEnv(validateBaseEnv());
 
 // Logger
 myContainer.bind(ConsoleLogProvider).toSelf();
 
 const loggerManager = new LoggerManager();
 loggerManager.addProvider(myContainer.get(ConsoleLogProvider));
-if (!isEmpty(process.env.LOKI_HOST)) {
-    loggerManager.addProvider(
-        new LokiLogProvider(
-            String(process.env.LOKI_HOST),
-            isEmpty(process.env.LOKI_AUTH) ? undefined : String(process.env.LOKI_AUTH),
-        ),
-    );
+if (!isEmpty(baseEnv.LOKI_HOST)) {
+    loggerManager.addProvider(new LokiLogProvider(String(baseEnv.LOKI_HOST), baseEnv.LOKI_AUTH));
 }
 myContainer.bind<Logger>(TYPES.Logger).toConstantValue(loggerManager.createLogger({}));
 
@@ -122,22 +127,45 @@ myContainer.bind<HttpClient>(TYPES.HttpClient).to(RetryHttpClient);
 myContainer.bind<TrophySource>(TYPES.TrophySource).to(PsnProfilesTrophySource);
 
 // Bot
+// M1.3: DISCORD_TOKEN / DISCORD_CLIENT_ID are required for the live bot
+// process, but this file is also imported by bin/console.ts and by the
+// entire test suite (via `myContainer`), neither of which sets a Discord
+// token on purpose — that absence is what makes InMemoryClient bind below
+// instead of a real Discord.Client. So this validates but does NOT exit(1)
+// on failure (unlike baseEnv above); only src/index.ts — the actual bot
+// process — calls validateBotEnv() again and exits(1) if it's missing.
+const botEnv = validateBotEnv();
+
 myContainer
     .bind<GuildClient>(TYPES.GuildClient)
-    .toConstantValue(new DiscordGuildClient(process.env.DISCORD_TOKEN ?? ''));
+    .toConstantValue(
+        new DiscordGuildClient(botEnv.config?.DISCORD_TOKEN, myContainer.get(TYPES.Logger)),
+    );
 myContainer.bind(BotExecutor).toSelf();
-if (process.env.DISCORD_TOKEN) {
+if (botEnv.config) {
     myContainer
         .bind(TYPES.Bot)
         .toConstantValue(
             new DiscordBot(
-                process.env.DISCORD_TOKEN ?? '',
-                process.env.DISCORD_CLIENT_ID ?? '',
+                botEnv.config.DISCORD_TOKEN,
+                botEnv.config.DISCORD_CLIENT_ID,
                 myContainer.get(TYPES.Logger),
                 myContainer.get(BotExecutor),
             ),
         );
 } else {
+    // Explicit and loud (M1.3), not a silent accident: InMemoryClient is a
+    // deliberate no-op escape hatch for the test suite and bin/console.ts,
+    // never for the live bot process — which fails fast instead, see
+    // src/index.ts.
+    myContainer
+        .get<Logger>(TYPES.Logger)
+        .warn(
+            'DISCORD_TOKEN/DISCORD_CLIENT_ID not set — binding InMemoryClient (no-op bot, no Discord connection). ' +
+                'Expected for the test suite and bin/console.ts. If you are running the actual bot process ' +
+                '(src/index.ts) and see this, your environment is misconfigured — it validates these ' +
+                'independently at boot and should have already exited(1).',
+        );
     myContainer.bind(TYPES.Bot).toConstantValue(new InMemoryClient());
 }
 

--- a/discord-bot/src/index.ts
+++ b/discord-bot/src/index.ts
@@ -2,9 +2,64 @@ import { myContainer } from './Infrastructure/DependencyInjection/inversify.conf
 import type { Bot } from './Domain/Bot/Bot.ts';
 import type Logger from './Application/Logger/Logger';
 import { TYPES } from './Infrastructure/DependencyInjection/types.ts';
+import type { PrismaClient } from '@prisma/client';
+import { exitOnEnvErrors, validateBotEnv } from './Infrastructure/Config/env.ts';
+import { createShutdown } from './Infrastructure/Bot/GracefulShutdown.ts';
+
+// M1.3: this is the one entry point that actually starts a live Discord
+// bot, so it is the one that enforces DISCORD_TOKEN / DISCORD_CLIENT_ID
+// being set — loudly, with every problem reported at once, exiting non-zero
+// rather than falling through to InMemoryClient. That fallback exists in
+// inversify.config.ts specifically for the test suite and bin/console.ts,
+// neither of which reach this file. See Infrastructure/Config/env.ts.
+exitOnEnvErrors(validateBotEnv().errors);
 
 const logger = myContainer.get<Logger>(TYPES.Logger);
 const app = myContainer.get<Bot>(TYPES.Bot);
+
+// The Domain/Bot/Bot.ts port only requires start() — deliberately not
+// widened here to add destroy(), since only DiscordBot implements it
+// (InMemoryClient never reaches this file, given the exit above, but is
+// still handled defensively by createShutdown/GracefulShutdown.ts).
+interface StoppableBot extends Bot {
+    destroy?: () => Promise<void>;
+}
+const stoppableApp = app as StoppableBot;
+
+// M4.4 — lifecycle hardening. Idempotency (a second SIGTERM/SIGINT, or an
+// uncaughtException that arrives mid-shutdown, must not double-destroy the
+// client or double-disconnect Prisma) lives in createShutdown itself — see
+// GracefulShutdown.ts and its tests.
+const shutdown = createShutdown({
+    destroy: async () => {
+        if (typeof stoppableApp.destroy === 'function') {
+            await stoppableApp.destroy();
+        }
+    },
+    disconnect: async () => {
+        const prisma = myContainer.get<PrismaClient>(TYPES.OrmClient);
+        await prisma.$disconnect();
+    },
+    log: (message) => logger.info(message),
+    logError: (message, error) => logger.error(message, { error }),
+    exit: (code) => process.exit(code),
+});
+
+process.on('SIGTERM', () => {
+    void shutdown('SIGTERM', 0);
+});
+process.on('SIGINT', () => {
+    void shutdown('SIGINT', 0);
+});
+
+process.on('unhandledRejection', (reason) => {
+    logger.error('Unhandled promise rejection', { reason });
+});
+
+process.on('uncaughtException', (error) => {
+    logger.error('Uncaught exception', { error });
+    void shutdown('uncaughtException', 1);
+});
 
 (async () => {
     try {
@@ -12,5 +67,9 @@ const app = myContainer.get<Bot>(TYPES.Bot);
         logger.info('⚡️ Discord Bot app is running!');
     } catch (error) {
         logger.error('Error starting app:', { error });
+        // M1.4: registerSlashCommands() (and start() more generally) now
+        // fails loudly instead of starting with a stale command set or a
+        // half-initialised client — so a thrown start() is fatal here too.
+        process.exit(1);
     }
 })();

--- a/discord-bot/tests/Integration/Application/Write/Screenshot/CreateScreenshot/AttachmentGuard.test.ts
+++ b/discord-bot/tests/Integration/Application/Write/Screenshot/CreateScreenshot/AttachmentGuard.test.ts
@@ -1,0 +1,149 @@
+import { describe, test, expect } from 'bun:test';
+import {
+    assertAllowedAttachmentHost,
+    assertContentLengthWithinLimit,
+    assertReportedSizeWithinLimit,
+    downloadWithLimit,
+} from '../../../../../../src/Application/Write/Screenshot/CreateScreenshot/AttachmentGuard.ts';
+import { InvalidAttachment } from '../../../../../../src/Application/Write/Screenshot/CreateScreenshot/InvalidAttachment.ts';
+
+/**
+ * Regression coverage for M4.9 (A4):
+ * `CreateScreenshotHandler.generateMd5FromImageUrl()` used to fetch
+ * whatever URL it was given into memory with no size cap, no timeout, and
+ * no restriction on the host. These guards close each gap independently.
+ *
+ * No mocking library is used in this codebase. `downloadWithLimit` needs a
+ * real HTTP response to stream against, so these tests spin up a real
+ * `Bun.serve()` on an ephemeral port rather than faking `fetch`.
+ */
+describe('assertAllowedAttachmentHost', () => {
+    test('accepts the Discord CDN hosts', () => {
+        expect(() =>
+            assertAllowedAttachmentHost('https://cdn.discordapp.com/attachments/1/2/x.png'),
+        ).not.toThrow();
+        expect(() =>
+            assertAllowedAttachmentHost('https://media.discordapp.net/attachments/1/2/x.png'),
+        ).not.toThrow();
+    });
+
+    test('rejects a non-Discord host', () => {
+        expect(() => assertAllowedAttachmentHost('https://evil.example.com/x.png')).toThrow(
+            InvalidAttachment,
+        );
+    });
+
+    test('rejects a host that merely contains the allowed name', () => {
+        // Guards against a naive substring check: this must not pass just
+        // because "cdn.discordapp.com" appears somewhere in the string.
+        expect(() =>
+            assertAllowedAttachmentHost('https://cdn.discordapp.com.evil.example.com/x.png'),
+        ).toThrow(InvalidAttachment);
+    });
+
+    test('rejects a URL that fails to parse', () => {
+        expect(() => assertAllowedAttachmentHost('not a url')).toThrow(InvalidAttachment);
+    });
+});
+
+describe('assertReportedSizeWithinLimit', () => {
+    test('accepts a size under the cap', () => {
+        expect(() => assertReportedSizeWithinLimit(1_000, 10_000)).not.toThrow();
+    });
+
+    test('rejects an oversized reported size before any network call', () => {
+        expect(() => assertReportedSizeWithinLimit(20_000, 10_000)).toThrow(InvalidAttachment);
+    });
+});
+
+describe('assertContentLengthWithinLimit', () => {
+    test('accepts a missing Content-Length header (nothing to check yet)', () => {
+        expect(() => assertContentLengthWithinLimit(null, 100)).not.toThrow();
+    });
+
+    test('accepts a Content-Length under the cap', () => {
+        expect(() => assertContentLengthWithinLimit('50', 100)).not.toThrow();
+    });
+
+    test('rejects a Content-Length over the cap', () => {
+        expect(() => assertContentLengthWithinLimit('999999', 100)).toThrow(InvalidAttachment);
+    });
+});
+
+describe('downloadWithLimit', () => {
+    test('downloads a small body successfully', async () => {
+        const server = Bun.serve({
+            port: 0,
+            fetch: () => new Response('hello world'),
+        });
+
+        try {
+            const buffer = await downloadWithLimit(`http://127.0.0.1:${server.port}/`, {
+                maxBytes: 1_000,
+            });
+            expect(buffer.toString('utf8')).toBe('hello world');
+        } finally {
+            server.stop(true);
+        }
+    });
+
+    test('aborts mid-stream once the byte cap is exceeded, even when Content-Length lies', async () => {
+        const maxBytes = 1_000;
+        const chunk = new Uint8Array(600).fill(97); // 'a'
+
+        const server = Bun.serve({
+            port: 0,
+            fetch: () => {
+                const stream = new ReadableStream<Uint8Array>({
+                    async start(controller) {
+                        // Reports a Content-Length under the cap, then
+                        // streams well past it — this is the "lying size"
+                        // case the streaming cap exists for.
+                        controller.enqueue(chunk);
+                        controller.enqueue(chunk);
+                        controller.enqueue(chunk);
+                        controller.close();
+                    },
+                });
+                return new Response(stream, {
+                    headers: { 'Content-Length': String(chunk.byteLength) },
+                });
+            },
+        });
+
+        try {
+            await expect(
+                downloadWithLimit(`http://127.0.0.1:${server.port}/`, { maxBytes }),
+            ).rejects.toThrow(InvalidAttachment);
+        } finally {
+            server.stop(true);
+        }
+    });
+
+    test('times out a response that never finishes', async () => {
+        const server = Bun.serve({
+            port: 0,
+            fetch: () => {
+                const stream = new ReadableStream<Uint8Array>({
+                    start(controller) {
+                        controller.enqueue(new Uint8Array([1, 2, 3]));
+                        // Never closes and never sends more — simulates a
+                        // stalled connection.
+                    },
+                });
+                return new Response(stream);
+            },
+        });
+
+        try {
+            await expect(
+                downloadWithLimit(`http://127.0.0.1:${server.port}/`, {
+                    maxBytes: 1_000,
+                    timeoutMs: 50,
+                }),
+            ).rejects.toThrow(InvalidAttachment);
+        } finally {
+            server.stop(true);
+        }
+    }, 2_000);
+});

--- a/discord-bot/tests/Integration/Application/Write/Screenshot/CreateScreenshot/CreateScreenshotHandler.test.ts
+++ b/discord-bot/tests/Integration/Application/Write/Screenshot/CreateScreenshot/CreateScreenshotHandler.test.ts
@@ -8,6 +8,13 @@ import { PrismaClient } from '@prisma/client';
 import { myContainer } from '../../../../../../src/Infrastructure/DependencyInjection/inversify.config';
 import DatabaseUtil from '../../../../../Helper/DatabaseUtil.ts';
 
+// This test hits the real network (no mocking library, matching the rest of
+// this suite), so the fixture URL has to be something actually fetchable.
+// `cdn.discordapp.com/embed/avatars/0.png` is one of Discord's static
+// default-avatar assets — unlike a signed attachment URL it does not expire,
+// and unlike the previous `placehold.co` fixture it satisfies the M4.9
+// Discord-CDN host allowlist that CreateScreenshotHandler now enforces
+// (see AttachmentGuard.ts).
 describe('CreateScreenshotHandler Integration Test', () => {
     let commandHandlerManager: CommandHandlerManager;
     let ormClient: PrismaClient;
@@ -31,7 +38,7 @@ describe('CreateScreenshotHandler Integration Test', () => {
         const channelId = 'channel123';
         const messageId = 'message123';
         const platform = 'PS5';
-        const imageUrl = 'https://placehold.co/600x400/png';
+        const imageUrl = 'https://cdn.discordapp.com/embed/avatars/0.png';
 
         const command = new CreateScreenshot(
             screenshotId,
@@ -64,7 +71,7 @@ describe('CreateScreenshotHandler Integration Test', () => {
 
     test('should throw ScreenshotAlreadyExist when screenshot with same MD5 exists', async () => {
         // Arrange
-        const imageUrl = 'https://placehold.co/600x400/png';
+        const imageUrl = 'https://cdn.discordapp.com/embed/avatars/0.png';
 
         // Create first screenshot
         const command1 = new CreateScreenshot(

--- a/discord-bot/tests/Integration/Infrastructure/Bot/GracefulShutdown.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/GracefulShutdown.test.ts
@@ -1,0 +1,87 @@
+import { describe, test, expect } from 'bun:test';
+import {
+    createShutdown,
+    type GracefulShutdownDeps,
+} from '../../../../src/Infrastructure/Bot/GracefulShutdown.ts';
+
+/**
+ * Regression coverage for M4.4 (C6): the container is killed today with
+ * no SIGTERM handling at all, leaving gateway sessions dangling on every
+ * redeploy. The fix must also be idempotent — a second SIGTERM arriving
+ * while the first is still shutting down (or an uncaughtException firing
+ * mid-shutdown) must not double-destroy the client or double-disconnect
+ * Prisma. Hand-rolled fakes, no mocking library, no real process/Discord
+ * client/database involved — src/index.ts wires the real dependencies.
+ */
+function createFakeDeps() {
+    const calls: string[] = [];
+    const exitCodes: number[] = [];
+
+    const deps: GracefulShutdownDeps = {
+        destroy: async () => {
+            calls.push('destroy');
+        },
+        disconnect: async () => {
+            calls.push('disconnect');
+        },
+        log: () => {},
+        logError: () => {},
+        exit: (code: number) => {
+            exitCodes.push(code);
+        },
+    };
+
+    return { calls, exitCodes, deps };
+}
+
+describe('createShutdown', () => {
+    test('destroys the client and disconnects once, then exits with the given code', async () => {
+        const { calls, exitCodes, deps } = createFakeDeps();
+        const shutdown = createShutdown(deps);
+
+        await shutdown('SIGTERM', 0);
+
+        expect(calls).toEqual(['destroy', 'disconnect']);
+        expect(exitCodes).toEqual([0]);
+    });
+
+    test('is idempotent: a second signal does not double-destroy or double-disconnect', async () => {
+        const { calls, exitCodes, deps } = createFakeDeps();
+        const shutdown = createShutdown(deps);
+
+        await shutdown('SIGTERM', 0);
+        await shutdown('SIGINT', 0);
+
+        expect(calls).toEqual(['destroy', 'disconnect']);
+        expect(exitCodes).toEqual([0]);
+    });
+
+    test('concurrent signals (no await between them) still only run the shutdown body once', async () => {
+        const { calls, exitCodes, deps } = createFakeDeps();
+        const shutdown = createShutdown(deps);
+
+        await Promise.all([shutdown('SIGTERM', 0), shutdown('SIGINT', 0)]);
+
+        expect(calls).toEqual(['destroy', 'disconnect']);
+        expect(exitCodes).toEqual([0]);
+    });
+
+    test('an error destroying the client does not stop Prisma from disconnecting', async () => {
+        const { calls, exitCodes, deps } = createFakeDeps();
+        deps.destroy = async () => {
+            calls.push('destroy');
+            throw new Error('client.destroy() blew up');
+        };
+        const errors: string[] = [];
+        deps.logError = (message) => {
+            errors.push(message);
+        };
+        const shutdown = createShutdown(deps);
+
+        await shutdown('uncaughtException', 1);
+
+        expect(calls).toEqual(['destroy', 'disconnect']);
+        expect(exitCodes).toEqual([1]);
+        expect(errors).toEqual(['Error destroying bot client during shutdown']);
+    });
+});

--- a/discord-bot/tests/Integration/Infrastructure/Community/Discord/DiscordGuildClient.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Community/Discord/DiscordGuildClient.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect } from 'bun:test';
+import { DiscordGuildClient } from '../../../../../src/Infrastructure/Community/Discord/DiscordGuildClient.ts';
+import { ClientError } from '../../../../../src/Domain/Community/ClientError.ts';
+import { CommunityChannels } from '../../../../../src/Domain/Community/CommunityChannels.ts';
+import { CustomEmoji } from '../../../../../src/Domain/Community/CustomEmoji.ts';
+
+/**
+ * Regression coverage for M4.5/A5/A6.
+ *
+ * A5: the previous implementation lazily built and `login()`-ed a whole
+ * second gateway `Client` on the bot token. Constructing DiscordGuildClient
+ * must not open any connection — these tests never call `.login()` or touch
+ * a gateway at all, only REST, and only after an explicit call.
+ *
+ * A6: an empty/undefined token used to be passed straight through
+ * (`process.env.DISCORD_TOKEN ?? ''`) and silently produced a client that
+ * would fail deep inside discord.js with no context. `DiscordGuildClient`
+ * now takes `token: string | undefined` and fails fast with a clear
+ * `ClientError` before any network call is attempted.
+ */
+describe('DiscordGuildClient — no token configured', () => {
+    test('sendMessage fails fast with a clear error, without making a request', async () => {
+        const client = new DiscordGuildClient(undefined);
+
+        await expect(client.sendMessage(CommunityChannels.SCREENSHOTS, 'hello')).rejects.toThrow(
+            ClientError,
+        );
+    });
+
+    test('getMessageUrl fails fast with a clear error, without making a request', async () => {
+        const client = new DiscordGuildClient(undefined);
+
+        await expect(
+            client.getMessageUrl(CommunityChannels.SCREENSHOTS, '123456789012345678'),
+        ).rejects.toThrow(ClientError);
+    });
+
+    test('getTotalReactionsByEmoji fails fast with a clear error, without making a request', async () => {
+        const client = new DiscordGuildClient(undefined);
+
+        await expect(
+            client.getTotalReactionsByEmoji(
+                CommunityChannels.SCREENSHOTS,
+                '123456789012345678',
+                CustomEmoji.TROPHY_PLAT,
+            ),
+        ).rejects.toThrow(ClientError);
+    });
+
+    test('the same guard fires for an empty-string token, not just undefined', async () => {
+        const client = new DiscordGuildClient('');
+
+        await expect(client.sendMessage(CommunityChannels.SCREENSHOTS, 'hello')).rejects.toThrow(
+            ClientError,
+        );
+    });
+});
+
+describe('DiscordGuildClient — construction', () => {
+    test('constructing the client does not throw and does not require a token', () => {
+        expect(() => new DiscordGuildClient(undefined)).not.toThrow();
+    });
+});

--- a/discord-bot/tests/Integration/Infrastructure/Config/env.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Config/env.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect } from 'bun:test';
+import { validateBaseEnv, validateBotEnv } from '../../../../src/Infrastructure/Config/env.ts';
+
+/**
+ * Regression coverage for M1.3 (A6): an unset DISCORD_TOKEN used to
+ * silently bind InMemoryClient with no indication anything was wrong.
+ * `validateBaseEnv`/`validateBotEnv` take `env` as a parameter, exactly like
+ * `resolveDiscordIds` (DiscordChannels.ts), specifically so this can be
+ * asserted without a mocking library or touching the real process.env —
+ * and, critically, without calling `process.exit()`, which would kill the
+ * test runner. `exitOnEnvErrors`/`requireEnv` (the process.exit(1) side) are
+ * intentionally not exercised here.
+ */
+describe('validateBaseEnv', () => {
+    test('rejects a missing DATABASE_URL', () => {
+        const { config, errors } = validateBaseEnv({});
+
+        expect(config).toBeUndefined();
+        expect(errors).toEqual(['DATABASE_URL is required but was not set']);
+    });
+
+    test('rejects a blank DATABASE_URL the same as a missing one', () => {
+        const { config, errors } = validateBaseEnv({ DATABASE_URL: '   ' });
+
+        expect(config).toBeUndefined();
+        expect(errors).toEqual(['DATABASE_URL is required but was not set']);
+    });
+
+    test('accepts a set DATABASE_URL and leaves Loki config optional', () => {
+        const { config, errors } = validateBaseEnv({
+            DATABASE_URL: 'mysql://root:pw@localhost:3306/db',
+        });
+
+        expect(errors).toEqual([]);
+        expect(config).toEqual({
+            DATABASE_URL: 'mysql://root:pw@localhost:3306/db',
+            LOKI_HOST: undefined,
+            LOKI_AUTH: undefined,
+        });
+    });
+
+    test('carries LOKI_HOST/LOKI_AUTH through when set', () => {
+        const { config } = validateBaseEnv({
+            DATABASE_URL: 'mysql://root:pw@localhost:3306/db',
+            LOKI_HOST: 'https://loki.example.com',
+            LOKI_AUTH: 'user:pass',
+        });
+
+        expect(config?.LOKI_HOST).toBe('https://loki.example.com');
+        expect(config?.LOKI_AUTH).toBe('user:pass');
+    });
+});
+
+describe('validateBotEnv', () => {
+    test('reports every missing required var at once, not just the first', () => {
+        const { config, errors } = validateBotEnv({});
+
+        expect(config).toBeUndefined();
+        expect(errors).toEqual([
+            'DISCORD_TOKEN is required but was not set',
+            'DISCORD_CLIENT_ID is required but was not set',
+        ]);
+    });
+
+    test('reports only the missing one when the other is set', () => {
+        const { errors } = validateBotEnv({ DISCORD_TOKEN: 'abc' });
+
+        expect(errors).toEqual(['DISCORD_CLIENT_ID is required but was not set']);
+    });
+
+    test('accepts both when set', () => {
+        const { config, errors } = validateBotEnv({
+            DISCORD_TOKEN: 'abc',
+            DISCORD_CLIENT_ID: 'def',
+        });
+
+        expect(errors).toEqual([]);
+        expect(config).toEqual({ DISCORD_TOKEN: 'abc', DISCORD_CLIENT_ID: 'def' });
+    });
+});


### PR DESCRIPTION
## Summary

Implements GLOBAL-PLAN work items **M1.3, M1.4, M4.4, M4.5, M4.6, M4.9** (boot validation, lifecycle hardening, and attachment ingest safety). Scope per the work order: `src/index.ts`, `src/Infrastructure/Config/**`, `src/Infrastructure/Community/Discord/DiscordGuildClient.ts`, `CreateScreenshotHandler.ts`, `bin/console.ts`, and — in `DiscordBot.ts` — only the constructor, `start()` lifecycle and `registerSlashCommands()`. The `InteractionCreate` callback body and `SlashCommand/**` are untouched (owned by a parallel PR).

### M1.3 — Env validation at boot
- New `src/Infrastructure/Config/env.ts`: hand-rolled validator (no zod/typebox — three required string vars didn't justify a new runtime dependency, and it stays well under the ~80-line guidance). `validateBaseEnv` (DATABASE_URL, always required) and `validateBotEnv` (DISCORD_TOKEN/DISCORD_CLIENT_ID) are pure and take `env` as a parameter — same pattern as the existing `resolveDiscordIds` — so tests never call `process.exit()`. `exitOnEnvErrors`/`requireEnv` do the actual logging + `process.exit(1)`.
- **Critical constraint honoured**: `inversify.config.ts` (loaded by the whole test suite and `bin/console.ts`) validates `DATABASE_URL` eagerly (exits if missing — safe, every entry point sets it) but only *checks* DISCORD_TOKEN/DISCORD_CLIENT_ID without exiting, logging a loud warning through the Logger before binding `InMemoryClient`. Only `src/index.ts` — the actual bot process — calls `validateBotEnv()` again and `exitOnEnvErrors()`, so an unset token now fails loudly (exit 1, every problem listed) instead of silently running a no-op bot. Verified manually: `bun run src/index.ts` with no token exits 1 with both problems listed; `bin/console.ts help` logs the warning and still runs.
- Deleted all three `?? ''` fallbacks in `inversify.config.ts` (DiscordBot's token/clientId, DiscordGuildClient's token).

### M1.4 — registerSlashCommands fails loudly
- Logs through the injected `Logger` (not `console.error`) and rethrows. `start()` no longer swallows the failure, so the client never `login()`s with a stale command set. Verified manually against a fake token: logs "Failed to register application (/) commands", `index.ts` logs "Error starting app" and exits 1.

### M4.4 — Lifecycle hardening
- `Events.Error`/`Events.ShardError` handlers on the Client, logged.
- `process.on('unhandledRejection'|'uncaughtException')` in `src/index.ts`, logged through the Logger; `uncaughtException` triggers shutdown with exit code 1.
- SIGTERM/SIGINT → `client.destroy()` + `prisma.$disconnect()`, exit 0. Idempotency lives in a new small factory, `src/Infrastructure/Bot/GracefulShutdown.ts` (`createShutdown`), specifically so it's unit-testable without a real process/client/DB — `src/index.ts` wires the real dependencies.

### M4.5 — Replace DiscordGuildClient's second gateway client
- Rewritten as REST-only (`REST`/`Routes`/`RESTEvents`/`APIMessage`, all re-exported by `discord.js` from `@discordjs/rest` and `discord-api-types/v10` — **no new dependency**). No `.login()`, no lingering gateway session. The `GuildClient` domain port is unchanged.
- Also fixes A6 properly: token is `string | undefined`, not `?? ''`; every method fails fast with a clear `ClientError` if unconfigured, instead of building a client that would 401 deep inside discord.js with no context.

### M4.6 — Client configuration
- `makeCache`/`sweepers` on the gateway `Client` (messages: 1h sweep / 30min lifetime; users: swept hourly, keeping only the bot's own user). Intents remain `Guilds`-only — untouched, as required.
- REST rate-limit/invalid-request events wired into the Logger on **both** REST clients this PR touches (`DiscordBot`'s command-registration client, `DiscordGuildClient`'s).

### M4.9 — Attachment ingest safety
- New `AttachmentGuard.ts` (host allowlist, reported-size check, streamed download with a hard byte cap + timeout) and `InvalidAttachment.ts`, both under `CreateScreenshot/`.
- `CreateScreenshotHandler` no longer goes through the injected `TYPES.HttpClient` for this — that abstraction's `get()` reads the whole response into a string via `.text()`, which is wrong for a binary image being hashed. Order of checks: host allowlist (no network) → reported `image.size` if present → Content-Length check → hard cap enforced while streaming (protects against a lying/absent Content-Length).
- **Left out / judgement call**: `CreateScreenshot.imageSize` is optional and not yet wired from the actual interaction attachment, because `CreateScreenshotSubcommand.ts` is owned by the parallel PR (`SlashCommand/**`). The streaming cap still fully protects memory either way; the pre-fetch short-circuit is just inactive until the other PR adds one line (`image.size`) to the `CreateScreenshot` constructor call.
- The existing `CreateScreenshotHandler.test.ts` fixture (`placehold.co`) was swapped for `cdn.discordapp.com/embed/avatars/0.png` (a stable, non-expiring Discord default-avatar asset) since it's now subject to the host allowlist.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` — 0 errors (112 pre-existing warnings, unchanged in kind)
- [x] `bun run format:check` clean
- [x] `bun test` — **115 pass, 0 fail** (was 57 before this branch + the rebased-in M7.1/M7.2 PR; this PR adds 28 new tests: env validation, attachment guard host/size/stream-cap/timeout, DiscordGuildClient no-token guard, graceful-shutdown idempotency)
- [x] `bun audit --audit-level=high` clean, no `package.json`/lockfile changes (confirms no new dependency)
- [x] Manual: `bun run src/index.ts` with no `DISCORD_TOKEN` → exits 1, both problems listed
- [x] Manual: `bun run src/index.ts` with a fake token → registerSlashCommands 401s, logs through Logger, `index.ts` exits 1 (no silent stale-command-set start)
- [x] Manual: `bun run:command help` (bin/console.ts, no token) → loud InMemoryClient warning, still runs to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)