### PR TITLE
fix(ci): rebuild stale release PRs instead of stranding them

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,6 +28,45 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Drop stale release branches *before* the action runs, so it rebuilds
+      # them from the current main in this same run.
+      #
+      # Why they go stale: every component's release PR rewrites its own line
+      # of the shared `.github/.release-please-manifest.json`, and those lines
+      # are adjacent, so once one release lands the siblings no longer merge.
+      # release-please does not rebase them — it only rewrites a release branch
+      # when that component's *release content* changes, which a sibling's
+      # release does not do. Observed 2026-08-21: portal-api's release PR was
+      # left CONFLICTING and untouched while discord-bot and portal-web
+      # released past it, and it would have sat there forever.
+      - name: Drop stale (conflicting) release PRs
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          prs=$(gh pr list --state open --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("release-please--branches--main--"))] | .[].number')
+
+          for pr in ${prs:-}; do
+            # `mergeable` is computed lazily by GitHub and is UNKNOWN for the
+            # first moments after a branch is pushed — poll rather than read a
+            # not-yet-computed answer as "conflicted" and close a good PR.
+            mergeable=UNKNOWN
+            for _ in 1 2 3 4 5 6; do
+              mergeable=$(gh pr view "$pr" --json mergeable --jq .mergeable)
+              [ "$mergeable" = "UNKNOWN" ] || break
+              sleep 5
+            done
+
+            if [ "$mergeable" = "CONFLICTING" ]; then
+              echo "Release PR #$pr conflicts with main — closing it; release-please rebuilds it below."
+              gh pr close "$pr" --delete-branch \
+                --comment "Superseded: this release branch no longer merges into main (the release manifest moved under it). Closing so release-please rebuilds it from the current main — see .github/workflows/release-please.yml."
+            fi
+          done
+
       - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
@@ -37,14 +76,12 @@ jobs:
       # Hand the release PR off to GitHub's auto-merge so it lands (and deploys)
       # on its own once CI is green. Two things this deliberately does NOT do:
       #
-      #  - It does not merge more than one release PR per run. All three
-      #    components share `.github/.release-please-manifest.json` and each
-      #    release PR rewrites its own line of it — adjacent lines, so git
-      #    cannot 3-way merge them and the second PR to land would conflict.
-      #    One per run is enough: the merge pushes main, which re-runs this
-      #    workflow, which rebases the remaining release PRs onto the new
-      #    manifest and queues the next one. Three pending releases drain in
-      #    three cycles.
+      #  - It does not merge more than one release PR per run. The release PRs
+      #    conflict with each other on the shared manifest (see the first step),
+      #    so they have to land one at a time. One per run is enough: the merge
+      #    pushes main, which re-runs this workflow, which drops the now-stale
+      #    siblings, has release-please rebuild them, and queues the next.
+      #    Three pending releases drain in three cycles.
       #  - It does not force the merge. Auto-merge waits for the required `CI`
       #    check (branch protection on main), so a red release PR just sits
       #    there. `--auto` is only refusable when there is nothing left to wait
@@ -78,6 +115,9 @@ jobs:
             done
 
             if [ "$mergeable" != "MERGEABLE" ]; then
+              # Conflicts are already handled by the first step, so reaching
+              # here means something else (a draft, a blocked base) — say so
+              # rather than silently doing nothing.
               echo "::warning::Release PR #$pr is $mergeable — skipping it this run."
               continue
             fi

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -135,14 +135,27 @@ Two consequences worth knowing:
   `.github/.release-please-manifest.json` and each release PR rewrites its own
   line of it. Those lines are adjacent, so git cannot 3-way merge two of them —
   the second PR to land would conflict. Three pending releases therefore drain
-  over three cycles, a few minutes apart, each one rebased by release-please
-  onto the manifest the previous one wrote.
+  over three cycles, a few minutes apart.
+- **Stale release PRs are closed and rebuilt, not rebased.** This is the part
+  that is easy to get wrong: release-please does *not* refresh a release branch
+  just because main moved. It rewrites one only when that component's own
+  release content changes, so a sibling's release leaves the others behind as
+  conflicting branches. (Observed 2026-08-21: portal-api's release PR #68 was
+  stranded while discord-bot and portal-web released past it.) So the workflow's
+  first step closes any conflicting release PR and deletes its branch, and the
+  release-please step immediately rebuilds it from the current main. Expect
+  release PR *numbers* to change between cycles — that is this, working.
 - **A red release PR just sits there.** Auto-merge waits for `CI`; it is not a
   bypass. Fix the PR (or main) and it lands by itself.
+- **Intermediate deploys can be cancelled.** Three release merges in quick
+  succession queue three `deploy.yml` runs, and GitHub keeps only one run
+  pending per concurrency group — a third arrival cancels the queued second.
+  Harmless: every deploy builds all three images from whatever main is at, so
+  the last one to run carries the whole set. A cancelled deploy in that burst
+  is not something to re-run.
 
-If the chain ever stalls — say a release PR was left conflicted — re-kick it
-with `gh workflow run release-please.yml` rather than merging by hand, so the
-next PR in line gets queued too.
+If the chain ever stalls, re-kick it with `gh workflow run release-please.yml`
+rather than merging by hand, so the next PR in line gets queued too.
 
 ## Portal (M8)
 


### PR DESCRIPTION
Follow-up to #70, which got two of the three pending releases out (discord-bot v1.3.0, portal-web v0.4.0) and then stalled: portal-api's release PR #68 has been sitting `CONFLICTING` and untouched since 19:33.

## Why it stalled

#70 assumed release-please rebases its open release PRs when main moves. It does not — it rewrites a release branch only when *that component's own release content* changes. A sibling release rewriting the shared `.github/.release-please-manifest.json` is not such a change, so the sibling branches are left behind, conflicting on the single file all three touch, with nothing in the system that would ever repair them.

## Fix

A new **first** step closes any conflicting release PR and deletes its branch; the release-please action then rebuilds it from the current main in the same run, and the existing queue step picks it up.

Ordering it *before* the action is what makes this terminate — no self-dispatch, no retry loop, and each cycle is strictly forward progress. Dry-run against the live repo correctly singles out #68 and leaves everything else alone. Mergeability is polled before judging, so a not-yet-computed `UNKNOWN` can never close a good PR.

Consequence worth knowing: release PR *numbers* change between cycles. `docs/operations.md` says so explicitly, so it doesn't read as churn.

## Also documented

A burst of release merges can leave an intermediate `deploy.yml` run cancelled — GitHub keeps only one run pending per concurrency group, so a third arrival cancels the queued second. That happened to the discord-bot 1.3.0 deploy tonight. It's harmless (every deploy builds all three images from current main, so the last run carries the whole set) but it looks alarming without the explanation.

Merging this should unstick portal-api 0.4.0 on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)