### PR TITLE
ci(ci): allow the `main` scope so release-please PR titles lint clean

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -32,6 +32,7 @@ jobs:
             perf
             revert
           scopes: |
+            main
             bot
             marketplace
             screenshots


### PR DESCRIPTION
release-please opens its release PR as `chore(main): release discord-bot X.Y.Z`. `main` was not in the allowed scope list of `.github/workflows/pr-title.yml`, so **PR Title** failed on every release PR — see #26, red on that check and nothing else.

That is the one PR class whose title is *generated*, not written, so it can never be fixed by editing the title. Adding `main` to the scope list is the fix release-please's own docs recommend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)