### PR TITLE
fix(ci): wait for the entrypoint to finish before resetting the test database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,16 @@ jobs:
         working-directory: discord-bot
         run: |
           docker compose -f docker-compose.ci.yml up -d
-          # Wait for the app container to be ready, then set up the test DB.
-          timeout 300 bash -c 'until docker compose -f docker-compose.ci.yml exec -T discord-bot true 2>/dev/null; do sleep 3; done'
+          # Wait for entrypoint.sh to have FINISHED its startup work -- not
+          # merely for the container to be up. `exec ... true` (what this used
+          # to be) succeeds while the entrypoint is still waiting on the DB or
+          # midway through `prisma migrate deploy`, so `test:setup` below --
+          # `prisma migrate reset --force`, a DROP of the whole schema -- raced
+          # it: the deploy failed P1014, `set -e` killed the entrypoint, the
+          # container exited, and the in-flight `exec` came back 137 with
+          # nothing in the test output to explain it. See entrypoint.sh for
+          # where the marker is written.
+          timeout 300 bash -c 'until docker compose -f docker-compose.ci.yml exec -T discord-bot test -f /tmp/entrypoint-ready 2>/dev/null; do sleep 3; done'
           docker compose -f docker-compose.ci.yml exec -T discord-bot bun run test:setup
           docker compose -f docker-compose.ci.yml exec -T discord-bot bun test
 

--- a/discord-bot/docker/entrypoint.sh
+++ b/discord-bot/docker/entrypoint.sh
@@ -115,6 +115,25 @@ ulimit -c 0
 # Run migrations
 bunx prisma migrate deploy
 
+# Everything above this line is startup work that mutates the database.
+# Signal that it is finished.
+#
+# CI waits for this marker before it runs `bun run test:setup`, which is
+# `prisma migrate reset --force` -- a DROP and recreate of the whole schema.
+# Without the marker, CI's readiness probe was `docker compose exec
+# discord-bot true`, which succeeds the moment the *container* is up: that is
+# already true while this script is still in its DB wait or halfway through
+# `migrate deploy`. The reset then dropped `_prisma_migrations` underneath the
+# deploy, which failed with P1014, `set -e` killed this script, the container
+# died, and the in-flight `docker compose exec` returned 137 -- a red CI run
+# with nothing in the test output to explain it. It is a race, so it passed
+# most of the time.
+#
+# /tmp rather than the app directory: the container runs as the unprivileged
+# `app` user and /tmp is the one path guaranteed writable regardless of how
+# the image is built.
+: > /tmp/entrypoint-ready
+
 # If a command was given (docker-compose.ci.yml uses this to keep the
 # container alive for `docker compose exec` -- see the comment there for
 # why), run that instead of starting the bot.


### PR DESCRIPTION
**This is a real race, not a flake.** #40 hit it on two consecutive runs, which is the only reason it was findable.

The Test job's readiness probe was:

```bash
until docker compose exec -T discord-bot true; do sleep 3; done
```

`exec … true` succeeds the moment the *container* is up — which is already true while `entrypoint.sh` is still waiting on MariaDB, or halfway through `prisma migrate deploy`.

So the very next line, `bun run test:setup` (= `prisma migrate reset --force`, a DROP and recreate of the whole schema), ran **concurrently with that deploy**. The sequence:

1. reset drops `_prisma_migrations`
2. the entrypoint's in-flight `migrate deploy` fails `P1014: The underlying table for model \`_prisma_migrations\` does not exist`
3. `set -e` kills the entrypoint → container exits
4. the in-flight `docker compose exec` returns **137**

The symptom is a red *Bot — typecheck & test* with **empty test output**, because the suite never started — and 137 reads as an OOM kill, which sends you looking in entirely the wrong place. The evidence is in #40's "Show app logs on failure" output: `Applying migration 20250416170150_init` immediately followed by `Error: P1014`.

The fix: `entrypoint.sh` writes `/tmp/entrypoint-ready` once its startup work is done, and CI waits for *that*. `/tmp` because the container runs as the unprivileged `app` user, and it is the one path guaranteed writable however the image is built.

Both sides carry a comment explaining what the marker is for, since the failure it prevents is entirely invisible from either file alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)