### PR TITLE
ci(infra): fail the deploy when the container does not stay up

### DIFF
--- a/.github/actions/portainer-deploy/action.yml
+++ b/.github/actions/portainer-deploy/action.yml
@@ -45,6 +45,21 @@ inputs:
     description: 'Local port on the runner to bind the tunnel to'
     required: false
     default: '9000'
+  health-check-container:
+    description: >-
+      Container name to verify after the deploy. The step polls it through
+      Portainer's Docker API proxy and fails the deploy if it is not running,
+      or if it restarts during the observation window. Leave empty to skip.
+    required: false
+    default: ''
+  health-check-settle-seconds:
+    description: 'How long to let the container settle before the first sample'
+    required: false
+    default: '20'
+  health-check-window-seconds:
+    description: 'How long to watch for restarts after it first reports running'
+    required: false
+    default: '45'
 
 runs:
   using: 'composite'
@@ -161,6 +176,103 @@ runs:
           jq '.message // .error // .' /tmp/response.json 2>/dev/null || cat /tmp/response.json
           exit 1
         fi
+
+    - name: Verify the deployed container stays up
+      if: ${{ inputs.health-check-container != '' }}
+      shell: bash
+      env:
+        PORTAINER_TOKEN: ${{ inputs.portainer-access-token }}
+        LOCAL_PORT: ${{ inputs.local-port }}
+        CONTAINER: ${{ inputs.health-check-container }}
+        SETTLE: ${{ inputs.health-check-settle-seconds }}
+        WINDOW: ${{ inputs.health-check-window-seconds }}
+      run: |
+        set -uo pipefail
+
+        # Why this step exists.
+        #
+        # A successful PUT to /api/stacks only means Portainer accepted the
+        # stack and started the containers. It says nothing about whether they
+        # STAY started -- and `restart: unless-stopped` will happily restart a
+        # container that dies on boot, forever, without anything reporting a
+        # failure. On 2026-08-20 the bot crash-looped for hours on an
+        # unresolvable DI binding while four consecutive deploys all reported
+        # green, and the healthcheck declared on the service never ran, because
+        # Docker does not run healthchecks against a container that is
+        # restarting. It was found by hand, over SSH, during an unrelated check.
+        #
+        # The deploy SSH key is tunnel-only (forced command,
+        # permitopen=127.0.0.1:9000), so `docker inspect` over SSH is not
+        # available here by design. Portainer proxies the Docker API through
+        # that same tunnel, which is how this reads container state without
+        # widening the key's permissions.
+        API="http://localhost:${LOCAL_PORT}/api/endpoints/${{ inputs.endpoint-id }}/docker"
+
+        inspect() {
+          curl -s --connect-timeout 10 --max-time 30 \
+            -H "X-API-Key: $PORTAINER_TOKEN" \
+            "${API}/containers/${CONTAINER}/json"
+        }
+
+        dump_logs() {
+          echo "--- last 60 log lines from ${CONTAINER} ---"
+          # Docker multiplexes stdout/stderr with an 8-byte header per frame
+          # when the container has no TTY; strip the non-printable bytes so
+          # the output is readable in the Actions log.
+          curl -s --connect-timeout 10 --max-time 30 \
+            -H "X-API-Key: $PORTAINER_TOKEN" \
+            "${API}/containers/${CONTAINER}/logs?stdout=1&stderr=1&tail=60" \
+            | tr -d '\000-\010\013\014\016-\037' || echo "(could not fetch logs)"
+          echo "--- end of logs ---"
+        }
+
+        echo "Letting ${CONTAINER} settle for ${SETTLE}s after the stack update..."
+        sleep "$SETTLE"
+
+        FIRST=$(inspect)
+        if [ -z "$FIRST" ] || ! echo "$FIRST" | jq -e '.State' > /dev/null 2>&1; then
+          echo "❌ Could not inspect ${CONTAINER} through Portainer's Docker API."
+          echo "$FIRST" | head -c 500
+          exit 1
+        fi
+
+        FIRST_STATUS=$(echo "$FIRST" | jq -r '.State.Status')
+        FIRST_RESTARTS=$(echo "$FIRST" | jq -r '.RestartCount')
+        echo "${CONTAINER}: status=${FIRST_STATUS} restartCount=${FIRST_RESTARTS}"
+
+        if [ "$FIRST_STATUS" != "running" ]; then
+          echo "❌ ${CONTAINER} is '${FIRST_STATUS}', not 'running', ${SETTLE}s after the deploy."
+          echo "   'restarting' means it is crash-looping: the process dies on boot and"
+          echo "   Docker keeps restarting it. The logs below are from the last attempt."
+          dump_logs
+          exit 1
+        fi
+
+        echo "Watching ${CONTAINER} for ${WINDOW}s to make sure it does not restart..."
+        sleep "$WINDOW"
+
+        SECOND=$(inspect)
+        SECOND_STATUS=$(echo "$SECOND" | jq -r '.State.Status')
+        SECOND_RESTARTS=$(echo "$SECOND" | jq -r '.RestartCount')
+        echo "${CONTAINER}: status=${SECOND_STATUS} restartCount=${SECOND_RESTARTS}"
+
+        if [ "$SECOND_STATUS" != "running" ]; then
+          echo "❌ ${CONTAINER} was running but is now '${SECOND_STATUS}' -- it died after boot."
+          dump_logs
+          exit 1
+        fi
+
+        # A container that boots, runs for a few seconds and then dies passes
+        # the status check on both samples if the restart happens to land
+        # between them. The restart *counter* is what catches that.
+        if [ "$SECOND_RESTARTS" != "$FIRST_RESTARTS" ]; then
+          echo "❌ ${CONTAINER} restarted during the observation window"
+          echo "   (${FIRST_RESTARTS} -> ${SECOND_RESTARTS}). It is not stable."
+          dump_logs
+          exit 1
+        fi
+
+        echo "✅ ${CONTAINER} has been up and stable for ${WINDOW}s (restartCount=${SECOND_RESTARTS})"
 
     - name: Close SSH tunnel
       if: always()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,10 @@ jobs:
           endpoint-id: ${{ vars.PORTAINER_ENDPOINT_ID }}
           stack-file: infrastructure/game-on-portugal.yaml
           version: ${{ github.sha }}
+          # Fail the deploy if the bot does not actually stay up. Portainer
+          # accepting the stack is not evidence the container survives boot,
+          # and `restart: unless-stopped` hides a crash loop indefinitely.
+          health-check-container: gop-bot
 
       - name: Notify Telegram
         if: always()


### PR DESCRIPTION
Follow-up to #45, which fixed the outage. This is the gate that would have caught it in under two minutes instead of several hours.

## The gap

A successful `PUT /api/stacks/{id}` means Portainer **accepted the stack and started the containers**. It says nothing about whether they *stay* started — and `restart: unless-stopped` will restart a container that dies on boot, forever, reporting nothing.

Today the bot crash-looped on an unresolvable DI binding while **four consecutive deploys all reported green**. The `healthcheck` declared on `gop-bot` in `infrastructure/game-on-portugal.yaml` did not help either: **Docker does not run healthchecks against a container that is restarting**, so a crash loop is precisely the case a service-level healthcheck cannot see. It was found by hand, over SSH, during an unrelated check.

## The gate

After the stack update, sample the container twice through Portainer's Docker API proxy — once after a settle period (20s), once after an observation window (45s) — and fail if:

- status is not `running` (`restarting` means crash-looping), or
- `RestartCount` moved between the two samples.

**Two samples, not one**, because a container that boots, runs a few seconds and dies would pass a single status check whenever the restart happens to land outside it. The counter is what catches that.

On failure it dumps the last 60 log lines, so the Actions log shows *why* — the DI error from #45 would have been right there. (Docker multiplexes stdout/stderr with a per-frame binary header on a TTY-less container, so the control bytes are stripped to keep the output readable.)

## Why Portainer's proxy and not SSH

The deploy key is deliberately tunnel-only — forced command plus `permitopen=127.0.0.1:9000` — so `docker inspect` over SSH is not available, by design, and widening the key to get it would be a bad trade. Portainer proxies the Docker API over the tunnel that is already open.

**Route verified against the live host**: `/api/endpoints/3/docker/containers/gop-bot/json` returns `401` unauthenticated (not `404`), so the path exists and only needs the API key the action already holds.

The check is opt-in per call site via `health-check-container`, so the action stays reusable for a stack with nothing worth probing; `deploy.yml` passes `gop-bot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)