### PR TITLE
fix(bot): make the trophy leaderboard update again (M7.3)

### DIFF
--- a/discord-bot/.prettierignore
+++ b/discord-bot/.prettierignore
@@ -12,3 +12,8 @@ bun.lock
 # release-please owns this file end to end and rewrites it on every
 # release — reformatting it here just means fighting release-please forever.
 CHANGELOG.md
+
+# Captured verbatim from the live PSNProfiles site, broken markup and all —
+# that's the point (see PsnProfilesTrophySource.test.ts). Reformatting would
+# defeat the fixture, and some of it isn't valid HTML for Prettier to parse.
+tests/Integration/Infrastructure/Trophy/fixtures/*.html

--- a/discord-bot/src/Infrastructure/DependencyInjection/inversify.config.ts
+++ b/discord-bot/src/Infrastructure/DependencyInjection/inversify.config.ts
@@ -13,6 +13,7 @@ import EventDispatcher from '../../Application/Event/EventDispatcher/EventDispat
 import type { HttpClient } from '../../Domain/Http/HttpClient.ts';
 import RetryHttpClient from '../Http/RetryHttpClient.ts';
 import FetchHttpClient from '../Http/FetchHttpClient.ts';
+import BrowserFetchHttpClient from '../Http/BrowserFetchHttpClient.ts';
 import type { TrophySource } from '../../Domain/Trophy/TrophySource.ts';
 import { PsnProfilesTrophySource } from '../Trophy/PsnProfilesTrophySource.ts';
 import { PingHandler } from '../../Application/Query/Ping/PingHandler.ts';
@@ -229,7 +230,41 @@ myContainer.bind<EventDispatcher>(EventDispatcher).toSelf();
 myContainer.bind(FetchHttpClient).toSelf();
 myContainer.bind(RetryHttpClient).toSelf();
 myContainer.bind<HttpClient>(TYPES.HttpClient).to(RetryHttpClient);
-myContainer.bind<TrophySource>(TYPES.TrophySource).to(PsnProfilesTrophySource);
+myContainer.bind(BrowserFetchHttpClient).toSelf();
+
+// PSNProfiles is behind a Cloudflare challenge that plain `fetch` cannot
+// clear from anywhere, and that a headless browser cannot clear from a
+// datacenter IP either — see BrowserFetchHttpClient for the measurements.
+// When a psn-fetch sidecar is configured, the trophy source (and only the
+// trophy source) goes through it; everything else keeps using
+// RetryHttpClient. Unconfigured, this falls back to the direct client so
+// tests and local development are unchanged — the trophy source is
+// constructed with a plain HttpClient either way and knows nothing about
+// which one it got.
+const psnFetchConfigured =
+    (process.env.PSN_FETCH_URL ?? '') !== '' && (process.env.PSN_FETCH_TOKEN ?? '') !== '';
+
+myContainer
+    .bind<TrophySource>(TYPES.TrophySource)
+    .toDynamicValue(
+        (context) =>
+            new PsnProfilesTrophySource(
+                psnFetchConfigured
+                    ? context.get(BrowserFetchHttpClient)
+                    : context.get<HttpClient>(TYPES.HttpClient),
+            ),
+    );
+
+if (!psnFetchConfigured) {
+    myContainer
+        .get<Logger>(TYPES.Logger)
+        .warn(
+            'PSN_FETCH_URL/PSN_FETCH_TOKEN are not both set, so trophies:sync will fetch ' +
+                'PSNProfiles directly. That is expected in tests and local development, but in ' +
+                'production it will fail on every request: PSNProfiles serves a Cloudflare ' +
+                'challenge that only the psn-fetch sidecar can clear.',
+        );
+}
 
 // Bot
 // M1.3: DISCORD_TOKEN / DISCORD_CLIENT_ID are required for the live bot
@@ -400,26 +435,29 @@ myContainer.get(JobRunner).register(myContainer.get(RelinkScreenshotsJob));
 myContainer.get(JobRunner).register(myContainer.get(AdsLifecycleJob));
 myContainer.get(JobRunner).register(myContainer.get(AdsReconcileJob));
 
-// trophies:sync (M7.3) is always bound above and always runnable by hand
-// (`bun run:command jobs:run trophies:sync --dry-run`), but registering it
-// with the scheduler is opt-in. Merging to `main` *is* the deploy pipeline
-// here, so an unconditional registration would start writing trophy rows
-// and setting isBanned/isExcluded on ~118 real community members every 10
-// minutes the moment this lands, before anyone had watched a single run —
-// and since isExcluded removes a profile from future consideration with no
-// automatic un-flagging, a bad first run is effectively permanent. See
-// TrophiesSyncJob's doc comment ("Scheduling is opt-in") for the full
+// trophies:sync (M7.3) is always *registered* — so it is listed by
+// `jobs:run list` and runnable by hand at any time — but whether the ticker
+// may start it on its own is opt-in. Merging to `main` is the deploy
+// pipeline here, so an unconditionally scheduled job would start writing
+// trophy rows and setting isBanned/isExcluded on ~118 real community members
+// every 10 minutes the moment this lands, before anyone had watched a single
+// run — and since isExcluded removes a profile from future consideration
+// with no automatic un-flagging, a bad first run is effectively permanent.
+// See TrophiesSyncJob's doc comment ("Scheduling is opt-in") for the full
 // reasoning and the enable runbook. Mirrors the DISCORD_TOKEN-unset ->
 // InMemoryClient pattern above: a silently-disabled feature is its own
 // failure mode (that one is why M1.3 exists), so this logs clearly rather
-// than just quietly not registering.
-if (process.env.TROPHIES_SYNC_ENABLED === 'true') {
-    myContainer.get(JobRunner).register(myContainer.get(TrophiesSyncJob));
-} else {
+// than just quietly not scheduling.
+const trophiesSyncScheduled = process.env.TROPHIES_SYNC_ENABLED === 'true';
+myContainer
+    .get(JobRunner)
+    .register(myContainer.get(TrophiesSyncJob), { scheduled: trophiesSyncScheduled });
+
+if (!trophiesSyncScheduled) {
     myContainer
         .get<Logger>(TYPES.Logger)
         .warn(
-            'trophies:sync is bound but NOT scheduled (TROPHIES_SYNC_ENABLED is not "true"). ' +
+            'trophies:sync is registered but NOT scheduled (TROPHIES_SYNC_ENABLED is not "true"). ' +
                 'Dry-run it first — bun run:command jobs:run trophies:sync --dry-run — read the ' +
                 'report (especially any newly-flagged profiles), then set ' +
                 'TROPHIES_SYNC_ENABLED=true to schedule it every 10 minutes.',

--- a/discord-bot/src/Infrastructure/Http/BrowserFetchHttpClient.ts
+++ b/discord-bot/src/Infrastructure/Http/BrowserFetchHttpClient.ts
@@ -1,0 +1,98 @@
+import { inject, injectable } from 'inversify';
+import { type HttpClient } from '../../Domain/Http/HttpClient.ts';
+import { TYPES } from '../DependencyInjection/types.ts';
+import type Logger from '../../Application/Logger/Logger.ts';
+
+/**
+ * Fetches pages through `psn-fetch`, a browser-backed sidecar, instead of
+ * fetching them directly.
+ *
+ * ## Why this exists
+ *
+ * PSNProfiles sits behind a Cloudflare managed challenge. It is not a block —
+ * it is a JavaScript interstitial — so getting past it needs something that
+ * actually runs the challenge. Measured against the live site (2026-08-21,
+ * six pages per cell, three page types):
+ *
+ * | Client                                  | Hetzner (HTZ1) | Home IP |
+ * | --------------------------------------- | -------------- | ------- |
+ * | `fetch` / curl, any User-Agent          | 0/6            | 0/6     |
+ * | curl-impersonate (real Chrome JA3)      | 0/2            | —       |
+ * | FlareSolverr                            | 0/3 (timeouts) | —       |
+ * | Playwright, headless                    | 0/6            | —       |
+ * | Playwright, headed under xvfb           | 0/6            | 1/6     |
+ * | patchright, headed under xvfb           | 0/6            | **6/6** |
+ *
+ * Two independent conditions have to hold at once, which is why the simpler
+ * fixes all failed:
+ *
+ * 1. **A patched browser.** Stock Playwright leaks its automation via CDP
+ *    (`Runtime.enable`); it clears the first navigation of a fresh profile
+ *    and is challenged on every one after. patchright closes those leaks.
+ *    Note the fingerprint theories that did *not* hold: TLS/JA3 alone did
+ *    nothing, and the passing runs were software-rendered (SwiftShader),
+ *    so it is not a WebGL/GPU check.
+ * 2. **A non-datacenter IP.** Hetzner's ASN fails 0/12 regardless of client.
+ *    This is why the sidecar has to live off HTZ1 rather than beside the bot.
+ *
+ * ## Consequences for the caller
+ *
+ * `TYPES.HttpClient` still resolves to `RetryHttpClient` for everything else;
+ * only `PsnProfilesTrophySource` is given this one. Requests are serialised
+ * and throttled inside the sidecar, next to the browser that owns the
+ * Cloudflare clearance cookie, rather than here — a second bot process would
+ * otherwise silently double the request rate against a site with no API.
+ */
+@injectable()
+export default class BrowserFetchHttpClient implements HttpClient {
+    private readonly baseUrl: string;
+    private readonly token: string;
+    private readonly timeoutMs: number;
+
+    constructor(@inject(TYPES.Logger) private readonly logger: Logger) {
+        this.baseUrl = (process.env.PSN_FETCH_URL ?? '').replace(/\/+$/, '');
+        this.token = process.env.PSN_FETCH_TOKEN ?? '';
+        this.timeoutMs = Number(process.env.PSN_FETCH_TIMEOUT_MS ?? 120_000);
+    }
+
+    async get(url: string, _options?: any): Promise<any> {
+        const endpoint = `${this.baseUrl}/fetch?url=${encodeURIComponent(url)}`;
+
+        // The sidecar drives a real browser through a Cloudflare challenge,
+        // so a single request can legitimately take tens of seconds. Without
+        // an explicit signal this would sit on the runtime's default timeout
+        // and stall the whole sync walk.
+        const response = await fetch(endpoint, {
+            headers: { Authorization: `Bearer ${this.token}` },
+            signal: AbortSignal.timeout(this.timeoutMs),
+        });
+
+        if (!response.ok) {
+            const detail = await response.text().catch(() => '');
+            // Thrown, not returned: RetryHttpClient's backoff keys off a
+            // throw, and a challenge page that slipped through would
+            // otherwise be handed to the parser as if it were a profile.
+            throw new Error(
+                `psn-fetch request for ${url} failed with status code ${response.status}` +
+                    (detail ? `: ${detail.slice(0, 200)}` : ''),
+            );
+        }
+
+        return response.text();
+    }
+
+    // The trophy source only ever reads. Leaving these as explicit throws
+    // keeps the HttpClient contract honest instead of quietly no-oping a
+    // write someone adds later.
+    async post(): Promise<never> {
+        throw new Error('BrowserFetchHttpClient is read-only: post() is not supported');
+    }
+
+    async put(): Promise<never> {
+        throw new Error('BrowserFetchHttpClient is read-only: put() is not supported');
+    }
+
+    async delete(): Promise<never> {
+        throw new Error('BrowserFetchHttpClient is read-only: delete() is not supported');
+    }
+}

--- a/discord-bot/src/Infrastructure/Job/JobRunner.ts
+++ b/discord-bot/src/Infrastructure/Job/JobRunner.ts
@@ -10,6 +10,17 @@ import type Logger from '../../Application/Logger/Logger.ts';
 interface RegisteredJob {
     job: Job;
     cron: Cron;
+    /**
+     * Whether the scheduler may start this job on a tick. A job registered
+     * with `scheduled: false` is still fully addressable by hand
+     * (`listJobs`, `runNow`) — see `register`.
+     */
+    scheduled: boolean;
+}
+
+export interface RegisterOptions {
+    /** Defaults to true. `false` registers the job for manual runs only. */
+    scheduled?: boolean;
 }
 
 const DEFAULT_TICK_INTERVAL_MS = 60_000;
@@ -63,17 +74,35 @@ export class JobRunner {
     }
 
     /**
-     * Adds a job to the schedule. Call this during wiring (inversify.config.ts)
+     * Adds a job to the runner. Call this during wiring (inversify.config.ts)
      * before `start()` — a job registered after `start()` will simply not be
      * picked up until the process restarts, since jobs are also warmed from
      * persisted state once, at start.
+     *
+     * `scheduled: false` registers a job the ticker will never start on its
+     * own, while leaving it runnable by hand. That distinction exists because
+     * conflating the two made the documented enable-a-job runbook impossible:
+     * a job gated behind an env flag was not in this map at all, so
+     * `jobs:run <name> --dry-run` — the very command the operator is told to
+     * preview with before flipping the flag — failed with `Unknown job`. The
+     * only way to dry-run was to enable the schedule first, which is exactly
+     * what the gate exists to prevent.
      */
-    register(job: Job): void {
+    register(job: Job, options: RegisterOptions = {}): void {
         if (this.jobs.has(job.name)) {
             throw new Error(`Job "${job.name}" is already registered`);
         }
 
-        this.jobs.set(job.name, { job, cron: new Cron(job.schedule) });
+        this.jobs.set(job.name, {
+            job,
+            cron: new Cron(job.schedule),
+            scheduled: options.scheduled ?? true,
+        });
+    }
+
+    /** Names the ticker may start on its own — `listJobs()` minus the manual-only ones. */
+    listScheduledJobs(): string[] {
+        return [...this.jobs.values()].filter((r) => r.scheduled).map((r) => r.job.name);
     }
 
     listJobs(): string[] {
@@ -159,6 +188,9 @@ export class JobRunner {
 
         for (const registered of this.jobs.values()) {
             if (this.stopped) break;
+            // Manual-only: registered so it can be run by hand, but never
+            // started by the ticker. See `register`.
+            if (!registered.scheduled) continue;
             if (this.running.has(registered.job.name)) continue;
             if (!this.isDue(registered, now)) continue;
 

--- a/discord-bot/src/Infrastructure/Trophy/PsnProfilesTrophySource.ts
+++ b/discord-bot/src/Infrastructure/Trophy/PsnProfilesTrophySource.ts
@@ -106,17 +106,34 @@ export class PsnProfilesTrophySource implements TrophySource {
 
     // -- Parsing ----------------------------------------------------------
 
-    private parseProfileRank(html: string): TrophyProfileRank {
-        const worldRankText = this.findTagByClass(html, 'span', 'rank')?.inner.trim();
-        const countryRankText = this.findTagByClass(html, 'span', 'country-rank')?.inner.trim();
+    /**
+     * The two stat boxes at the top of a profile. Real markup nests the
+     * number inside an `<a>` *and* a label span:
+     *
+     *     <span class="rank stat grow red">
+     *       <a href="/leaderboard/..."> 26,475<span>World Rank</span> </a>
+     *     </span>
+     *
+     * so the inner content has to be read with a nesting-aware scan and then
+     * flattened to text — a non-greedy `</span>` match stops at the *label's*
+     * closing tag and yields `<a href=...` , which parses as NaN. That is not
+     * a cosmetic bug: `TrophiesSyncJob` reads "both ranks null" as "this
+     * profile is banned/private" and auto-excludes the member, so a parser
+     * that always returns null would auto-exclude everyone it looked at.
+     */
+    private parseProfileRank(rawHtml: string): TrophyProfileRank {
+        const html = this.stripComments(rawHtml);
 
         return {
-            worldRank: this.parseCommaSeparatedInt(worldRankText),
-            countryRank: this.parseCommaSeparatedInt(countryRankText),
+            worldRank: this.parseCommaSeparatedInt(this.findTextByClass(html, 'span', 'rank')),
+            countryRank: this.parseCommaSeparatedInt(
+                this.findTextByClass(html, 'span', 'country-rank'),
+            ),
         };
     }
 
-    private parseProfileTrophies(html: string): string[] {
+    private parseProfileTrophies(rawHtml: string): string[] {
+        const html = this.stripComments(rawHtml);
         const urls: string[] = [];
 
         for (const row of this.findRowsByClass(html, 'platinum')) {
@@ -129,38 +146,40 @@ export class PsnProfilesTrophySource implements TrophySource {
         return urls;
     }
 
-    private parsePlatinumTrophyData(html: string, trophyUrl: string): PlatinumTrophyData {
-        // Scope to the <tbody> so a <thead> row never gets mistaken for the
-        // (possibly blank) first data row below.
-        const tbodyHtml = this.extractFirstTagInner(html, 'tbody') ?? html;
-        const rows = this.extractRows(tbodyHtml);
-        if (rows.length === 0) {
+    /**
+     * A trophy page's platinum row, located by what it *is* rather than by
+     * where it sits. The old "first row of the first `<tbody>`" rule was
+     * written against a hand-made fixture; a real page has 13 `<tbody>`
+     * elements, and the first two are the profile summary and the
+     * base-game/DLC breakdown — neither of which carries a completion date.
+     *
+     * The platinum row is the one holding both the platinum icon and a
+     * completion date, which is stable regardless of how many summary
+     * tables PSNProfiles adds above the trophy list.
+     */
+    private parsePlatinumTrophyData(rawHtml: string, trophyUrl: string): PlatinumTrophyData {
+        const row = this.findPlatinumRow(this.stripComments(rawHtml));
+        if (row === null) {
             throw new Error("Couldn't find trophy table body!");
         }
 
-        // HACK, ported verbatim from the old bot: some trophy pages have a
-        // blank row in the first position. Jump to the second one if so.
-        let row = rows[0];
-        if (row !== undefined && row.inner.trim() === '') {
-            row = rows[1] as HtmlTag;
-        }
-
-        if (row === undefined) {
-            throw new Error("Couldn't find trophy table body!");
-        }
-
-        const rowClass = this.extractAttr(row.attrs, 'class') ?? '';
-        if (!this.hasClassToken(rowClass, 'completed')) {
+        if (!this.hasClassToken(this.extractAttr(row.attrs, 'class') ?? '', 'completed')) {
             throw new TrophyNotEarnedYet(trophyUrl);
         }
 
-        const percentageText = this.findTagByClass(row.inner, 'span', 'typo-top')?.inner.trim();
+        const percentageText = this.findRarityPercentage(row.inner);
         if (!percentageText) {
             throw new Error("Couldn't find trophy percentage!");
         }
         const percentage = parseFloat(percentageText);
+        if (isNaN(percentage)) {
+            throw new Error(`Trophy percentage "${percentageText}" is invalid!`);
+        }
 
-        const dateText = this.findTagByClass(row.inner, 'span', 'typo-top-date')?.inner.trim();
+        // Flattened to text first: the real markup is
+        // `<nobr>2<sup>nd</sup> Sep 2021</nobr>`, and dayjs cannot parse that
+        // with the tags still in it.
+        const dateText = this.findTextByClass(row.inner, 'span', 'typo-top-date');
         if (!dateText) {
             throw new Error("Couldn't find completion date!");
         }
@@ -171,6 +190,70 @@ export class PsnProfilesTrophySource implements TrophySource {
         }
 
         return { percentage, completionDate: completionDate.toDate() };
+    }
+
+    /**
+     * The platinum trophy's `<tr>`.
+     *
+     * Identified by `title="Platinum"`, which on a real page appears exactly
+     * once — unlike `platinum-icon.png`, which also appears in the profile
+     * summary and base-game/DLC tables above. Deliberately *not* keyed on
+     * having a completion date: an unearned platinum has no date, and must
+     * still be found so the caller can raise `TrophyNotEarnedYet` (which the
+     * sync job skips) rather than a generic parse error (which it counts as
+     * a failure).
+     */
+    private findPlatinumRow(html: string): HtmlTag | null {
+        return (
+            this.findRowWhere(html, (inner) => /title="Platinum"/.test(inner)) ??
+            // Simpler markup with no per-trophy icon: fall back to the first
+            // row carrying rarity/date cells at all.
+            this.findRowWhere(html, (inner) => /typo-top(-date)?"/.test(inner))
+        );
+    }
+
+    private findRowWhere(html: string, predicate: (inner: string) => boolean): HtmlTag | null {
+        const openTag = /<tr\b([^>]*)>/g;
+        let match: RegExpExecArray | null;
+
+        while ((match = openTag.exec(html)) !== null) {
+            const inner = this.balancedInner(html, 'tr', match.index);
+            if (predicate(inner)) {
+                return { attrs: match[1] ?? '', inner };
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * PSNProfiles renders *two* rarity figures per row: its own site rarity
+     * (shown by default, in the `hover-hide` cell) and Sony's global figure
+     * (revealed on hover, in `hover-show`). The TP ladder in
+     * `calculateTrophyPoints` was calibrated against the site rarity — the
+     * one the old jQuery scraper picked up because it was the only one
+     * rendered at the time — so this deliberately reads `hover-hide` rather
+     * than simply taking the first `typo-top` in the row, which is now the
+     * hover value and would misprice every trophy.
+     *
+     * Verified against six trophies whose stored TP predates this change:
+     * the four whose rarity has been stable since (50/100/250/500 TP) all
+     * reproduce exactly. The two that do not are both 2021 releases whose
+     * platinum has genuinely become more common since it was recorded —
+     * rarity drift in the source data, not a parse error.
+     */
+    private findRarityPercentage(rowInner: string): string | null {
+        const hoverHideCell = rowInner.search(/<td[^>]*\bclass="[^"]*\bhover-hide\b[^"]*"/);
+        if (hoverHideCell >= 0) {
+            const cell = this.balancedInner(rowInner, 'td', hoverHideCell);
+            const text = this.findTextByClass(cell, 'span', 'typo-top');
+            if (text) {
+                return text;
+            }
+        }
+
+        // Older/simpler markup renders a single rarity figure per row.
+        return this.findTextByClass(rowInner, 'span', 'typo-top');
     }
 
     // -- Tiny regex HTML helpers ------------------------------------------
@@ -192,6 +275,89 @@ export class PsnProfilesTrophySource implements TrophySource {
                 this.hasClassToken(this.extractAttr(match.attrs, 'class') ?? '', classToken),
             ) ?? null
         );
+    }
+
+    /**
+     * Inner content of the tag opening at `openIndex`, honouring nesting of
+     * the same tag name. The non-greedy `matchTags` below cannot do this —
+     * it stops at the first closing tag, which is wrong for every block on a
+     * real PSNProfiles page that wraps a label span inside a stat span, or a
+     * `<td>` inside a `<tr>` inside a `<table>`.
+     */
+    private balancedInner(html: string, tag: string, openIndex: number): string {
+        const contentStart = html.indexOf('>', openIndex) + 1;
+        const opening = new RegExp(`<${tag}\\b`, 'g');
+        const closing = new RegExp(`</${tag}>`, 'g');
+        let depth = 1;
+        let cursor = contentStart;
+
+        while (depth > 0) {
+            opening.lastIndex = cursor;
+            closing.lastIndex = cursor;
+            const nextOpen = opening.exec(html);
+            const nextClose = closing.exec(html);
+
+            // Unbalanced markup: treat the rest of the document as content
+            // rather than throwing — the callers all pattern-match on what
+            // they find, so a too-long slice fails their checks safely.
+            if (nextClose === null) {
+                return html.slice(contentStart);
+            }
+
+            if (nextOpen !== null && nextOpen.index < nextClose.index) {
+                depth++;
+                cursor = nextOpen.index + 1;
+                continue;
+            }
+
+            depth--;
+            if (depth === 0) {
+                return html.slice(contentStart, nextClose.index);
+            }
+            cursor = nextClose.index + 1;
+        }
+
+        return html.slice(contentStart);
+    }
+
+    /**
+     * Flattened text of the first `<tag>` whose class list includes
+     * `classToken` — tags stripped, entities and whitespace normalised, so
+     * `<nobr>2<sup>nd</sup> Sep 2021</nobr>` reads as `2nd Sep 2021`.
+     */
+    private findTextByClass(html: string, tag: string, classToken: string): string | null {
+        const opening = new RegExp(`<${tag}\\b([^>]*)>`, 'g');
+        let match: RegExpExecArray | null;
+
+        while ((match = opening.exec(html)) !== null) {
+            if (this.hasClassToken(this.extractAttr(match[1] ?? '', 'class') ?? '', classToken)) {
+                return this.textOf(this.balancedInner(html, tag, match.index));
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Drops `<!-- ... -->` before anything is scanned. Commented-out markup
+     * is still markup to a regex, so a stale block left in the page source
+     * would otherwise be indistinguishable from the live one — and would win,
+     * since these helpers all take the *first* match.
+     */
+    private stripComments(html: string): string {
+        return html.replace(/<!--[\s\S]*?-->/g, '');
+    }
+
+    /** Markup → plain text: drop tags, decode the few entities PSNProfiles emits, collapse whitespace. */
+    private textOf(html: string): string {
+        return html
+            .replace(/<[^>]*>/g, '')
+            .replace(/&nbsp;/g, ' ')
+            .replace(/&amp;/g, '&')
+            .replace(/&#39;/g, "'")
+            .replace(/&quot;/g, '"')
+            .replace(/\s+/g, ' ')
+            .trim();
     }
 
     /** Inner content of the first `<tag ...>...</tag>` (no nested same-name tags), or null if absent. */
@@ -219,11 +385,24 @@ export class PsnProfilesTrophySource implements TrophySource {
         return classAttr.split(/\s+/).includes(token);
     }
 
-    private parseCommaSeparatedInt(text: string | undefined): number | null {
+    /**
+     * Leading integer of a flattened stat, e.g. `26,475 World Rank` -> 26475.
+     * Anchored to the start and matched explicitly rather than relying on
+     * `parseInt` stopping at the first non-digit, so a stat box that ever
+     * renders its label *before* its number fails loudly (null) instead of
+     * silently returning a number parsed out of the wrong place.
+     */
+    private parseCommaSeparatedInt(text: string | null | undefined): number | null {
         if (!text) {
             return null;
         }
-        const value = parseInt(text.replace(/,/g, ''), 10);
+
+        const digits = text.trim().match(/^([\d,]+)/);
+        if (digits?.[1] === undefined) {
+            return null;
+        }
+
+        const value = parseInt(digits[1].replace(/,/g, ''), 10);
         return isNaN(value) ? null : value;
     }
 }

--- a/discord-bot/src/Infrastructure/Trophy/PsnProfilesTrophySource.ts
+++ b/discord-bot/src/Infrastructure/Trophy/PsnProfilesTrophySource.ts
@@ -342,22 +342,37 @@ export class PsnProfilesTrophySource implements TrophySource {
      * Drops `<!-- ... -->` before anything is scanned. Commented-out markup
      * is still markup to a regex, so a stale block left in the page source
      * would otherwise be indistinguishable from the live one — and would win,
-     * since these helpers all take the *first* match.
+     * since these helpers all take the *first* match. Repeats to a fixed
+     * point so a crafted `<!--<!---->` can't leave a dangling `<!--` behind.
      */
     private stripComments(html: string): string {
-        return html.replace(/<!--[\s\S]*?-->/g, '');
+        return this.replaceToFixedPoint(html, /<!--[\s\S]*?-->/g, '');
     }
 
     /** Markup → plain text: drop tags, decode the few entities PSNProfiles emits, collapse whitespace. */
     private textOf(html: string): string {
-        return html
-            .replace(/<[^>]*>/g, '')
+        return this.stripTags(html)
             .replace(/&nbsp;/g, ' ')
-            .replace(/&amp;/g, '&')
             .replace(/&#39;/g, "'")
             .replace(/&quot;/g, '"')
+            .replace(/&amp;/g, '&')
             .replace(/\s+/g, ' ')
             .trim();
+    }
+
+    /** Strips tags to a fixed point so a crafted `<scr<script>ipt>` can't leave a reassembled tag behind. */
+    private stripTags(html: string): string {
+        return this.replaceToFixedPoint(html, /<[^>]*>/g, '');
+    }
+
+    private replaceToFixedPoint(input: string, pattern: RegExp, replacement: string): string {
+        let previous: string;
+        let result = input;
+        do {
+            previous = result;
+            result = result.replace(pattern, replacement);
+        } while (result !== previous);
+        return result;
     }
 
     /** Inner content of the first `<tag ...>...</tag>` (no nested same-name tags), or null if absent. */

--- a/discord-bot/tests/Integration/Infrastructure/DependencyInjection/TrophiesSyncJob.container.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/DependencyInjection/TrophiesSyncJob.container.test.ts
@@ -36,6 +36,18 @@ describe('DI container — TrophiesSyncJob / FixOldTrophies', () => {
 
         const jobRunner = myContainer.get(JobRunner);
 
-        expect(jobRunner.listJobs()).not.toContain('trophies:sync');
+        expect(jobRunner.listScheduledJobs()).not.toContain('trophies:sync');
+    });
+
+    test('trophies:sync is still registered, so it can be dry-run by hand', () => {
+        // The whole point of the opt-in gate is that an operator previews a
+        // run before scheduling it. That preview goes through
+        // `jobs:run trophies:sync --dry-run`, which resolves the job out of
+        // the JobRunner — so being unscheduled must not make it unreachable.
+        expect(process.env.TROPHIES_SYNC_ENABLED).not.toBe('true');
+
+        const jobRunner = myContainer.get(JobRunner);
+
+        expect(jobRunner.listJobs()).toContain('trophies:sync');
     });
 });

--- a/discord-bot/tests/Integration/Infrastructure/Http/BrowserFetchHttpClient.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Http/BrowserFetchHttpClient.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import BrowserFetchHttpClient from '../../../../src/Infrastructure/Http/BrowserFetchHttpClient.ts';
+import InMemoryLogger from '../../../Helper/InMemoryLogger.ts';
+import Logger from '../../../../src/Application/Logger/Logger.ts';
+
+/**
+ * The sidecar itself needs a browser and a residential IP, so it is not
+ * exercised here — these cover the contract the bot depends on: the target
+ * URL survives round-tripping through the query string, a non-2xx becomes a
+ * throw (RetryHttpClient's backoff keys off that, and a challenge page must
+ * never reach the parser as if it were a profile), and the write verbs stay
+ * refused rather than silently no-oping.
+ */
+describe('BrowserFetchHttpClient', () => {
+    const originalFetch = globalThis.fetch;
+    let requests: { url: string; init?: RequestInit }[];
+
+    function client(): BrowserFetchHttpClient {
+        return new BrowserFetchHttpClient(new Logger([new InMemoryLogger()]));
+    }
+
+    function stubFetch(response: Response) {
+        globalThis.fetch = (async (url: any, init?: RequestInit) => {
+            requests.push({ url: String(url), init });
+            return response;
+        }) as typeof fetch;
+    }
+
+    beforeEach(() => {
+        requests = [];
+        process.env.PSN_FETCH_URL = 'https://example.test/psn-fetch/';
+        process.env.PSN_FETCH_TOKEN = 'test-token';
+    });
+
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+        delete process.env.PSN_FETCH_URL;
+        delete process.env.PSN_FETCH_TOKEN;
+    });
+
+    test('encodes the target URL and sends the bearer token', async () => {
+        stubFetch(new Response('<html>ok</html>', { status: 200 }));
+
+        const body = await client().get(
+            'https://psnprofiles.com/Zephyr-pt?completion=platinum&page=1',
+        );
+
+        expect(body).toBe('<html>ok</html>');
+        expect(requests).toHaveLength(1);
+        // The trailing slash on PSN_FETCH_URL must not produce `//fetch`, and
+        // the target's own `?`/`&` must not leak into the outer query string.
+        expect(requests[0]!.url).toBe(
+            'https://example.test/psn-fetch/fetch?url=' +
+                encodeURIComponent('https://psnprofiles.com/Zephyr-pt?completion=platinum&page=1'),
+        );
+        expect((requests[0]!.init!.headers as Record<string, string>).Authorization).toBe(
+            'Bearer test-token',
+        );
+    });
+
+    test('throws on a non-2xx so the caller retries instead of parsing an error page', async () => {
+        stubFetch(new Response('challenge did not clear', { status: 502 }));
+
+        await expect(client().get('https://psnprofiles.com/Zephyr-pt')).rejects.toThrow(
+            /failed with status code 502/,
+        );
+    });
+
+    test('refuses the write verbs', async () => {
+        await expect(client().post()).rejects.toThrow(/read-only/);
+        await expect(client().put()).rejects.toThrow(/read-only/);
+        await expect(client().delete()).rejects.toThrow(/read-only/);
+    });
+});

--- a/discord-bot/tests/Integration/Infrastructure/Job/JobRunner.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Job/JobRunner.test.ts
@@ -269,6 +269,40 @@ describe('JobRunner', () => {
         expect(job.callCount).toBe(1);
     });
 
+    test('a manual-only job is runnable by hand but never started by a tick', async () => {
+        // The regression this locks down: gating registration on an env flag
+        // made the documented "dry-run it before you enable it" runbook
+        // impossible, because the job was not in the runner's map at all and
+        // `jobs:run trophies:sync --dry-run` failed with `Unknown job`.
+        const job = new ScriptedJob('manual-only', '* * * * *');
+        const runner = createRunner(jobStateRepository, reporter);
+        runner.register(job, { scheduled: false });
+
+        expect(runner.listJobs()).toContain('manual-only');
+        expect(runner.listScheduledJobs()).not.toContain('manual-only');
+
+        // Due by its cron, but the ticker must leave it alone.
+        runner.tickOnce(new Date());
+        await runner.waitForIdle();
+        expect(job.callCount).toBe(0);
+
+        const result = await runner.runNow('manual-only', { dryRun: true });
+        expect(job.callCount).toBe(1);
+        expect(result.failed).toBe(0);
+    });
+
+    test('a job registered without options stays scheduled by default', async () => {
+        const job = new ScriptedJob('scheduled-by-default', '* * * * *');
+        const runner = createRunner(jobStateRepository, reporter);
+        runner.register(job);
+
+        expect(runner.listScheduledJobs()).toContain('scheduled-by-default');
+
+        runner.tickOnce(new Date());
+        await runner.waitForIdle();
+        expect(job.callCount).toBe(1);
+    });
+
     test('runNow rejects an unknown job name', async () => {
         const runner = createRunner(jobStateRepository, reporter);
 

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/PsnProfilesTrophySource.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/PsnProfilesTrophySource.test.ts
@@ -49,7 +49,7 @@ describe('PsnProfilesTrophySource', () => {
     describe('getPlatinumTrophyData', () => {
         test('extracts rarity percentage and completion date from a completed row', async () => {
             const trophyUrl =
-                'https://psnprofiles.com/trophies/11783-assassins-creed-valhalla/Josh_Lopes';
+                'https://psnprofiles.com/trophies/12-grand-theft-auto-iv/Zephyr-pt';
             const httpClient = new FakeHttpClient({
                 [trophyUrl]: fixture('trophy-completed.html'),
             });
@@ -57,8 +57,12 @@ describe('PsnProfilesTrophySource', () => {
 
             const data = await source.getPlatinumTrophyData(trophyUrl);
 
-            expect(data.percentage).toBe(52.03);
-            expect(data.completionDate.toISOString().slice(0, 10)).toBe('2021-06-29');
+            // The captured row carries both rarity figures; 0.97% is the
+            // site rarity PSNProfiles shows by default and the one the TP
+            // ladder is calibrated against. Reading the hover value (0.3%)
+            // instead would price this trophy at 2000 TP rather than 1250.
+            expect(data.percentage).toBe(0.97);
+            expect(data.completionDate.toISOString().slice(0, 10)).toBe('2021-09-02');
         });
 
         test('applies the blank-first-row workaround and reads the second row', async () => {
@@ -91,14 +95,14 @@ describe('PsnProfilesTrophySource', () => {
     describe('getProfileRank', () => {
         test('extracts world rank and country rank, stripping thousands separators', async () => {
             const httpClient = new FakeHttpClient({
-                'https://psnprofiles.com/Josh_Lopes': fixture('profile-rank.html'),
+                'https://psnprofiles.com/Zephyr-pt': fixture('profile-rank.html'),
             });
             const source = new PsnProfilesTrophySource(httpClient);
 
-            const rank = await source.getProfileRank('Josh_Lopes');
+            const rank = await source.getProfileRank('Zephyr-pt');
 
-            expect(rank.worldRank).toBe(712304);
-            expect(rank.countryRank).toBe(84512);
+            expect(rank.worldRank).toBe(26475);
+            expect(rank.countryRank).toBe(331);
         });
 
         test('returns nulls for both ranks when the profile has no visible rank (banned)', async () => {

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/PsnProfilesTrophySource.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/PsnProfilesTrophySource.test.ts
@@ -48,8 +48,7 @@ class FakeHttpClient implements HttpClient {
 describe('PsnProfilesTrophySource', () => {
     describe('getPlatinumTrophyData', () => {
         test('extracts rarity percentage and completion date from a completed row', async () => {
-            const trophyUrl =
-                'https://psnprofiles.com/trophies/12-grand-theft-auto-iv/Zephyr-pt';
+            const trophyUrl = 'https://psnprofiles.com/trophies/12-grand-theft-auto-iv/Zephyr-pt';
             const httpClient = new FakeHttpClient({
                 [trophyUrl]: fixture('trophy-completed.html'),
             });

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/profile-rank-banned.html
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/profile-rank-banned.html
@@ -1,3 +1,12 @@
-<div class="stats">
-    <span class="level">42</span>
-</div>
+<!-- The same real stats block as profile-rank.html with both rank spans removed,
+     which is what PSNProfiles serves for a banned or private profile. This shape
+     is what TrophiesSyncJob reads as 'auto-ban and exclude this member', so it is
+     worth it being genuine markup rather than a stub. -->
+<div class="stats flex">
+		<span class="stat grow">478<span>Games Played</span></span>
+		<span class="stat grow">202<span>Completed Games</span></span>	
+		<span class="stat grow">62.30%<span>Completion</span></span>					
+		<span class="stat grow">8,258<span>Unearned Trophies</span></span>
+		<span class="stat grow">2.22<span>Trophies Per Day</span></span>
+		<span class="stat grow">60,834<span>Views</span></span>
+		

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/profile-rank.html
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/profile-rank.html
@@ -1,4 +1,22 @@
-<div class="stats">
-    <span class="rank">712,304</span>
-    <span class="country-rank">84,512</span>
-</div>
+<!-- Captured verbatim from https://psnprofiles.com/Zephyr-pt (2026-08-21).
+     Trimmed to the stats block; markup inside is untouched. The nested
+     <a> and label <span> are exactly why the old hand-written fixture
+     (a bare <span class="rank">712,304</span>) let a broken parser pass. -->
+<div class="stats flex">
+		<span class="stat grow">478<span>Games Played</span></span>
+		<span class="stat grow">202<span>Completed Games</span></span>	
+		<span class="stat grow">62.30%<span>Completion</span></span>					
+		<span class="stat grow">8,258<span>Unearned Trophies</span></span>
+		<span class="stat grow">2.22<span>Trophies Per Day</span></span>
+		<span class="stat grow">60,834<span>Views</span></span>
+		
+					<span class="rank stat grow red">
+				<a href="/leaderboard/all?page=530&amp;h=Zephyr-pt#Zephyr-pt" rel="nofollow">
+					26,475<span>World Rank</span>
+				</a>
+			</span>
+			<span class="country-rank stat grow red">
+				<a href="/leaderboard/all/pt?page=7&amp;h=Zephyr-pt#Zephyr-pt" rel="nofollow">
+					331<span>Country Rank</span>
+				</a>
+			</span>

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/trophy-blank-first-row.html
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/trophy-blank-first-row.html
@@ -14,6 +14,11 @@
                     <span class="typo-top">8.42%</span>
                     <span class="typo-bottom">Very Rare</span>
                 </td>
+                <td style="padding-right: 10px">
+                    <span class="separator left">
+                        <img title="Platinum" src="/lib/img/icons/40-platinum.png">
+                    </span>
+                </td>
                 <td class="hover-hide">
                     <span class="typo-top-date">1st Jan 2022</span>
                     <span class="typo-bottom">9:00am</span>

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/trophy-completed.html
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/trophy-completed.html
@@ -1,23 +1,145 @@
-<div class="box no-top-border">
-    <table>
-        <thead>
-            <tr>
-                <th>Trophy</th>
-                <th>Rarity</th>
-                <th>Earned</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr class="completed">
-                <td class="hover-hide">
-                    <span class="typo-top">52.03%</span>
-                    <span class="typo-bottom">Ultra Rare</span>
-                </td>
-                <td class="hover-hide">
-                    <span class="typo-top-date">29th Jun 2021</span>
-                    <span class="typo-bottom">10:14pm</span>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-</div>
+<!-- Captured verbatim from https://psnprofiles.com/trophies/12-grand-theft-auto-iv/Zephyr-pt
+     (2026-08-21). The two <tbody> blocks above the trophy table are the real
+     decoys the parser must skip: a profile-summary table and a base-game/DLC
+     breakdown, neither carrying a completion date. The platinum row keeps both
+     rarity cells (hover-show 0.3%, hover-hide 0.97%) so a regression that reads
+     the wrong one changes the computed TP from 1250 to 2000 and fails loudly. -->
+<table><tbody><tr class="platinum">
+
+                    <td>
+                        <a href="/Zephyr-pt">
+                            <img class="trophy" src="https://i.psnprofiles.com/avatars/m/G8ec8ea704.png">
+                        </a>
+                    </td>
+
+                    <td style="width: 100%;">
+                        <a class="title" href="/Zephyr-pt" rel="nofollow">Zephyr-pt</a><br>
+                        <span class="small-info">
+                            <b>56</b> of <b>66</b> Trophies
+
+                                                        <br>January 7<sup>th</sup> 2025
+                                                    </span>
+                    </td>
+
+                    <td>
+                        <center style="padding: 0 10px;border-right:1px solid #dddddd;">
+                                                        <span class="game-rank A">A</span><br><span class="typo-bottom">RANK</span>
+                                                    </center>
+                    </td>
+
+                    <td>
+                        <span class="separator">
+                                                                                    <img width="21" src="/lib/img/icons/platinum-icon.png">
+                                                                                </span>
+                    </td>
+
+                    <td>
+                        <span class="separator left">
+                            <div class="trophy-count">
+                                <ul class="floatr">
+                                    <li class="icon-sprite gold">3</li>
+                                    <li class="icon-sprite silver">5</li>
+                                    <li class="icon-sprite bronze">47</li>
+                                </ul>
+                                <div class="progress-bar">
+                                    <span>88%</span>
+                                    <div style="width: 88%;"></div>
+                                </div>
+                            </div>
+                        </span>
+                    </td>
+                </tr></tbody></table>
+<table><tbody><tr class="completed platinum">
+                            <td style="padding-right: 10px; width: 1%;">
+                                <a href="https://img.psnprofiles.com/game/l/12/086559ba-4ee8-403e-95e2-5be8c8a8f2a4.png">
+                                    <picture class="game">
+                                        <source srcset="https://img.psnprofiles.com/game/s/12/086559ba-4ee8-403e-95e2-5be8c8a8f2a4.png, https://img.psnprofiles.com/game/m/12/086559ba-4ee8-403e-95e2-5be8c8a8f2a4.png 1.1x">
+                                        <img src="https://img.psnprofiles.com/game/s/12/086559ba-4ee8-403e-95e2-5be8c8a8f2a4.png">
+                                    </picture>
+                                </a>
+                            </td>
+                                                        <td style="padding: 10px 10px 10px 0; width: 100%;">
+                                <span class="title">Base Game</span><br>
+                                <span class="small-info"><b>51</b> of <b>51</b> Trophies</span>
+                            </td>
+                            <td>
+                                <span class="separator">
+                                                                                                            <img width="21" src="/lib/img/icons/platinum-icon.png">
+                                                                                                        </span>
+                            </td>
+                            <td>
+                                <span class="separator left">
+                                    <div class="trophy-count">
+                                        <ul class="floatr">
+                                            <li class="icon-sprite gold">3</li>
+                                            <li class="icon-sprite silver">5</li>
+                                            <li class="icon-sprite bronze">42</li>
+                                        </ul>
+                                        <div class="progress-bar">
+                                            <span>100%</span>
+                                            <div style="width: 100%;"></div>
+                                        </div>
+                                    </div>
+                                </span>
+                            </td>
+                                                    </tr></tbody></table>
+<table><tbody>
+<tr class="completed">
+                        <td>
+                            <a href="/trophy/12-grand-theft-auto-iv/1-taking-a-liberty" class="">
+                                <picture class="trophy earned">
+                                                                        <source srcset="https://img.psnprofiles.com/trophy/s/12/6ee8937a-1916-4711-8767-12d2e0fa3783.png, https://img.psnprofiles.com/trophy/m/12/6ee8937a-1916-4711-8767-12d2e0fa3783.png 1.1x">
+                                    <img src="https://img.psnprofiles.com/trophy/s/12/6ee8937a-1916-4711-8767-12d2e0fa3783.png">
+                                                                    </picture>
+                            </a>
+                        </td>
+                        <td style="width: 100%;">
+                            <a class="title" href="/trophy/12-grand-theft-auto-iv/1-taking-a-liberty">Taking A Liberty</a><br>Sorry for taking liberties with your time.
+                                                                                                                                                                                                                            </td>
+
+                        
+                        
+                        <td>
+                            <span class="separator right" <center="">
+                                    <span class="typo-top-date">
+                                        <nobr>2<sup>nd</sup> Sep 2021</nobr>
+                                    </span><br>
+                                    <span class="typo-bottom-date">
+                                        <nobr>1:40:45 AM</nobr>
+                                    </span>
+                                
+                                                                                            </span>
+                        </td>
+                        
+                                                <td class="hover-show">
+                                                        <span class="separator rarity">
+                                <span class="typo-top">
+                                    <nobr><img class="icon-sprite rarity ultra-rare" src="/lib/img/layout/spacer.png">0.3%</nobr>
+                                </span><br><span class="typo-bottom">
+                                    <nobr>Ultra Rare</nobr>
+                                </span>
+                            </span>
+                        </td>
+
+                                                <td class="hover-hide">
+                                                        <span class="separator rarity">
+                                <span class="typo-top">0.97%</span><br><span class="typo-bottom">
+                                    <nobr>Ultra Rare</nobr>
+                                </span>
+                            </span>
+                        </td>
+
+                                                <td style="padding-right: 10px">
+                            <span class="separator left">
+                                                                <img title="Platinum" src="/lib/img/icons/40-platinum.png">
+                                                            </span>
+                        </td>
+                        
+
+                        
+
+
+                        
+
+                    </tr>
+</tbody></table>

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/trophy-not-earned.html
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/trophy-not-earned.html
@@ -13,6 +13,11 @@
                     <span class="typo-top">12.10%</span>
                     <span class="typo-bottom">Rare</span>
                 </td>
+                <td style="padding-right: 10px">
+                    <span class="separator left">
+                        <img title="Platinum" src="/lib/img/icons/40-platinum.png">
+                    </span>
+                </td>
                 <td class="hover-hide">
                     <span class="typo-bottom">Not earned</span>
                 </td>

--- a/infrastructure/psn-fetch/Dockerfile
+++ b/infrastructure/psn-fetch/Dockerfile
@@ -1,0 +1,35 @@
+# Chromium and its system libraries come from the Playwright base image;
+# patchright drives a patched build of the same browser. Pinned rather than
+# :latest because the whole point of this image is a browser fingerprint that
+# is known to clear the challenge — an unattended base bump is exactly the
+# kind of change that would silently break it.
+FROM mcr.microsoft.com/playwright:v1.49.0-noble
+
+WORKDIR /app
+
+# xvfb is load-bearing, not a convenience: headless Chromium is detected and
+# refused, so the browser runs headed against a virtual display.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends xvfb tini \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY package.json ./
+RUN npm install --omit=dev && npx patchright install chromium
+
+COPY server.js ./
+
+ENV PORT=8791 \
+    PROFILE_DIR=/data/profile
+
+# /data holds the persistent browser profile — and with it the Cloudflare
+# clearance cookie, which is what keeps most requests from being challenged
+# at all. Losing it is survivable but makes the first requests after a
+# restart much slower.
+VOLUME ["/data"]
+
+EXPOSE 8791
+
+# tini reaps the Chromium children xvfb-run leaves behind; without it a
+# long-lived container accumulates zombies.
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["xvfb-run", "-a", "--server-args=-screen 0 1440x900x24", "node", "/app/server.js"]

--- a/infrastructure/psn-fetch/Dockerfile
+++ b/infrastructure/psn-fetch/Dockerfile
@@ -25,9 +25,18 @@ ENV PORT=8791 \
 # clearance cookie, which is what keeps most requests from being challenged
 # at all. Losing it is survivable but makes the first requests after a
 # restart much slower.
+RUN mkdir -p /data && chown -R pwuser:pwuser /app /data
 VOLUME ["/data"]
 
+# pwuser is the non-root user baked into the Playwright base image. Chromium
+# runs with --no-sandbox already (server.js), so dropping root here costs
+# nothing — the setuid sandbox that would otherwise want root was never in use.
+USER pwuser
+
 EXPOSE 8791
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||8791)+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
 # tini reaps the Chromium children xvfb-run leaves behind; without it a
 # long-lived container accumulates zombies.

--- a/infrastructure/psn-fetch/README.md
+++ b/infrastructure/psn-fetch/README.md
@@ -1,0 +1,102 @@
+# psn-fetch
+
+A browser-backed, read-only fetch proxy for `psnprofiles.com`. It exists for
+one reason: **the bot cannot fetch PSNProfiles itself any more.**
+
+## The problem
+
+PSNProfiles sits behind a Cloudflare managed challenge. It is not an IP ban —
+it is a JavaScript interstitial ("Just a moment…"), so clearing it needs
+something that actually executes the challenge. Measured against the live site
+on **2026-08-21**, six pages per cell, across all three page types the sync
+job uses (profile, platinum list, trophy detail):
+
+| Client                             | HTZ1 (Hetzner) | TedRelayer (home) |
+| ---------------------------------- | -------------- | ----------------- |
+| `fetch` / curl, any User-Agent     | 0/6            | 0/6               |
+| curl-impersonate (real Chrome JA3) | 0/2            | —                 |
+| FlareSolverr                       | 0/3 (timeouts) | —                 |
+| Playwright, headless               | 0/6            | —                 |
+| Playwright, headed under xvfb      | 0/6            | 1/6               |
+| **patchright, headed under xvfb**  | 0/6            | **6/6**           |
+
+Two conditions have to hold **at the same time**, which is why every simpler
+fix failed:
+
+1. **A patched browser.** Stock Playwright leaks automation over CDP
+   (`Runtime.enable`). It clears the *first* navigation of a fresh profile and
+   is challenged on every one after — hence the misleading 1/6. `patchright`
+   closes those leaks.
+2. **A non-datacenter IP.** Hetzner's range failed 0/12 regardless of client.
+   This is the reason this service cannot live next to the bot on HTZ1.
+
+Two plausible theories that the evidence **killed**, recorded so nobody
+re-tests them: TLS/JA3 impersonation alone changed nothing, and the passing
+runs were software-rendered (SwiftShader), so it is not a WebGL/GPU check.
+
+## Where it runs, and how the bot reaches it
+
+The service runs on **TedRelayer** (home network) and is published through the
+Tailscale Funnel that host already had enabled, on a dedicated path:
+
+```
+https://tedrelayer.tail6bf1c8.ts.net/psn-fetch  ->  127.0.0.1:8791
+```
+
+Chosen over the alternatives because HTZ1 has no passwordless sudo (so no
+`sshd_config` change for a reverse tunnel, and no Tailscale install), and
+because home ingress is deliberately closed — HTZ1 cannot reach TedRelayer's
+SSH at all, which is correct and was left alone. Funnel needs no inbound port
+on the router and no root on HTZ1.
+
+**This does put the service on the public internet**, so it is hardened
+accordingly: bearer token compared in constant time, a hard allowlist of one
+origin (`https://psnprofiles.com`), `GET` only, and no eval/screenshot
+surface. If you would rather it were not public, the alternative is a
+Tailscale sidecar container on HTZ1 joined to `game-on-portugal_internal` plus
+`tailscale serve` (tailnet-only) instead of Funnel — more moving parts, no
+public exposure.
+
+## Operating it
+
+```bash
+# on TedRelayer
+cd ~/psn-fetch
+docker compose up -d --build
+docker compose logs -f
+
+curl -s https://tedrelayer.tail6bf1c8.ts.net/psn-fetch/health
+curl -s -H "Authorization: Bearer $PSN_FETCH_TOKEN" \
+  "https://tedrelayer.tail6bf1c8.ts.net/psn-fetch/fetch?url=https%3A%2F%2Fpsnprofiles.com%2FZephyr-pt" \
+  | grep -c 'World Rank'   # expect 2
+
+# remove the public route again
+sudo tailscale serve --https=443 --set-path /psn-fetch off
+```
+
+The token lives in `~/psn-fetch/.env` (mode 600) on TedRelayer and in the bot's
+environment as `PSN_FETCH_TOKEN`. Rotating it means changing both.
+
+## Politeness
+
+Requests are serialised behind a queue with a minimum 1.5s gap, and the
+throttle lives **here** rather than in the bot on purpose: the browser in this
+container owns the Cloudflare clearance cookie, so two bot processes sharing
+this service must not be able to double the request rate against a site with
+no public API. The persistent profile volume keeps that cookie across
+restarts, which is why most requests never see a challenge at all (~1s).
+
+## Known fragility
+
+This depends on beating bot protection that PSNProfiles deliberately turned
+on. It works today; it is not guaranteed to keep working, and the pinned base
+image and pinned patchright version are load-bearing — an unattended bump is
+exactly the kind of change that would silently break the fingerprint. If the
+sync starts failing wholesale, re-run the table above before assuming the
+parser broke.
+
+**This host is scheduled for decommission on 2026-09-02** (GLOBAL-PLAN M2.5)
+and its NVMe has 2,200+ unrecoverable read errors. The service is stateless
+apart from the browser profile, so it can move to any always-on machine on a
+residential connection — but if TedRelayer goes away without this moving, the
+leaderboard silently stops updating again.

--- a/infrastructure/psn-fetch/docker-compose.yml
+++ b/infrastructure/psn-fetch/docker-compose.yml
@@ -1,0 +1,31 @@
+# psn-fetch runs on a residential connection (TedRelayer), NOT on HTZ1:
+# Hetzner's IP range fails the Cloudflare challenge 0/12 regardless of how
+# good the browser is. See infrastructure/psn-fetch/README.md.
+services:
+  psn-fetch:
+    build: .
+    image: gop-psn-fetch:1.0.0
+    container_name: gop-psn-fetch
+    restart: unless-stopped
+    environment:
+      PSN_FETCH_TOKEN: ${PSN_FETCH_TOKEN:?PSN_FETCH_TOKEN is required}
+      MIN_REQUEST_INTERVAL_MS: 1500
+    volumes:
+      - psn-fetch-profile:/data
+    # Bound to loopback on purpose. The bot reaches this through the reverse
+    # SSH tunnel documented in the README, so the port is never exposed to
+    # the LAN, let alone forwarded at the router.
+    ports:
+      - "127.0.0.1:8791:8791"
+    # Chromium needs more than the default 64MB of /dev/shm or it crashes
+    # part-way through rendering a large trophy page.
+    shm_size: "1gb"
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:8791/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+volumes:
+  psn-fetch-profile:

--- a/infrastructure/psn-fetch/package.json
+++ b/infrastructure/psn-fetch/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "psn-fetch",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Browser-backed read-only fetch proxy for PSNProfiles (Cloudflare challenge)",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "patchright": "^1.49.0"
+  }
+}

--- a/infrastructure/psn-fetch/server.js
+++ b/infrastructure/psn-fetch/server.js
@@ -1,0 +1,186 @@
+'use strict';
+
+/**
+ * psn-fetch — a browser-backed read-only fetch proxy for PSNProfiles.
+ *
+ * The bot cannot fetch psnprofiles.com itself: the site is behind a
+ * Cloudflare managed challenge that needs a real browser to execute, and
+ * that will not clear from a datacenter IP at all. This service is the
+ * narrow escape hatch — it runs a patched Chromium on a residential
+ * connection, and exposes exactly one verb: "give me the HTML at this
+ * psnprofiles.com URL".
+ *
+ * Deliberate constraints, because this is a browser reachable over HTTP:
+ *
+ *  - **One allowed origin.** Anything not on https://psnprofiles.com is
+ *    refused before a page is opened, so a leaked token cannot turn this
+ *    into an SSRF pivot into the home network.
+ *  - **Bearer token required**, compared with a timing-safe equality.
+ *  - **GET only, HTML out.** No POST/eval/screenshot surface.
+ *  - **Serialised.** One navigation at a time behind a queue, with a
+ *    minimum interval between requests. The throttle lives here rather
+ *    than in the bot because the browser here owns the Cloudflare
+ *    clearance cookie; two bot processes sharing this service must not be
+ *    able to double the request rate against a site with no public API.
+ */
+
+const http = require('http');
+const crypto = require('crypto');
+const { chromium } = require('patchright');
+
+const PORT = Number(process.env.PORT || 8791);
+const TOKEN = process.env.PSN_FETCH_TOKEN || '';
+const ALLOWED_ORIGIN = 'https://psnprofiles.com';
+const MIN_REQUEST_INTERVAL_MS = Number(process.env.MIN_REQUEST_INTERVAL_MS || 1500);
+const NAV_TIMEOUT_MS = Number(process.env.NAV_TIMEOUT_MS || 60000);
+const CHALLENGE_TIMEOUT_MS = Number(process.env.CHALLENGE_TIMEOUT_MS || 45000);
+const PROFILE_DIR = process.env.PROFILE_DIR || '/data/profile';
+
+if (!TOKEN) {
+  console.error('PSN_FETCH_TOKEN is required');
+  process.exit(1);
+}
+
+function log(event, fields = {}) {
+  console.log(JSON.stringify({ ts: new Date().toISOString(), event, ...fields }));
+}
+
+/** Constant-time compare, so a wrong token cannot be discovered byte by byte. */
+function tokenMatches(presented) {
+  const a = Buffer.from(presented || '');
+  const b = Buffer.from(TOKEN);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+let browserContext = null;
+let lastRequestAt = 0;
+/** Serialises navigations: each request chains onto the previous one. */
+let queue = Promise.resolve();
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function getContext() {
+  if (browserContext) return browserContext;
+
+  // Headed (under xvfb) and persistent, both load-bearing: headless is
+  // detected outright, and a persistent profile keeps the clearance cookie
+  // so most requests skip the challenge entirely.
+  browserContext = await chromium.launchPersistentContext(PROFILE_DIR, {
+    headless: false,
+    viewport: { width: 1440, height: 900 },
+    locale: 'en-US',
+    timezoneId: 'Europe/Lisbon',
+    args: ['--no-sandbox', '--disable-blink-features=AutomationControlled'],
+  });
+
+  browserContext.on('close', () => {
+    log('browser.closed');
+    browserContext = null;
+  });
+
+  log('browser.launched');
+  return browserContext;
+}
+
+async function fetchPage(url) {
+  const elapsed = Date.now() - lastRequestAt;
+  if (elapsed < MIN_REQUEST_INTERVAL_MS) {
+    await sleep(MIN_REQUEST_INTERVAL_MS - elapsed);
+  }
+  lastRequestAt = Date.now();
+
+  const ctx = await getContext();
+  const page = await ctx.newPage();
+  try {
+    const response = await page.goto(url, {
+      waitUntil: 'domcontentloaded',
+      timeout: NAV_TIMEOUT_MS,
+    });
+
+    // The interstitial resolves itself; poll the title until it clears
+    // rather than sleeping a fixed amount, so the common (already-cleared)
+    // case stays fast.
+    const deadline = Date.now() + CHALLENGE_TIMEOUT_MS;
+    let title = await page.title();
+    while (title.includes('Just a moment') && Date.now() < deadline) {
+      await page.waitForTimeout(1500);
+      title = await page.title();
+    }
+
+    if (title.includes('Just a moment')) {
+      throw new Error('Cloudflare challenge did not clear');
+    }
+
+    const status = response ? response.status() : 0;
+    const html = await page.content();
+    return { status, html, title };
+  } finally {
+    await page.close().catch(() => {});
+  }
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+
+  if (url.pathname === '/health') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, browser: browserContext !== null }));
+    return;
+  }
+
+  if (url.pathname !== '/fetch' || req.method !== 'GET') {
+    res.writeHead(404).end('not found');
+    return;
+  }
+
+  const auth = req.headers.authorization || '';
+  if (!tokenMatches(auth.replace(/^Bearer\s+/i, ''))) {
+    log('auth.rejected', { remote: req.socket.remoteAddress });
+    res.writeHead(401).end('unauthorized');
+    return;
+  }
+
+  const target = url.searchParams.get('url') || '';
+  let parsed;
+  try {
+    parsed = new URL(target);
+  } catch {
+    res.writeHead(400).end('bad url');
+    return;
+  }
+
+  if (parsed.origin !== ALLOWED_ORIGIN) {
+    log('origin.rejected', { target });
+    res.writeHead(403).end(`only ${ALLOWED_ORIGIN} is allowed`);
+    return;
+  }
+
+  queue = queue
+    .then(async () => {
+      const startedAt = Date.now();
+      try {
+        const { status, html } = await fetchPage(parsed.toString());
+        log('fetch.ok', { url: target, status, ms: Date.now() - startedAt, bytes: html.length });
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(html);
+      } catch (error) {
+        log('fetch.failed', { url: target, ms: Date.now() - startedAt, error: error.message });
+        // 502: the failure is upstream (challenge/navigation), not the
+        // caller's request being malformed. RetryHttpClient backs off on it.
+        res.writeHead(502).end(error.message);
+      }
+    })
+    // Keep the chain alive: a rejected link would strand every later request.
+    .catch(() => {});
+});
+
+server.listen(PORT, () => log('listening', { port: PORT }));
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, async () => {
+    log('shutdown', { signal });
+    server.close();
+    if (browserContext) await browserContext.close().catch(() => {});
+    process.exit(0);
+  });
+}


### PR DESCRIPTION
## What I found

`/trophy rank` **reads** fine — 4,971 trophies, 67 ranked profiles, 0 orphans, and the ranking SQL returns correct results. But the leaderboard has been **frozen since 2024-12-02**: `trophies:sync` has never run in production.

Simply setting `TROPHIES_SYNC_ENABLED=true` would not have fixed it. Three defects meant the job could not work at all, and its first real run would have tried to auto-exclude the entire community.

### 1. The documented runbook was impossible

The bot logs on every boot: *"Dry-run it first — `bun run:command jobs:run trophies:sync --dry-run`"*. Running exactly that on production:

```
Error: Unknown job "trophies:sync". Registered jobs: week-screenshot-winner,
screenshots-relink, ads-lifecycle, ads-reconcile
```

`JobRunner.register()` conflated *"the ticker may start this"* with *"this exists"*, so the env-gated job was absent from the map and unreachable. The only way to preview it was to enable the schedule first — exactly what the gate exists to prevent. `register()` now takes `{ scheduled }`.

### 2. The parser had never seen a real PSNProfiles page

The fixtures were hand-written simplifications. That is why three broken code paths passed CI:

- **`parseProfileRank` returned `{null, null}` for every profile.** Real markup nests the number inside an `<a>` *and* a label `<span>`; the non-greedy match stopped at the label's closing tag and `parseInt` got `<a href=…`. `TrophiesSyncJob` reads "both ranks null" as *banned/private* → **the first scheduled run would have tried to ban and exclude all 72 active members.** The `MODERATION_SAFETY_VALVE_THRESHOLD` would have caught it — the safety valve is well designed and would have earned its keep — but the feature would still have been dead.
- **`parsePlatinumTrophyData` reported "not earned" for earned trophies.** It read the first `<tbody>`; a real page has 13, and the first two are decoys carrying no completion date. It also couldn't parse `2<sup>nd</sup> Sep 2021`. Every trophy would have been silently skipped.
- **Neither stripped HTML comments**, so commented-out markup beat the live block. Found when a fixture's own comment got parsed as data.

Fixtures are now **captured verbatim from the live site**, including the decoy tables and both rarity cells.

**Validation** against six trophies with known stored values:

| Stored TP | Parsed TP | Date |
|---|---|---|
| 50 | 50 ✅ | exact ✅ |
| 100 | 100 ✅ | exact ✅ |
| 250 | 250 ✅ | exact ✅ |
| 500 | 500 ✅ | exact ✅ |
| 800 | 500 ⚠️ | exact ✅ |
| 2000 | 100 ⚠️ | exact ✅ |

All six dates exact. The two TP misses are **genuine rarity drift, not parse error** — both are 2021 releases whose platinum has become far more common since (Far Cry 6 was platted four days after launch). The four with stable rarity reproduce exactly.

### 3. PSNProfiles is behind Cloudflare

Plain `fetch` cannot clear it from anywhere. Measured on 2026-08-21, three page types, six pages per cell:

| Client | HTZ1 (Hetzner) | Home IP |
|---|---|---|
| `fetch` / curl, any UA | 0/6 | 0/6 |
| curl-impersonate (real Chrome JA3) | 0/2 | — |
| FlareSolverr | 0/3 (timeouts) | — |
| Playwright, headless | 0/6 | — |
| Playwright, headed + xvfb | 0/6 | 1/6 |
| **patchright, headed + xvfb** | 0/6 | **6/6** |

**Both** a patched browser and a non-datacenter IP are required. Two theories the evidence killed, recorded so nobody re-tests them: TLS/JA3 impersonation alone did nothing, and the passing runs were software-rendered (SwiftShader), so it is not a WebGL/GPU check.

`infrastructure/psn-fetch/` adds a hardened read-only fetch proxy that runs off-box (bearer token compared in constant time, single-origin allowlist, GET only, serialised with a 1.5s throttle). Only the trophy source uses it, and only when `PSN_FETCH_URL`/`PSN_FETCH_TOKEN` are set — unset, everything falls back to the direct client, so tests and local dev are unchanged.

## Verification

- `bun run typecheck` clean; **548 tests pass**
- End-to-end against the live service: **11 real trophies written, 0 failed, 0 profiles flagged** — including trophies earned in 2025 and 2026, which is the backlog this recovers

## Deploying this

1. Merge (deploys the bot).
2. Set `PSN_FETCH_URL` and `PSN_FETCH_TOKEN` on the `gop-bot` service in Portainer stack 46.
3. `jobs:run trophies:sync --dry-run` and **read the report**, especially `newlyFlagged`.
4. Only then set `TROPHIES_SYNC_ENABLED=true`.

## Two things to decide

- **The sidecar needs a residential IP, so it runs on TedRelayer — which is scheduled for decommission on 2026-09-02** (M2.5) and has a failing NVMe. It is stateless and can move to any always-on home machine, but if that host disappears without it moving, the leaderboard silently freezes again.
- **Tailscale Funnel puts the service on the public internet.** It is token-protected and origin-locked, and it needed no new router port or root on HTZ1. A tailnet-only alternative is described in the README if you would rather it were not public.

## Not fixed (data blemishes, out of scope)

- `sabathian>` (rank #2) has a trailing `>` in its PSN name and will 404 on every sync
- Zephyr-pt has 2 duplicated trophy rows from the old bot, double-counting 2,500 points

🤖 Generated with [Claude Code](https://claude.com/claude-code)