### PR TITLE
ci: auto-merge release PRs so releases tag and deploy unattended

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,8 +1,8 @@
 name: Release Please
 
 # Maintains per-component release PRs + tags + CHANGELOGs from Conventional
-# Commits on main. Deploys are driven separately by deploy.yml on merge — this
-# only tracks versions.
+# Commits on main, and merges those release PRs itself so a release needs no
+# manual click. Deploys are driven separately by deploy.yml on merge.
 #
 # Why a PAT and not the default GITHUB_TOKEN: PRs opened with GITHUB_TOKEN do not
 # trigger downstream workflows (GitHub's recursion guard), so the release PR
@@ -13,10 +13,16 @@ name: Release Please
 on:
   push:
     branches: [main]
+  # Lets a stalled release chain be re-kicked without an empty commit.
+  workflow_dispatch: ~
 
 permissions:
   contents: write
   pull-requests: write
+
+concurrency:
+  group: release-please
+  cancel-in-progress: false
 
 jobs:
   release-please:
@@ -27,3 +33,66 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+
+      # Hand the release PR off to GitHub's auto-merge so it lands (and deploys)
+      # on its own once CI is green. Two things this deliberately does NOT do:
+      #
+      #  - It does not merge more than one release PR per run. All three
+      #    components share `.github/.release-please-manifest.json` and each
+      #    release PR rewrites its own line of it — adjacent lines, so git
+      #    cannot 3-way merge them and the second PR to land would conflict.
+      #    One per run is enough: the merge pushes main, which re-runs this
+      #    workflow, which rebases the remaining release PRs onto the new
+      #    manifest and queues the next one. Three pending releases drain in
+      #    three cycles.
+      #  - It does not force the merge. Auto-merge waits for the required `CI`
+      #    check (branch protection on main), so a red release PR just sits
+      #    there. `--auto` is only refusable when there is nothing left to wait
+      #    for, which is the one case where merging immediately is also correct.
+      - name: Queue the next release PR for auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          prs=$(gh pr list --state open --json number,headRefName,createdAt \
+            --jq '[.[] | select(.headRefName | startswith("release-please--branches--main--"))]
+                  | sort_by(.createdAt, .number) | .[].number')
+
+          if [ -z "$prs" ]; then
+            echo "No open release PRs."
+            exit 0
+          fi
+          echo "Open release PRs: $(echo $prs)"
+
+          for pr in $prs; do
+            # `mergeable` is computed lazily by GitHub and is UNKNOWN for the
+            # first moments after a branch is pushed — poll rather than read a
+            # not-yet-computed answer as "conflicted".
+            mergeable=UNKNOWN
+            for _ in 1 2 3 4 5 6; do
+              mergeable=$(gh pr view "$pr" --json mergeable --jq .mergeable)
+              [ "$mergeable" = "UNKNOWN" ] || break
+              sleep 5
+            done
+
+            if [ "$mergeable" != "MERGEABLE" ]; then
+              echo "::warning::Release PR #$pr is $mergeable — skipping it this run."
+              continue
+            fi
+
+            if gh pr merge "$pr" --squash --auto; then
+              echo "Auto-merge enabled on #$pr; it lands when CI goes green."
+            else
+              # Only reachable when the PR is already fully green, so there is
+              # nothing for auto-merge to wait on. Merge it now instead.
+              echo "Auto-merge refused on #$pr (already clean) — merging now."
+              gh pr merge "$pr" --squash
+            fi
+
+            echo "Queued #$pr. Any other release PR is picked up on the next run."
+            exit 0
+          done
+
+          echo "::warning::No release PR was in a mergeable state this run."

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -195,7 +195,7 @@ no configured linter enforces. Style is visibly inconsistent — 4-space and
 2-space indentation, semicolons and no semicolons, sometimes within one
 directory.
 
-### 6. release-please has never produced a release — 🔸 repo side fixed, PAT still outstanding
+### 6. release-please has never produced a release — ✅ fixed
 
 Configured since April 2025, running on every `main` push. Result: **zero tags,
 zero GitHub releases**, both manifest entries still `0.0.0`. Two candidate
@@ -211,16 +211,14 @@ that actually exists (`discord-bot`), `version` added to its `package.json` (the
 Commits on the PR title — which is the actual root cause, since PRs are
 squash-merged and `chore:` never triggers a release. That part is fixed.
 
-**Still open**: the `RELEASE_PLEASE_TOKEN` PAT was **not created** during the
-2026-08-19 infrastructure migration — it cannot be minted non-interactively.
-`release-please.yml` falls back to `secrets.GITHUB_TOKEN`, which lets it open
-and update release PRs, but PRs opened with the default token do not trigger
-downstream workflows (CI, and therefore the deploy that would run on merging
-the release PR). `MY_RELEASE_PLEASE_TOKEN` still exists as a secret but is not
-read by the current workflow — safe to delete once `RELEASE_PLEASE_TOKEN` is
-minted. Until then, expect a release PR to open on the next `feat:`/`fix:`
-merge, but treat its own merge as needing a manual deploy trigger
-(`workflow_dispatch`) if CI did not visibly run on it.
+**Closed 2026-08-21.** `RELEASE_PLEASE_TOKEN` was minted on 2026-08-20, and
+seven releases have been cut since (`discord-bot-v1.0.0` … `portal-web-v0.3.0`).
+The last manual step — someone having to click Merge on the release PR, which
+is why three release PRs sat open on 2026-08-21 — is gone too:
+`release-please.yml` now enables auto-merge on one open release PR per run, so
+a release lands, tags and deploys unattended. See "Releases merge themselves"
+in [`operations.md`](operations.md). `MY_RELEASE_PLEASE_TOKEN` is still an
+unread leftover secret and is safe to delete.
 
 ### 7. Dependencies are ~14 months stale
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -98,9 +98,10 @@ pull request
 
 merge to main
       ├─ ci.yml + security.yml
-      ├─ release-please.yml  release PR / tag / CHANGELOG per component
-      │                      (falls back to GITHUB_TOKEN — RELEASE_PLEASE_TOKEN
-      │                       not yet created, so the release PR itself gets no CI)
+      ├─ release-please.yml  release PR / tag / CHANGELOG per component, then
+      │                      enables auto-merge on ONE open release PR (see
+      │                      "Releases merge themselves" below) — so a release
+      │                      lands, tags, and deploys with no manual click
       └─ deploy.yml          build + push joshlopes/game-on-portugal-{bot,portal-api,portal-web}:{latest,<sha>}
                              → Portainer stack `game-on-portugal` (id 46) on HTZ1
                                 (SSH tunnel → PUT /api/stacks/46)
@@ -113,6 +114,35 @@ any failure → workflow-failed.yml → Telegram
 
 Full wiring reference — secrets, variables, Portainer stack, DNS, Caddy — is in
 [`../infrastructure/SETUP.md`](../infrastructure/SETUP.md).
+
+## Releases merge themselves
+
+Nothing about a release is manual. Merge a `feat:`/`fix:` PR and the chain runs
+to production on its own:
+
+1. `release-please.yml` opens (or updates) the release PR for each affected
+   component — `discord-bot`, `portal-api`, `portal-web`.
+2. The same run enables GitHub auto-merge on **one** open release PR. It lands
+   as soon as the required `CI` check is green.
+3. That merge pushes `main`, which re-runs `release-please.yml` — cutting the
+   tag + GitHub Release for what just merged, and queueing the next release PR
+   — and runs `deploy.yml`, which rebuilds the images and rolls the Portainer
+   stack.
+
+Two consequences worth knowing:
+
+- **One release per cycle, by design.** All three components share
+  `.github/.release-please-manifest.json` and each release PR rewrites its own
+  line of it. Those lines are adjacent, so git cannot 3-way merge two of them —
+  the second PR to land would conflict. Three pending releases therefore drain
+  over three cycles, a few minutes apart, each one rebased by release-please
+  onto the manifest the previous one wrote.
+- **A red release PR just sits there.** Auto-merge waits for `CI`; it is not a
+  bypass. Fix the PR (or main) and it lands by itself.
+
+If the chain ever stalls — say a release PR was left conflicted — re-kick it
+with `gh workflow run release-please.yml` rather than merging by hand, so the
+next PR in line gets queued too.
 
 ## Portal (M8)
 

--- a/infrastructure/SETUP.md
+++ b/infrastructure/SETUP.md
@@ -27,7 +27,7 @@ external `proxy` network.
 | `ci.yml` | PR, push to main | Bot typecheck + integration tests. Single aggregate `CI` status |
 | `docker-build.yml` | PR | Validates the production image builds (no push) |
 | `deploy.yml` | push to main, manual | Builds + pushes `joshlopes/game-on-portugal-bot`, rolls the Portainer stack |
-| `release-please.yml` | push to main | Maintains release PRs, tags, CHANGELOGs |
+| `release-please.yml` | push to main, manual | Maintains release PRs, tags, CHANGELOGs; auto-merges one release PR per run |
 | `pr-title.yml` | PR | Enforces Conventional Commits on the PR title |
 | `labeler.yml` | PR | Path-based labels |
 | `security.yml` | PR, push, weekly | CodeQL + Trivy + Gitleaks |
@@ -42,7 +42,12 @@ evidence the GameOnPortugal org has access to them).
 
 - Default branch `main`; **allow squash merging only**. PR titles are linted as
   Conventional Commits and become the squash commit that release-please reads.
-- Branch protection on `main`: require the `CI` status check.
+- Branch protection on `main`: require the `CI` status check. Applied
+  2026-08-21, with `enforce_admins: false` so an admin is never locked out.
+- **Allow auto-merge: on** (applied 2026-08-21). Both of these exist for
+  `release-please.yml`'s auto-merge step: GitHub only lets auto-merge be
+  enabled on a PR that is *not* already mergeable, so without a required check
+  there is nothing for it to wait on and the API refuses.
 - The repo's history is ~30 consecutive `chore:` commits, which is exactly why
   release-please has never cut a release. `pr-title.yml` prevents a recurrence.
 
@@ -71,11 +76,11 @@ rather than deleted, and is safe to remove whenever `RELEASE_PLEASE_TOKEN` is
 finally created.
 
 `RELEASE_PLEASE_TOKEN` (a fine-grained PAT, `contents:write` +
-`pull-requests:write`) is **still outstanding** — it cannot be minted
-non-interactively, so `release-please.yml` currently falls back to
-`GITHUB_TOKEN`. That works, but PRs opened with the default token do not
-trigger CI or the downstream deploy on the release PR itself. Mint it and set
-it when someone has interactive GitHub access.
+`pull-requests:write`) was minted on **2026-08-20** and is live. It matters
+twice over: PRs opened with the default `GITHUB_TOKEN` get no CI, and — since
+2026-08-21 — the same token is what merges the release PR, so the merge commit
+is attributed to a real user and does trigger `deploy.yml`. Merging with
+`GITHUB_TOKEN` would land the release on main and deploy nothing.
 
 Also still outstanding: copying the real bot token into 1Password (it exists
 only in the Portainer stack env and in `~/game-on-portugal/.env` on the


### PR DESCRIPTION
## What was wrong

Release PRs were being *created* and going green, but nothing merged them — three were sitting open (#67 discord-bot 1.3.0, #68 portal-api 0.4.0, #69 portal-web 0.4.0), all `MERGEABLE`, all CI-green, since 19:33. Since the tag, the GitHub Release and `deploy.yml` all hang off the *merge* of a release PR, a release only ever happened when someone clicked Merge.

The rest of the chain is fine: `RELEASE_PLEASE_TOKEN` exists (minted 2026-08-20), CI runs on the release PRs, and the last two release merges (#60, #61) each did deploy successfully. Only the click was missing.

## What this does

`release-please.yml` now hands **one** open release PR per run to GitHub auto-merge, with `RELEASE_PLEASE_TOKEN` — a `GITHUB_TOKEN` merge would land on main and trigger no deploy.

One per run is deliberate: all three components rewrite their own line of the shared `.github/.release-please-manifest.json`, and those lines are adjacent, so git cannot 3-way merge two of them (verified locally — merging #67 then #68 conflicts). The merge pushes main, which re-runs the workflow, which rebases the remaining release PRs and queues the next. Three pending releases drain over three cycles.

It never forces a merge: auto-merge waits for the required `CI` check, so a red release PR just sits there. The direct-merge fallback is only reachable when the PR is already fully green and there is nothing left to wait for.

Also adds `workflow_dispatch` (re-kick a stalled chain without an empty commit) and a `release-please` concurrency group.

## Repo settings applied

GitHub only permits auto-merge on a PR that is *not* already mergeable, so both of these were needed:

- **Allow auto-merge**: on.
- **Branch protection on `main`**: require the `CI` status check, `enforce_admins: false` so an admin is never locked out. This was already written down as intended in `infrastructure/SETUP.md §1` but had never actually been applied.

## Docs

`docs/operations.md` gains a "Releases merge themselves" section; the pipeline diagram and `infrastructure/SETUP.md` had stale claims that `RELEASE_PLEASE_TOKEN` did not exist; known-issue #6 is closed out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)