### PR TITLE
fix(bot): resolve the Bot and GuildClient bindings lazily so the container can boot

### DIFF
--- a/discord-bot/src/Infrastructure/DependencyInjection/inversify.config.ts
+++ b/discord-bot/src/Infrastructure/DependencyInjection/inversify.config.ts
@@ -174,28 +174,54 @@ const botEnv = validateBotEnv();
 // stand-in instead, which is what makes the M6.4 winner job's
 // tie / vanished-message / dry-run behaviour assertable without a mocking
 // library.
+// `toDynamicValue`, NOT `toConstantValue(new …(myContainer.get(…)))`.
+//
+// `toConstantValue` needs its argument *now*, so every `myContainer.get()`
+// inside one resolves while this module is still executing — against a
+// container that only holds the bindings declared above this line. That made
+// binding **order** load-bearing, silently, and in a way no test could see:
+// these two branches are the only ones a real `DISCORD_TOKEN` takes, so the
+// test suite and CI (which deliberately run without a token, binding
+// InMemoryGuildClient/InMemoryClient instead) never executed them at all.
+//
+// It cost a production outage. `myContainer.get(BotExecutor)` below pulls in
+// every SlashCommandHandler -> subcommand -> CommandHandlerManager -> every
+// `TYPES.CommandHandler`, and one of those (CreateScreenshotHandler) needs
+// `TYPES.MediaStorage` — which is bound ~40 lines *further down* this file.
+// The live bot crash-looped on `No bindings found for service:
+// "Symbol(MediaStorage)"` while CI stayed green.
+//
+// A dynamic value defers resolution to the first `container.get(TYPES.Bot)`,
+// by which point the whole file has run and every binding exists. Reordering
+// the lines would have fixed today's symptom and left the trap armed for the
+// next binding added in the wrong place.
 if (botEnv.config) {
+    const config = botEnv.config;
     myContainer
         .bind<GuildClient>(TYPES.GuildClient)
-        .toConstantValue(
-            new DiscordGuildClient(botEnv.config.DISCORD_TOKEN, myContainer.get(TYPES.Logger)),
-        );
+        .toDynamicValue(
+            () => new DiscordGuildClient(config.DISCORD_TOKEN, myContainer.get(TYPES.Logger)),
+        )
+        .inSingletonScope();
 } else {
     myContainer.bind<GuildClient>(TYPES.GuildClient).to(InMemoryGuildClient).inSingletonScope();
 }
 myContainer.bind(BotExecutor).toSelf();
 if (botEnv.config) {
+    const config = botEnv.config;
     myContainer
         .bind(TYPES.Bot)
-        .toConstantValue(
-            new DiscordBot(
-                botEnv.config.DISCORD_TOKEN,
-                botEnv.config.DISCORD_CLIENT_ID,
-                myContainer.get(TYPES.Logger),
-                myContainer.get(BotExecutor),
-                botEnv.config.DISCORD_DEV_GUILD_ID,
-            ),
-        );
+        .toDynamicValue(
+            () =>
+                new DiscordBot(
+                    config.DISCORD_TOKEN,
+                    config.DISCORD_CLIENT_ID,
+                    myContainer.get(TYPES.Logger),
+                    myContainer.get(BotExecutor),
+                    config.DISCORD_DEV_GUILD_ID,
+                ),
+        )
+        .inSingletonScope();
 } else {
     // Explicit and loud (M1.3), not a silent accident: InMemoryClient is a
     // deliberate no-op escape hatch for the test suite and bin/console.ts,

--- a/discord-bot/tests/Integration/Infrastructure/DependencyInjection/ContainerBoot.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/DependencyInjection/ContainerBoot.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'bun:test';
+
+/**
+ * The gate that was missing when the bot crash-looped in production on
+ * `No bindings found for service: "Symbol(MediaStorage)"`.
+ *
+ * `inversify.config.ts` takes a *different branch* when `DISCORD_TOKEN` and
+ * `DISCORD_CLIENT_ID` are set: it binds `DiscordBot`/`DiscordGuildClient`
+ * instead of the in-memory stand-ins. The whole test suite runs without a
+ * token on purpose — that absence is what keeps tests off the network — so
+ * until this file existed, **the branch that production actually takes was
+ * never executed by anything**. A binding graph that resolved cleanly in CI
+ * could still be unresolvable at boot, and was.
+ *
+ * This has to run in a subprocess. The container is a module-level singleton
+ * built at import time from `process.env`, so it cannot be re-created with
+ * different env inside a test that has already imported it — and `bun test`
+ * shares one module registry across the file. Spawning is not a workaround
+ * here; booting the container in a fresh process with production-shaped env
+ * *is* the thing under test.
+ *
+ * The token is a syntactically-plausible fake. Nothing in this path talks to
+ * Discord: `DiscordGuildClient` builds a REST client without logging in, and
+ * `DiscordBot`'s constructor only configures a client — `login()` happens in
+ * `start()`, which is never called here.
+ */
+
+const FAKE_CLIENT_ID = '123456789012345678';
+
+/**
+ * Assembled from parts rather than written as a literal. A Discord bot token
+ * is `base64(clientId).<timestamp>.<hmac>`, and a realistic-looking literal
+ * matches GitHub's secret-scanning pattern well enough that push protection
+ * rejects the commit — correctly, since it cannot know a token is fake. This
+ * still produces the right *shape*, which is all `validateBotEnv()` and the
+ * REST client care about, without tripping the scanner.
+ */
+const FAKE_TOKEN = [
+    Buffer.from(FAKE_CLIENT_ID).toString('base64').replace(/=+$/, ''),
+    'A'.repeat(6),
+    'B'.repeat(27),
+].join('.');
+
+async function bootContainerWithBotEnv(script: string): Promise<{
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+}> {
+    const proc = Bun.spawn(['bun', '-e', script], {
+        cwd: `${import.meta.dir}/../../../..`,
+        env: {
+            ...process.env,
+            DISCORD_TOKEN: FAKE_TOKEN,
+            DISCORD_CLIENT_ID: FAKE_CLIENT_ID,
+            // Explicitly unset: DISCORD_DEV_GUILD_ID must not leak in from a
+            // developer's shell and change which registration branch runs.
+            DISCORD_DEV_GUILD_ID: undefined,
+        },
+        stdout: 'pipe',
+        stderr: 'pipe',
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
+
+    return { exitCode, stdout, stderr };
+}
+
+describe('Container boot with a Discord token (the production branch)', () => {
+    it('resolves TYPES.Bot to a real DiscordBot, with every transitive binding present', async () => {
+        const { exitCode, stdout, stderr } = await bootContainerWithBotEnv(`
+            const { myContainer } = await import('./src/Infrastructure/DependencyInjection/inversify.config.ts');
+            const { TYPES } = await import('./src/Infrastructure/DependencyInjection/types.ts');
+            console.log('BOT=' + myContainer.get(TYPES.Bot).constructor.name);
+        `);
+
+        // The failure this guards against surfaces as "No bindings found for
+        // service: Symbol(<whatever was bound too late)", so assert on the
+        // output rather than only on the exit code — it is the message that
+        // tells the next person which binding moved.
+        expect(`${stdout}${stderr}`).not.toContain('No bindings found');
+        expect(exitCode).toBe(0);
+        expect(stdout).toContain('BOT=DiscordBot');
+    }, 60_000);
+
+    it('resolves every slash command, component and autocomplete handler through BotExecutor', async () => {
+        // BotExecutor is what the eager `myContainer.get()` used to pull in,
+        // and it is the widest fan-out in the graph: every SlashCommandHandler
+        // -> subcommand -> CommandHandlerManager -> every TYPES.CommandHandler.
+        // Resolving it is the cheapest way to prove the whole application
+        // layer is bindable.
+        const { exitCode, stdout, stderr } = await bootContainerWithBotEnv(`
+            const { myContainer } = await import('./src/Infrastructure/DependencyInjection/inversify.config.ts');
+            const { BotExecutor } = await import('./src/Infrastructure/Bot/BotExecutor.ts');
+            const executor = myContainer.get(BotExecutor);
+            console.log('COMMANDS=' + executor.getCommandNames().sort().join(','));
+            console.log('AUTOCOMPLETE=' + executor.autocompleteHandlers.length);
+        `);
+
+        expect(`${stdout}${stderr}`).not.toContain('No bindings found');
+        expect(exitCode).toBe(0);
+        expect(stdout).toContain('COMMANDS=marketplace,ping,screenshot,trophy');
+        // Loose assertion on purpose: adding an autocomplete handler should
+        // not fail this test, but removing all of them should.
+        expect(stdout).not.toContain('AUTOCOMPLETE=0');
+    }, 60_000);
+
+    it('resolves the job runner and every registered job', async () => {
+        // The scheduler path is resolved from bin/console.ts, which has no
+        // Discord token — but it shares this container, and a job that needs
+        // a late-bound service would fail the same way.
+        const { exitCode, stdout, stderr } = await bootContainerWithBotEnv(`
+            const { myContainer } = await import('./src/Infrastructure/DependencyInjection/inversify.config.ts');
+            const { JobRunner } = await import('./src/Infrastructure/Job/JobRunner.ts');
+            myContainer.get(JobRunner);
+            console.log('JOBS_OK');
+        `);
+
+        expect(`${stdout}${stderr}`).not.toContain('No bindings found');
+        expect(exitCode).toBe(0);
+        expect(stdout).toContain('JOBS_OK');
+    }, 60_000);
+});


### PR DESCRIPTION
## Production is down right now

`gop-bot` on HTZ1 is in a restart loop:

```
error: No bindings found for service: "Symbol(MediaStorage)".
Trying to resolve bindings for "Symbol(CommandHandler)".
```

## Cause

`inversify.config.ts` bound `TYPES.Bot` as:

```ts
.toConstantValue(new DiscordBot(…, myContainer.get(BotExecutor), …))
```

`toConstantValue` needs its argument **now**, so that `myContainer.get()` ran while the module was still executing — against a container holding only the bindings declared *above that line*.

`BotExecutor` fans out to every `SlashCommandHandler` → each subcommand → `CommandHandlerManager` → every `TYPES.CommandHandler`. One of those, `CreateScreenshotHandler`, needs `TYPES.MediaStorage` — bound **~40 lines further down the same file**. Binding order was load-bearing, silently.

## Why CI stayed green through it

Both eager branches sit behind `if (botEnv.config)`, true only when `DISCORD_TOKEN` is set. The test suite runs **without** a token on purpose — that absence is what binds `InMemoryClient`/`InMemoryGuildClient` and keeps tests off the network. So the branch production actually takes had never been executed by anything, and a binding graph that resolved cleanly in CI was unresolvable at boot.

## Fix

`toDynamicValue` for both `TYPES.Bot` and `TYPES.GuildClient`, in singleton scope. Resolution defers to the first `container.get()`, by which point the whole file has run and every binding exists.

Reordering the lines would have fixed today's symptom and left the trap armed for the next binding added in the wrong place — so this removes the ordering dependency rather than satisfying it.

## The gate that was missing

`tests/Integration/Infrastructure/DependencyInjection/ContainerBoot.test.ts` boots the container **in a subprocess** with production-shaped env and resolves `TYPES.Bot`, `BotExecutor` and `JobRunner`.

The subprocess is not a workaround: the container is a module-level singleton built from `process.env` at import time, so it cannot be rebuilt with different env inside a file that has already imported it. Booting it fresh with a token *is* the thing under test. The fake token never reaches the network — `DiscordGuildClient` builds a REST client without logging in, and `DiscordBot`'s constructor only configures a client; `login()` happens in `start()`, which is never called. It is assembled from parts rather than written as a literal, because a realistic-looking literal trips GitHub push protection — correctly, since the scanner cannot know a token is fake.

Verified both ways: **all three cases fail without the fix and pass with it.**

```
bunx tsc --noEmit   # clean
bun test            # 358 pass, 0 fail (was 355 — 3 new)
bunx eslint .       # 0 errors
```

Merging this is what restores the live bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)