### PR TITLE
docs(plans): add a manual test plan and the decommission/cleanup plan

### DIFF
--- a/docs/plans/08-decommission-and-cleanup.md
+++ b/docs/plans/08-decommission-and-cleanup.md
@@ -1,0 +1,157 @@
+# Plan 08 — Decommission & cleanup
+
+**Goal**: retire everything the revival replaced, without removing a rollback
+path before it has earned retiring.
+
+Written 2026-08-21, from an audit of the live hosts and the repo rather than
+from memory. Every item below states what was *verified*, not what was assumed.
+
+> **The ordering rule for this whole plan**: nothing that is currently a
+> rollback path gets deleted until the thing replacing it has run unattended
+> for long enough to trust. That is why C1 is dated and not merely "todo".
+
+---
+
+## Already done — do not redo
+
+| | Verified 2026-08-21 |
+| --- | --- |
+| `old-discord-bot/` | **Deleted** (#44, M9.6). Not present in the tree. |
+| Seven dead Prisma models | **Dropped** (migration `20260820102655_drop_dead_models`) — 4 LFG + `StockUrls` + `CommandChannelLink` + `SpecialChannel` |
+| Dead env vars | `SENTRY_DSN`, `REDIS_DSN`, `TROPHY_WEBHOOK`, `TELEGRAM_ACCESS_TOKEN` gone from `.env.example` and the compose files |
+| Dependabot alerts | **76 → 0**. Every one lived in `old-discord-bot/package-lock.json`. |
+
+### ⚠️ Do NOT remove: `old-discord-bot` mentions in `discord-bot/src`
+
+A grep still finds the string in ~6 source files. **These are provenance
+comments, not leftovers** — e.g.
+
+```
+* Ported from `old-discord-bot/src/service/trophy/psnCrawlService.js#getPsnProfileByUrl`
+```
+
+They record *why* a piece of logic looks the way it does, and the code they
+point at is still in git history. Stripping them to make a grep clean would
+delete the only explanation of some genuinely non-obvious behaviour (the
+Monday→Sunday week window, the points ladder, the `sell`/`sale` adType split).
+Leave them.
+
+---
+
+## C1 — Decommission TedRelayer (M2.5) — **due 2026-09-02, not before**
+
+TedRelayer (`ssh -p 2224 tedcrypto@192.168.0.184`) is the pre-HTZ1 home for the
+bot. It is **stopped-but-intact on purpose**: it is the rollback path.
+
+Audited 2026-08-21:
+
+| container | state | note |
+| --- | --- | --- |
+| `game-on-portugal-app` | Exited (137), 47h | the old bot — already stopped |
+| `game-on-portugal-scheduler` | Exited (137), 47h | old cron sidecar |
+| `game-on-portugal-db` | **Up 7 weeks (healthy)** | MariaDB 11.5.2 — the rollback data |
+| `game-on-portugal-redis` | **Up 7 weeks** | Keyv cache; nothing reads it now |
+| `game-on-portugal-db-backup` | **Up 47 hours** | still dumping the frozen DB |
+
+Volumes: `game-on-portugal_gop-db-data`, `_gop-redis-data`, `_gop-backup`.
+Stale images: `joshlopes/game-on-portugal-bot` (411 MB, 13 months old),
+`joshlopes/game-on-portugal-scheduler` (116 MB, 16 months old).
+
+**Steps, in order, on or after 2026-09-02:**
+
+1. **Take a final dump of the old database and put it somewhere durable** —
+   not on TedRelayer. This is the only irreversible step; do it first and
+   verify the file is readable before touching anything else.
+   > The nightly backup silently failed for **seven weeks** in 2026 because the
+   > dump succeeded and the SMB *upload* failed against a DDNS name. "The
+   > backup container is Up" is not evidence a backup exists. Open the file.
+2. Confirm HTZ1 has been serving without incident since the cutover, and that
+   `job_runs` shows recent successful runs.
+3. Stop `game-on-portugal-redis` and `game-on-portugal-db-backup`. Nothing
+   reads Redis; the backup job is dumping a database nobody writes to.
+4. Stop `game-on-portugal-db`.
+5. Wait a further week with everything stopped but volumes intact.
+6. Remove the containers, then the three volumes, then the two stale images.
+7. Delete the old stack definition and any `.env` on that host.
+
+**Do not skip step 5.** Stopping is reversible; `docker volume rm` is not.
+
+---
+
+## C2 — Delete `webpage/` (part of M8.15)
+
+`webpage/` is a 111-file Bootstrap template copy of the old site. It is
+**deployed by nothing** (`docs/known-issues.md` #9), its `index.html`
+references an `assets/img/logo.png` that does not exist, and the live site was
+GitHub Pages — now the portal.
+
+**Blocked on**: the apex DNS cutover completing and the portal serving
+`game-on-portugal.pt`. Until then this is still the only copy of the old
+markup in the working tree.
+
+Files that reference it and must be updated in the same PR:
+
+- `.github/labeler.yml` — a `webpage/**` path label
+- `.github/workflows/security.yml` — a scan-exclusion comment
+- `AGENT.md` — the repo table and the "Where it lives" note
+- `docs/README.md`, `docs/plans/00-overview.md`, `docs/known-issues.md` #9
+- `brand/README.md` — references it as *why* there was no logo file (rewrite as
+  past tense; the point still stands)
+
+---
+
+## C3 — Archive `GameOnPortugal/gameonportugal.github.io`
+
+Verified 2026-08-21: **not archived**, last pushed **2021-11-11**.
+
+Once the apex serves the portal, archive the repo (do not delete — it is the
+provenance of the old site). Then remove the now-pointless
+`_github-pages-challenge-gameonportugal` TXT record from the OVH zone.
+
+**Order matters**: keep the TXT record until you are certain you will not roll
+back to Pages, because re-verifying a domain there is slower than leaving one
+stale TXT record in place.
+
+---
+
+## C4 — Rotate the Discord OAuth client secret
+
+`DISCORD_CLIENT_SECRET` was created on 2026-08-21 and transited a chat
+transcript on its way into 1Password. It is one click to reset in the Discord
+Developer Portal (application `854400559633268766` → OAuth2 → Reset Secret).
+
+Not urgent — the secret only grants the OAuth flow for this one application,
+and the admin surface is behind a `ManageMessages` check regardless — but it is
+cheap hygiene once the portal is confirmed working end to end. Update the
+1Password item and the Portainer stack env together; rotating one without the
+other logs every admin out with a confusing error.
+
+---
+
+## C5 — Smaller leftovers
+
+- **`.env.example` drift** — re-read it against what `src/Infrastructure/Config/env.ts`
+  actually validates. It has drifted in both directions before (advertising dead
+  vars, omitting live ones).
+- **The audit-log volume is not backed up.** `portal_audit_data` holds M8.11's
+  SQLite audit log. The nightly job dumps MySQL only, so the audit log survives
+  redeploys but not disk loss. Either add it to the backup or write down that it
+  is deliberately ephemeral.
+- **`deepmerge-ts` override** (`discord-bot/package.json`) — added to clear a
+  high advisory Prisma 7 pulls through `@prisma/config`. Remove it once
+  `@prisma/config` widens its range; the reason is in the M3.6 row.
+- **Two unrecoverable screenshots** — 2022-era rows whose Discord CDN
+  attachments no longer exist. `screenshots-relink` will reconsider them on
+  every run forever. Harmless, but if it ever bothers anyone, mark them rather
+  than letting the job retry indefinitely.
+
+---
+
+## What this plan deliberately does not do
+
+**It does not delete anything on the strength of "it looks unused."** Every
+item above names how its disuse was verified — a container state, a grep, a
+row count, an archive flag. The one time this project deleted on assumption
+(the scheduler pointing at `node scripts/…` commands that did not exist), the
+result was a scheduler that ran zero jobs for sixteen months without anyone
+noticing.

--- a/docs/plans/GLOBAL-PLAN.md
+++ b/docs/plans/GLOBAL-PLAN.md
@@ -63,6 +63,8 @@ workflow in the same PR rather than picking the nearest existing scope.
 | [`06-discord-api-modernisation.md`](06-discord-api-modernisation.md) | Deprecations **P1–P5**, interaction lifecycle, components |
 | [`07-dependency-upgrades.md`](07-dependency-upgrades.md) | Locked inventory, hygiene defects **D1–D5**, Prisma 6→7 |
 | [`01`](01-marketplace-overhaul.md) [`02`](02-scheduler-and-lifecycle.md) [`03`](03-portal.md) [`04`](04-infrastructure-migration.md) | Per-area designs and task tables, all open questions already decided |
+| [`08-decommission-and-cleanup.md`](08-decommission-and-cleanup.md) | What is left to retire (TedRelayer, `webpage/`, the Pages repo) and in what order |
+| [`../test-plan.md`](../test-plan.md) | Manual end-to-end verification checklist for a release |
 | [`../session-log-2026-08-19.md`](../session-log-2026-08-19.md) | How we found all of this, and the decision log |
 
 ---

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -1,0 +1,178 @@
+# Manual test plan — Game On Portugal
+
+**Purpose**: verify, by hand, that everything the community touches actually
+works in production. Written 2026-08-21, after the revival effort took the
+queue from 41/93 to 90/93.
+
+This exists because the failure that started all of this was **invisible**:
+`/marketplace sell` failed on 100% of invocations for fourteen months and
+nobody noticed, because nothing ever exercised it end to end. Automated tests
+now cover the layers underneath; this covers the part only a human in Discord
+can see.
+
+> **Run this after any release you care about.** It takes about 15 minutes.
+
+## Before you start
+
+| | |
+| --- | --- |
+| Guild | Game On Portugal (`818108848492773377`) |
+| Bot | `GameOnPortugalBot#9387` |
+| Portal | https://game-on-portugal.pt (after M8.15 DNS propagates) |
+| Media | https://media.game-on-portugal.pt |
+| Host | `ssh -p 2224 ezweb@195.201.192.35`, Portainer stack `game-on-portugal` |
+
+Quick health check before touching anything:
+
+```bash
+ssh -p 2224 ezweb@195.201.192.35 \
+  'docker inspect gop-bot --format "status={{.State.Status}} restarts={{.RestartCount}} health={{.State.Health.Status}}"'
+```
+
+Expect `status=running restarts=0 health=healthy`. **A non-zero restart count
+is the single most useful early warning** — it is what a crash-loop looks like,
+and it is exactly what went unnoticed during the 2026-08-20 outage.
+
+---
+
+## 1. Marketplace — the feature that was most broken
+
+### 1.1 Create a sale listing
+`/marketplace sell` — name, price, state, zone, dispatch, (optional) warranty,
+description, image.
+
+- [ ] You get an **ephemeral** confirmation with a link to the listing
+- [ ] The listing appears in **`📖anuncios`**, not in the channel you typed in
+- [ ] The embed is **Portuguese**, mint-coloured, with the item image
+- [ ] The **ad ID is in the footer**
+- [ ] Three buttons: `💬 Contactar`, `✅ Marcar vendido`, `🔄 Renovar`
+
+> **Why this matters**: for fourteen months this command saved the ad, then
+> threw on the message-ID write-back and replied twice, burying the real error.
+> 28 of 33 ads created after the rewrite carry an empty `message_id`.
+
+If you attached an image, check its URL: it must be on
+`media.game-on-portugal.pt`, **never** `cdn.discordapp.com`. A Discord CDN link
+dies within 24h — that is what killed the screenshot gallery.
+
+### 1.2 Wanted listing
+`/marketplace wanted` — [ ] posts to the same channel, **blue** embed, distinct copy.
+
+### 1.3 Browse
+- [ ] `/marketplace list` — ephemeral, paginated, Prev/Next work, links open the real message
+- [ ] `/marketplace search` with a keyword — filters correctly
+- [ ] `/marketplace search` with nonsense — returns an empty result, not an error
+- [ ] Click **Next**, wait 15+ minutes, click again → expect a polite *"search expired, run it again"*, **not** stale results
+
+### 1.4 Lifecycle
+- [ ] `/marketplace bump` — reposts the listing
+- [ ] `/marketplace bump` again immediately → refused (72h cooldown)
+- [ ] `/marketplace edit` — opens a **modal**; saving re-renders the posted message in place
+- [ ] `/marketplace sold` — marks sold, message removed
+- [ ] `/marketplace delete` — the `id` option **autocompletes to your own ads**; you should never type a UUID
+
+> Autocomplete replaced a positional index (`delete 2`) that resolved against a
+> *fresh* query — so an ad created or expired in between deleted the wrong row.
+
+### 1.5 Permissions
+- [ ] A non-owner pressing `✅ Marcar vendido` on someone else's ad → refused
+- [ ] A moderator (`ManageMessages`) pressing it → allowed
+- [ ] Post 10 active ads, try an 11th → refused with a clear pt-PT message
+
+---
+
+## 2. Screenshots
+
+- [ ] `/screenshot create` with an image → confirmation, appears in the gallery
+- [ ] Its URL is on `media.game-on-portugal.pt` (re-hosted at submit time)
+- [ ] `/screenshot list` → your screenshots
+- [ ] `/screenshot delete` → `id` **autocompletes to your own**
+- [ ] Deleting someone else's → refused
+
+---
+
+## 3. Trophies
+
+- [ ] `/trophy create` with a PSNProfiles URL — try **both** URL shapes
+- [ ] `/trophy check` — shows your profile and **live rank**
+- [ ] `/trophy rank` — leaderboard with the guild's plat/gold/silver/bronze emojis on 1/2/3
+- [ ] Pagination buttons page forward and back
+- [ ] Page past the end → clamps, does not error or render empty
+
+> Sanity check: the true #1 is **`Zephyr-pt`, 58,050 points, 193 trophies**. The
+> old broken query showed an arbitrary ten profiles and did not include the real
+> leader at all.
+
+---
+
+## 4. Portal — https://game-on-portugal.pt
+
+- [ ] Home loads, stats are real (~9 active ads, 624 screenshots, 4,971 trophies, 118 profiles)
+- [ ] Marketplace grid, filters, detail page
+- [ ] Screenshots gallery — **grid tiles load thumbnails, not full images**
+- [ ] Trophies leaderboard matches `/trophy rank`
+- [ ] Mobile at 375px — this is the primary target, not desktop
+- [ ] A broken image degrades gracefully (2 of 624 are dead 2022 Discord links)
+
+Thumbnail spot-check — the tile should be a few KB, not a few hundred:
+```bash
+curl -sI "https://game-on-portugal.pt/api/media/thumbnail?src=<image-url>&w=320" | grep -i content-length
+```
+
+### Admin (needs `ManageMessages`)
+- [ ] `/admin` → Discord OAuth → back to the portal
+- [ ] A non-member is refused; a member without `ManageMessages` is refused
+- [ ] Jobs page shows real `job_runs` rows
+- [ ] A destructive admin action appears in the **audit log**
+
+---
+
+## 5. Scheduled jobs
+
+Jobs run on cron. Check the record rather than waiting:
+
+```bash
+ssh -p 2224 ezweb@195.201.192.35 \
+  'docker exec gop-db sh -c "mariadb -uroot -p\$MARIADB_ROOT_PASSWORD -B discord-bot \
+   -e \"SELECT job_name,last_run_at,status FROM job_runs ORDER BY last_run_at DESC\""'
+```
+
+| job | schedule | |
+| --- | --- | --- |
+| `ads-reconcile` | daily 03:00 | [ ] recent, `success` |
+| `ads-lifecycle` | daily 10:00 | [ ] recent, `success` |
+| `screenshots-relink` | Sat 22:00 | [ ] `success` |
+| `week-screenshot-winner` | Sun 23:50 | [ ] `success` |
+| `trophies:sync` | every 10 min | **opt-in**; not scheduled unless `TROPHIES_SYNC_ENABLED=true` |
+
+- [ ] **Every row reads `success`.** A `failed` row that nobody clears is how a
+      broken job hides — `week-screenshot-winner` sat `failed` for a day after
+      it had actually been fixed, because it only runs on Sundays.
+
+Any job can be dry-run safely:
+```bash
+docker exec gop-bot sh -c "cd /app && bun run:command jobs:run <job-name> --dry-run"
+```
+
+---
+
+## 6. Things that should NOT happen
+
+- [ ] Naming an item `@everyone` does **not** ping the server
+- [ ] An error reply is **ephemeral**, never public
+- [ ] No command ever shows *"This application did not respond"*
+- [ ] Typing in an autocomplete field never leaves the box spinning forever
+
+---
+
+## If something is wrong
+
+1. `docker logs gop-bot --since 10m` on the host — errors go through the logger
+2. Check `RestartCount`; non-zero means crash-looping
+3. Deploys fail loudly now: the pipeline samples each container twice and fails
+   if it is not running or if `RestartCount` moved
+4. Rollback is a Portainer redeploy of the previous image tag
+
+Report anything you find in `docs/known-issues.md` rather than only in Discord —
+the reason this project accumulated fourteen months of breakage is that nothing
+was ever written down.


### PR DESCRIPTION
Two artifacts this project never had, both written from an audit of the live hosts rather than from memory.

## `docs/test-plan.md`

A ~15 minute manual pass over everything a member can touch: marketplace (all 8 subcommands, buttons, modal, limits, admin override), screenshots, trophies, the portal, the admin surface, and the scheduled jobs.

It exists because **the failure that started the revival was invisible** — `/marketplace sell` failed on 100% of invocations for fourteen months because nothing exercised it end to end. Automated tests now cover the layers underneath; this covers the part only a human in Discord can see.

Each section says what to expect *and* what the historical failure looked like, so a tester knows what they're guarding against — the empty `message_id`, the ranking that omitted the real #1, the positional delete that removed the wrong ad, the CDN links that died in 24 hours.

## `docs/plans/08-decommission-and-cleanup.md`

Audited 2026-08-21 against the actual hosts. Records what is **already done** so nobody redoes it (`old-discord-bot/`, the seven dead models, the dead env vars, 76 → 0 Dependabot alerts), and what remains.

**One thing it explicitly protects**: a grep for `old-discord-bot` still hits ~6 files under `discord-bot/src`. Those are *provenance comments* — `Ported from old-discord-bot/src/service/trophy/psnCrawlService.js#getPsnProfileByUrl` and similar. They are the only surviving explanation of several non-obvious behaviours (the Monday→Sunday week window, the points ladder, the `sell`/`sale` adType split). Making a grep clean is not a reason to delete them.

**TedRelayer stays dated 2026-09-02** and ordered: final *verified* dump → stop containers → wait a week → then remove volumes. Stopping is reversible; `docker volume rm` is not. The step insisting someone actually opens the dump file is there because the nightly backup silently failed for seven weeks while its container reported `Up`.

Audit findings worth knowing: TedRelayer still runs 3 containers (MariaDB up 7 weeks, Redis up 7 weeks, and a backup job still dumping a frozen database), holds 3 volumes and 2 stale images totalling ~527 MB. The GitHub Pages repo is **not archived**, last pushed 2021-11-11.

Also covers rotating the OAuth secret, the un-backed-up audit-log volume, the `deepmerge-ts` override's removal condition, and the 2 permanently unrecoverable 2022 screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)