### PR TITLE
feat(bot): announce what the trophy crawl recovered while it was down

### DIFF
--- a/discord-bot/.prettierignore
+++ b/discord-bot/.prettierignore
@@ -12,3 +12,8 @@ bun.lock
 # release-please owns this file end to end and rewrites it on every
 # release — reformatting it here just means fighting release-please forever.
 CHANGELOG.md
+
+# Captured verbatim from the live PSNProfiles site, broken markup and all —
+# that's the point (see PsnProfilesTrophySource.test.ts). Reformatting would
+# defeat the fixture, and some of it isn't valid HTML for Prettier to parse.
+tests/Integration/Infrastructure/Trophy/fixtures/*.html

--- a/discord-bot/bin/console.ts
+++ b/discord-bot/bin/console.ts
@@ -6,6 +6,7 @@ import WeekScreenshotWinner from '../src/Ui/Cli/WeekScreenshotWinner.ts';
 import { RunJobConsoleCommand } from '../src/Infrastructure/Job/RunJobConsoleCommand.ts';
 import FixOldTrophies from '../src/Ui/Cli/FixOldTrophies.ts';
 import ApplyAutoModConfig from '../src/Ui/Cli/ApplyAutoModConfig.ts';
+import TrophiesCatchUpAnnounce from '../src/Ui/Cli/TrophiesCatchUpAnnounce.ts';
 
 const logger = myContainer.get<Logger>(TYPES.Logger);
 const consoleCommands: Record<string, ConsoleCommand> = {};
@@ -20,6 +21,10 @@ consoleCommands[FixOldTrophies.commandName] = myContainer.get<FixOldTrophies>(Fi
 // M9.1 — manual AutoMod config reconciliation, dry-run by default (see ApplyAutoModConfig.ts).
 consoleCommands[ApplyAutoModConfig.commandName] =
     myContainer.get<ApplyAutoModConfig>(ApplyAutoModConfig);
+// One-off "the trophy hall is alive again" post after a backfill — previews
+// by default, posts only with --post (see TrophiesCatchUpAnnounce.ts).
+consoleCommands[TrophiesCatchUpAnnounce.commandName] =
+    myContainer.get<TrophiesCatchUpAnnounce>(TrophiesCatchUpAnnounce);
 
 async function run(): Promise<number> {
     const args = process.argv.slice(2);

--- a/discord-bot/src/Domain/Trophy/CatchUpSummary.ts
+++ b/discord-bot/src/Domain/Trophy/CatchUpSummary.ts
@@ -1,0 +1,17 @@
+/**
+ * One member's worth of trophies recovered by a backfill — what
+ * `trophies:catchup-announce` turns into a single "here is what you earned
+ * while the crawl was down" message.
+ *
+ * `points` and `numTrophies` are aggregated in SQL rather than by loading
+ * rows, because the whole point of this summary is to avoid pulling ~20
+ * months of trophies into memory just to count them.
+ */
+export interface CatchUpSummary {
+    userId: string;
+    psnProfile: string;
+    points: number;
+    numTrophies: number;
+    firstCompletionDate: Date;
+    lastCompletionDate: Date;
+}

--- a/discord-bot/src/Domain/Trophy/PsnProfileUrl.ts
+++ b/discord-bot/src/Domain/Trophy/PsnProfileUrl.ts
@@ -1,4 +1,35 @@
 /**
+ * PSN online IDs are 3-16 characters, starting with a letter or digit, and
+ * may otherwise contain only letters, digits, `-` and `_`.
+ *
+ * Validating here is what stops a malformed name reaching the database. One
+ * profile in production (`sabathian>`, registered 2022 by the old bot's raw
+ * `url.split('/')`) carries a stray `>`; PSNProfiles normalises it away on
+ * fetch, so the crawl works, but it renders as `sabathian>` on every
+ * leaderboard. All 118 production profiles satisfy this pattern once that
+ * row is corrected, so it rejects nothing legitimate.
+ */
+const PSN_ONLINE_ID = /^[A-Za-z0-9][A-Za-z0-9_-]{2,15}$/;
+
+function toPsnOnlineId(segment: string | undefined): string | null {
+    if (segment === undefined || segment.length === 0) {
+        return null;
+    }
+
+    // `new URL()` percent-encodes anything unusual in the path, so a pasted
+    // `.../sabathian>` arrives here as `sabathian%3E`. Decode first, then
+    // validate, so the check sees the character rather than its escape.
+    let decoded: string;
+    try {
+        decoded = decodeURIComponent(segment);
+    } catch {
+        return null;
+    }
+
+    return PSN_ONLINE_ID.test(decoded) ? decoded : null;
+}
+
+/**
  * Extracts a PSN profile username from either URL shape PSNProfiles.com
  * supports (M7.5):
  *
@@ -38,14 +69,13 @@ export function extractPsnProfileFromUrl(url: string): string | null {
 
     // Bare profile URL: https://psnprofiles.com/<username>
     if (segments.length === 1) {
-        return segments[0] ?? null;
+        return toPsnOnlineId(segments[0]);
     }
 
     // Trophy URL: https://psnprofiles.com/trophies/<id>-<game>/<username>
     // — three path segments, matching the old bot's 6-part full-URL split.
     if (segments.length === 3 && segments[0] === 'trophies') {
-        const username = segments[2];
-        return username !== undefined && username.length > 0 ? username : null;
+        return toPsnOnlineId(segments[2]);
     }
 
     return null;

--- a/discord-bot/src/Domain/Trophy/TrophyRepository.ts
+++ b/discord-bot/src/Domain/Trophy/TrophyRepository.ts
@@ -1,6 +1,7 @@
 import type { Trophy } from './Trophy';
 import type { TrophyId } from './TrophyId';
 import type { TrophyRankData } from './TrophyRankData';
+import type { CatchUpSummary } from './CatchUpSummary';
 import type { TrophyProfileId } from './TrophyProfileId';
 import type { UserPosition } from './UserPosition';
 
@@ -74,4 +75,19 @@ export interface TrophyRepository {
     countLifetimeHunters(): Promise<number>;
 
     findUserPosition(userId: string): Promise<UserPosition>;
+
+    /**
+     * Per-member totals for trophies *earned* on or after `since`, newest
+     * window first — the input to `trophies:catchup-announce` (the one-off
+     * "the crawl is back and here is what it recovered" post).
+     *
+     * Filters on `completionDate`, not `createdAt`, deliberately: the
+     * message tells a member what *they* achieved in that period, which is
+     * about when they earned the platinum, not when this bot happened to
+     * notice it.
+     *
+     * Excluded profiles and profiles with no linked Discord user are left
+     * out — there is nobody to mention.
+     */
+    findCatchUpSummariesSince(since: Date): Promise<CatchUpSummary[]>;
 }

--- a/discord-bot/src/Infrastructure/DependencyInjection/inversify.config.ts
+++ b/discord-bot/src/Infrastructure/DependencyInjection/inversify.config.ts
@@ -79,6 +79,7 @@ import type { AutoModClient } from '../../Domain/Community/AutoModClient.ts';
 import { DiscordAutoModClient } from '../Community/Discord/DiscordAutoModClient.ts';
 import { InMemoryAutoModClient } from '../Community/InMemory/InMemoryAutoModClient.ts';
 import ApplyAutoModConfig from '../../Ui/Cli/ApplyAutoModConfig.ts';
+import TrophiesCatchUpAnnounce from '../../Ui/Cli/TrophiesCatchUpAnnounce.ts';
 import WeekScreenshotWinner from '../../Ui/Cli/WeekScreenshotWinner.ts';
 import { InMemoryClient } from '../Bot/InMemory/InMemoryClient.ts';
 import type { JobStateRepository } from '../../Domain/Job/JobStateRepository.ts';
@@ -403,6 +404,7 @@ myContainer.bind(FixOldTrophies).toSelf();
 // M9.1 — manual, operator-run reconciliation of the checked-in AutoMod
 // config; see ApplyAutoModConfig.ts for why this is not a scheduled Job.
 myContainer.bind(ApplyAutoModConfig).toSelf();
+myContainer.bind(TrophiesCatchUpAnnounce).toSelf();
 
 // Jobs (M6.1, M6.8) — an in-process replacement for the deleted `scheduler/`
 // container. Register a new job here alongside its dependencies; it becomes

--- a/discord-bot/src/Infrastructure/DependencyInjection/inversify.config.ts
+++ b/discord-bot/src/Infrastructure/DependencyInjection/inversify.config.ts
@@ -13,6 +13,7 @@ import EventDispatcher from '../../Application/Event/EventDispatcher/EventDispat
 import type { HttpClient } from '../../Domain/Http/HttpClient.ts';
 import RetryHttpClient from '../Http/RetryHttpClient.ts';
 import FetchHttpClient from '../Http/FetchHttpClient.ts';
+import BrowserFetchHttpClient from '../Http/BrowserFetchHttpClient.ts';
 import type { TrophySource } from '../../Domain/Trophy/TrophySource.ts';
 import { PsnProfilesTrophySource } from '../Trophy/PsnProfilesTrophySource.ts';
 import { PingHandler } from '../../Application/Query/Ping/PingHandler.ts';
@@ -229,7 +230,41 @@ myContainer.bind<EventDispatcher>(EventDispatcher).toSelf();
 myContainer.bind(FetchHttpClient).toSelf();
 myContainer.bind(RetryHttpClient).toSelf();
 myContainer.bind<HttpClient>(TYPES.HttpClient).to(RetryHttpClient);
-myContainer.bind<TrophySource>(TYPES.TrophySource).to(PsnProfilesTrophySource);
+myContainer.bind(BrowserFetchHttpClient).toSelf();
+
+// PSNProfiles is behind a Cloudflare challenge that plain `fetch` cannot
+// clear from anywhere, and that a headless browser cannot clear from a
+// datacenter IP either — see BrowserFetchHttpClient for the measurements.
+// When a psn-fetch sidecar is configured, the trophy source (and only the
+// trophy source) goes through it; everything else keeps using
+// RetryHttpClient. Unconfigured, this falls back to the direct client so
+// tests and local development are unchanged — the trophy source is
+// constructed with a plain HttpClient either way and knows nothing about
+// which one it got.
+const psnFetchConfigured =
+    (process.env.PSN_FETCH_URL ?? '') !== '' && (process.env.PSN_FETCH_TOKEN ?? '') !== '';
+
+myContainer
+    .bind<TrophySource>(TYPES.TrophySource)
+    .toDynamicValue(
+        (context) =>
+            new PsnProfilesTrophySource(
+                psnFetchConfigured
+                    ? context.get(BrowserFetchHttpClient)
+                    : context.get<HttpClient>(TYPES.HttpClient),
+            ),
+    );
+
+if (!psnFetchConfigured) {
+    myContainer
+        .get<Logger>(TYPES.Logger)
+        .warn(
+            'PSN_FETCH_URL/PSN_FETCH_TOKEN are not both set, so trophies:sync will fetch ' +
+                'PSNProfiles directly. That is expected in tests and local development, but in ' +
+                'production it will fail on every request: PSNProfiles serves a Cloudflare ' +
+                'challenge that only the psn-fetch sidecar can clear.',
+        );
+}
 
 // Bot
 // M1.3: DISCORD_TOKEN / DISCORD_CLIENT_ID are required for the live bot
@@ -400,26 +435,29 @@ myContainer.get(JobRunner).register(myContainer.get(RelinkScreenshotsJob));
 myContainer.get(JobRunner).register(myContainer.get(AdsLifecycleJob));
 myContainer.get(JobRunner).register(myContainer.get(AdsReconcileJob));
 
-// trophies:sync (M7.3) is always bound above and always runnable by hand
-// (`bun run:command jobs:run trophies:sync --dry-run`), but registering it
-// with the scheduler is opt-in. Merging to `main` *is* the deploy pipeline
-// here, so an unconditional registration would start writing trophy rows
-// and setting isBanned/isExcluded on ~118 real community members every 10
-// minutes the moment this lands, before anyone had watched a single run —
-// and since isExcluded removes a profile from future consideration with no
-// automatic un-flagging, a bad first run is effectively permanent. See
-// TrophiesSyncJob's doc comment ("Scheduling is opt-in") for the full
+// trophies:sync (M7.3) is always *registered* — so it is listed by
+// `jobs:run list` and runnable by hand at any time — but whether the ticker
+// may start it on its own is opt-in. Merging to `main` is the deploy
+// pipeline here, so an unconditionally scheduled job would start writing
+// trophy rows and setting isBanned/isExcluded on ~118 real community members
+// every 10 minutes the moment this lands, before anyone had watched a single
+// run — and since isExcluded removes a profile from future consideration
+// with no automatic un-flagging, a bad first run is effectively permanent.
+// See TrophiesSyncJob's doc comment ("Scheduling is opt-in") for the full
 // reasoning and the enable runbook. Mirrors the DISCORD_TOKEN-unset ->
 // InMemoryClient pattern above: a silently-disabled feature is its own
 // failure mode (that one is why M1.3 exists), so this logs clearly rather
-// than just quietly not registering.
-if (process.env.TROPHIES_SYNC_ENABLED === 'true') {
-    myContainer.get(JobRunner).register(myContainer.get(TrophiesSyncJob));
-} else {
+// than just quietly not scheduling.
+const trophiesSyncScheduled = process.env.TROPHIES_SYNC_ENABLED === 'true';
+myContainer
+    .get(JobRunner)
+    .register(myContainer.get(TrophiesSyncJob), { scheduled: trophiesSyncScheduled });
+
+if (!trophiesSyncScheduled) {
     myContainer
         .get<Logger>(TYPES.Logger)
         .warn(
-            'trophies:sync is bound but NOT scheduled (TROPHIES_SYNC_ENABLED is not "true"). ' +
+            'trophies:sync is registered but NOT scheduled (TROPHIES_SYNC_ENABLED is not "true"). ' +
                 'Dry-run it first — bun run:command jobs:run trophies:sync --dry-run — read the ' +
                 'report (especially any newly-flagged profiles), then set ' +
                 'TROPHIES_SYNC_ENABLED=true to schedule it every 10 minutes.',

--- a/discord-bot/src/Infrastructure/Http/BrowserFetchHttpClient.ts
+++ b/discord-bot/src/Infrastructure/Http/BrowserFetchHttpClient.ts
@@ -1,0 +1,98 @@
+import { inject, injectable } from 'inversify';
+import { type HttpClient } from '../../Domain/Http/HttpClient.ts';
+import { TYPES } from '../DependencyInjection/types.ts';
+import type Logger from '../../Application/Logger/Logger.ts';
+
+/**
+ * Fetches pages through `psn-fetch`, a browser-backed sidecar, instead of
+ * fetching them directly.
+ *
+ * ## Why this exists
+ *
+ * PSNProfiles sits behind a Cloudflare managed challenge. It is not a block —
+ * it is a JavaScript interstitial — so getting past it needs something that
+ * actually runs the challenge. Measured against the live site (2026-08-21,
+ * six pages per cell, three page types):
+ *
+ * | Client                                  | Hetzner (HTZ1) | Home IP |
+ * | --------------------------------------- | -------------- | ------- |
+ * | `fetch` / curl, any User-Agent          | 0/6            | 0/6     |
+ * | curl-impersonate (real Chrome JA3)      | 0/2            | —       |
+ * | FlareSolverr                            | 0/3 (timeouts) | —       |
+ * | Playwright, headless                    | 0/6            | —       |
+ * | Playwright, headed under xvfb           | 0/6            | 1/6     |
+ * | patchright, headed under xvfb           | 0/6            | **6/6** |
+ *
+ * Two independent conditions have to hold at once, which is why the simpler
+ * fixes all failed:
+ *
+ * 1. **A patched browser.** Stock Playwright leaks its automation via CDP
+ *    (`Runtime.enable`); it clears the first navigation of a fresh profile
+ *    and is challenged on every one after. patchright closes those leaks.
+ *    Note the fingerprint theories that did *not* hold: TLS/JA3 alone did
+ *    nothing, and the passing runs were software-rendered (SwiftShader),
+ *    so it is not a WebGL/GPU check.
+ * 2. **A non-datacenter IP.** Hetzner's ASN fails 0/12 regardless of client.
+ *    This is why the sidecar has to live off HTZ1 rather than beside the bot.
+ *
+ * ## Consequences for the caller
+ *
+ * `TYPES.HttpClient` still resolves to `RetryHttpClient` for everything else;
+ * only `PsnProfilesTrophySource` is given this one. Requests are serialised
+ * and throttled inside the sidecar, next to the browser that owns the
+ * Cloudflare clearance cookie, rather than here — a second bot process would
+ * otherwise silently double the request rate against a site with no API.
+ */
+@injectable()
+export default class BrowserFetchHttpClient implements HttpClient {
+    private readonly baseUrl: string;
+    private readonly token: string;
+    private readonly timeoutMs: number;
+
+    constructor(@inject(TYPES.Logger) private readonly logger: Logger) {
+        this.baseUrl = (process.env.PSN_FETCH_URL ?? '').replace(/\/+$/, '');
+        this.token = process.env.PSN_FETCH_TOKEN ?? '';
+        this.timeoutMs = Number(process.env.PSN_FETCH_TIMEOUT_MS ?? 120_000);
+    }
+
+    async get(url: string, _options?: any): Promise<any> {
+        const endpoint = `${this.baseUrl}/fetch?url=${encodeURIComponent(url)}`;
+
+        // The sidecar drives a real browser through a Cloudflare challenge,
+        // so a single request can legitimately take tens of seconds. Without
+        // an explicit signal this would sit on the runtime's default timeout
+        // and stall the whole sync walk.
+        const response = await fetch(endpoint, {
+            headers: { Authorization: `Bearer ${this.token}` },
+            signal: AbortSignal.timeout(this.timeoutMs),
+        });
+
+        if (!response.ok) {
+            const detail = await response.text().catch(() => '');
+            // Thrown, not returned: RetryHttpClient's backoff keys off a
+            // throw, and a challenge page that slipped through would
+            // otherwise be handed to the parser as if it were a profile.
+            throw new Error(
+                `psn-fetch request for ${url} failed with status code ${response.status}` +
+                    (detail ? `: ${detail.slice(0, 200)}` : ''),
+            );
+        }
+
+        return response.text();
+    }
+
+    // The trophy source only ever reads. Leaving these as explicit throws
+    // keeps the HttpClient contract honest instead of quietly no-oping a
+    // write someone adds later.
+    async post(): Promise<never> {
+        throw new Error('BrowserFetchHttpClient is read-only: post() is not supported');
+    }
+
+    async put(): Promise<never> {
+        throw new Error('BrowserFetchHttpClient is read-only: put() is not supported');
+    }
+
+    async delete(): Promise<never> {
+        throw new Error('BrowserFetchHttpClient is read-only: delete() is not supported');
+    }
+}

--- a/discord-bot/src/Infrastructure/Job/JobRunner.ts
+++ b/discord-bot/src/Infrastructure/Job/JobRunner.ts
@@ -10,6 +10,17 @@ import type Logger from '../../Application/Logger/Logger.ts';
 interface RegisteredJob {
     job: Job;
     cron: Cron;
+    /**
+     * Whether the scheduler may start this job on a tick. A job registered
+     * with `scheduled: false` is still fully addressable by hand
+     * (`listJobs`, `runNow`) — see `register`.
+     */
+    scheduled: boolean;
+}
+
+export interface RegisterOptions {
+    /** Defaults to true. `false` registers the job for manual runs only. */
+    scheduled?: boolean;
 }
 
 const DEFAULT_TICK_INTERVAL_MS = 60_000;
@@ -63,17 +74,35 @@ export class JobRunner {
     }
 
     /**
-     * Adds a job to the schedule. Call this during wiring (inversify.config.ts)
+     * Adds a job to the runner. Call this during wiring (inversify.config.ts)
      * before `start()` — a job registered after `start()` will simply not be
      * picked up until the process restarts, since jobs are also warmed from
      * persisted state once, at start.
+     *
+     * `scheduled: false` registers a job the ticker will never start on its
+     * own, while leaving it runnable by hand. That distinction exists because
+     * conflating the two made the documented enable-a-job runbook impossible:
+     * a job gated behind an env flag was not in this map at all, so
+     * `jobs:run <name> --dry-run` — the very command the operator is told to
+     * preview with before flipping the flag — failed with `Unknown job`. The
+     * only way to dry-run was to enable the schedule first, which is exactly
+     * what the gate exists to prevent.
      */
-    register(job: Job): void {
+    register(job: Job, options: RegisterOptions = {}): void {
         if (this.jobs.has(job.name)) {
             throw new Error(`Job "${job.name}" is already registered`);
         }
 
-        this.jobs.set(job.name, { job, cron: new Cron(job.schedule) });
+        this.jobs.set(job.name, {
+            job,
+            cron: new Cron(job.schedule),
+            scheduled: options.scheduled ?? true,
+        });
+    }
+
+    /** Names the ticker may start on its own — `listJobs()` minus the manual-only ones. */
+    listScheduledJobs(): string[] {
+        return [...this.jobs.values()].filter((r) => r.scheduled).map((r) => r.job.name);
     }
 
     listJobs(): string[] {
@@ -159,6 +188,9 @@ export class JobRunner {
 
         for (const registered of this.jobs.values()) {
             if (this.stopped) break;
+            // Manual-only: registered so it can be run by hand, but never
+            // started by the ticker. See `register`.
+            if (!registered.scheduled) continue;
             if (this.running.has(registered.job.name)) continue;
             if (!this.isDue(registered, now)) continue;
 

--- a/discord-bot/src/Infrastructure/Orm/OrmTrophyRepository.ts
+++ b/discord-bot/src/Infrastructure/Orm/OrmTrophyRepository.ts
@@ -5,6 +5,7 @@ import { Trophy, type TrophyArray } from '../../Domain/Trophy/Trophy';
 import { TrophyId } from '../../Domain/Trophy/TrophyId';
 import type { TrophyRepository } from '../../Domain/Trophy/TrophyRepository';
 import type { TrophyRankData } from '../../Domain/Trophy/TrophyRankData';
+import type { CatchUpSummary } from '../../Domain/Trophy/CatchUpSummary';
 import type { UserPosition } from '../../Domain/Trophy/UserPosition';
 import RecordNotFound from '../../Domain/RecordNotFound';
 import { TrophyAlreadyClaimed } from '../../Domain/Trophy/TrophyAlreadyClaimed';
@@ -25,6 +26,15 @@ interface UserRankRow {
     position: number;
     points: number;
     num_trophies: number;
+}
+
+interface CatchUpSummaryRow {
+    userId: string;
+    psnProfile: string | null;
+    points: number;
+    num_trophies: number;
+    first_completion: Date;
+    last_completion: Date;
 }
 
 /**
@@ -304,6 +314,35 @@ export class OrmTrophyRepository implements TrophyRepository {
         `);
 
         return Number(rows[0]?.total ?? 0);
+    }
+
+    async findCatchUpSummariesSince(since: Date): Promise<CatchUpSummary[]> {
+        const rows = await this.prismaClient.$queryRaw<CatchUpSummaryRow[]>(Prisma.sql`
+            SELECT
+                tp.userId AS userId,
+                tp.psnProfile AS psnProfile,
+                CAST(COALESCE(SUM(t.points), 0) AS SIGNED) AS points,
+                CAST(COUNT(t.id) AS SIGNED) AS num_trophies,
+                MIN(t.completionDate) AS first_completion,
+                MAX(t.completionDate) AS last_completion
+            FROM trophyprofiles tp
+            INNER JOIN trophies t ON t.trophyProfile = tp.id
+            WHERE tp.isExcluded = false
+              AND tp.userId IS NOT NULL
+              AND tp.userId <> ''
+              AND t.completionDate >= ${since}
+            GROUP BY tp.id, tp.userId, tp.psnProfile
+            ORDER BY points DESC, num_trophies DESC, tp.psnProfile ASC
+        `);
+
+        return rows.map((row) => ({
+            userId: row.userId,
+            psnProfile: row.psnProfile ?? '',
+            points: Number(row.points ?? 0),
+            numTrophies: Number(row.num_trophies ?? 0),
+            firstCompletionDate: new Date(row.first_completion),
+            lastCompletionDate: new Date(row.last_completion),
+        }));
     }
 
     /**

--- a/discord-bot/src/Infrastructure/Trophy/PsnProfilesTrophySource.ts
+++ b/discord-bot/src/Infrastructure/Trophy/PsnProfilesTrophySource.ts
@@ -106,17 +106,34 @@ export class PsnProfilesTrophySource implements TrophySource {
 
     // -- Parsing ----------------------------------------------------------
 
-    private parseProfileRank(html: string): TrophyProfileRank {
-        const worldRankText = this.findTagByClass(html, 'span', 'rank')?.inner.trim();
-        const countryRankText = this.findTagByClass(html, 'span', 'country-rank')?.inner.trim();
+    /**
+     * The two stat boxes at the top of a profile. Real markup nests the
+     * number inside an `<a>` *and* a label span:
+     *
+     *     <span class="rank stat grow red">
+     *       <a href="/leaderboard/..."> 26,475<span>World Rank</span> </a>
+     *     </span>
+     *
+     * so the inner content has to be read with a nesting-aware scan and then
+     * flattened to text — a non-greedy `</span>` match stops at the *label's*
+     * closing tag and yields `<a href=...` , which parses as NaN. That is not
+     * a cosmetic bug: `TrophiesSyncJob` reads "both ranks null" as "this
+     * profile is banned/private" and auto-excludes the member, so a parser
+     * that always returns null would auto-exclude everyone it looked at.
+     */
+    private parseProfileRank(rawHtml: string): TrophyProfileRank {
+        const html = this.stripComments(rawHtml);
 
         return {
-            worldRank: this.parseCommaSeparatedInt(worldRankText),
-            countryRank: this.parseCommaSeparatedInt(countryRankText),
+            worldRank: this.parseCommaSeparatedInt(this.findTextByClass(html, 'span', 'rank')),
+            countryRank: this.parseCommaSeparatedInt(
+                this.findTextByClass(html, 'span', 'country-rank'),
+            ),
         };
     }
 
-    private parseProfileTrophies(html: string): string[] {
+    private parseProfileTrophies(rawHtml: string): string[] {
+        const html = this.stripComments(rawHtml);
         const urls: string[] = [];
 
         for (const row of this.findRowsByClass(html, 'platinum')) {
@@ -129,38 +146,40 @@ export class PsnProfilesTrophySource implements TrophySource {
         return urls;
     }
 
-    private parsePlatinumTrophyData(html: string, trophyUrl: string): PlatinumTrophyData {
-        // Scope to the <tbody> so a <thead> row never gets mistaken for the
-        // (possibly blank) first data row below.
-        const tbodyHtml = this.extractFirstTagInner(html, 'tbody') ?? html;
-        const rows = this.extractRows(tbodyHtml);
-        if (rows.length === 0) {
+    /**
+     * A trophy page's platinum row, located by what it *is* rather than by
+     * where it sits. The old "first row of the first `<tbody>`" rule was
+     * written against a hand-made fixture; a real page has 13 `<tbody>`
+     * elements, and the first two are the profile summary and the
+     * base-game/DLC breakdown — neither of which carries a completion date.
+     *
+     * The platinum row is the one holding both the platinum icon and a
+     * completion date, which is stable regardless of how many summary
+     * tables PSNProfiles adds above the trophy list.
+     */
+    private parsePlatinumTrophyData(rawHtml: string, trophyUrl: string): PlatinumTrophyData {
+        const row = this.findPlatinumRow(this.stripComments(rawHtml));
+        if (row === null) {
             throw new Error("Couldn't find trophy table body!");
         }
 
-        // HACK, ported verbatim from the old bot: some trophy pages have a
-        // blank row in the first position. Jump to the second one if so.
-        let row = rows[0];
-        if (row !== undefined && row.inner.trim() === '') {
-            row = rows[1] as HtmlTag;
-        }
-
-        if (row === undefined) {
-            throw new Error("Couldn't find trophy table body!");
-        }
-
-        const rowClass = this.extractAttr(row.attrs, 'class') ?? '';
-        if (!this.hasClassToken(rowClass, 'completed')) {
+        if (!this.hasClassToken(this.extractAttr(row.attrs, 'class') ?? '', 'completed')) {
             throw new TrophyNotEarnedYet(trophyUrl);
         }
 
-        const percentageText = this.findTagByClass(row.inner, 'span', 'typo-top')?.inner.trim();
+        const percentageText = this.findRarityPercentage(row.inner);
         if (!percentageText) {
             throw new Error("Couldn't find trophy percentage!");
         }
         const percentage = parseFloat(percentageText);
+        if (isNaN(percentage)) {
+            throw new Error(`Trophy percentage "${percentageText}" is invalid!`);
+        }
 
-        const dateText = this.findTagByClass(row.inner, 'span', 'typo-top-date')?.inner.trim();
+        // Flattened to text first: the real markup is
+        // `<nobr>2<sup>nd</sup> Sep 2021</nobr>`, and dayjs cannot parse that
+        // with the tags still in it.
+        const dateText = this.findTextByClass(row.inner, 'span', 'typo-top-date');
         if (!dateText) {
             throw new Error("Couldn't find completion date!");
         }
@@ -171,6 +190,70 @@ export class PsnProfilesTrophySource implements TrophySource {
         }
 
         return { percentage, completionDate: completionDate.toDate() };
+    }
+
+    /**
+     * The platinum trophy's `<tr>`.
+     *
+     * Identified by `title="Platinum"`, which on a real page appears exactly
+     * once — unlike `platinum-icon.png`, which also appears in the profile
+     * summary and base-game/DLC tables above. Deliberately *not* keyed on
+     * having a completion date: an unearned platinum has no date, and must
+     * still be found so the caller can raise `TrophyNotEarnedYet` (which the
+     * sync job skips) rather than a generic parse error (which it counts as
+     * a failure).
+     */
+    private findPlatinumRow(html: string): HtmlTag | null {
+        return (
+            this.findRowWhere(html, (inner) => /title="Platinum"/.test(inner)) ??
+            // Simpler markup with no per-trophy icon: fall back to the first
+            // row carrying rarity/date cells at all.
+            this.findRowWhere(html, (inner) => /typo-top(-date)?"/.test(inner))
+        );
+    }
+
+    private findRowWhere(html: string, predicate: (inner: string) => boolean): HtmlTag | null {
+        const openTag = /<tr\b([^>]*)>/g;
+        let match: RegExpExecArray | null;
+
+        while ((match = openTag.exec(html)) !== null) {
+            const inner = this.balancedInner(html, 'tr', match.index);
+            if (predicate(inner)) {
+                return { attrs: match[1] ?? '', inner };
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * PSNProfiles renders *two* rarity figures per row: its own site rarity
+     * (shown by default, in the `hover-hide` cell) and Sony's global figure
+     * (revealed on hover, in `hover-show`). The TP ladder in
+     * `calculateTrophyPoints` was calibrated against the site rarity — the
+     * one the old jQuery scraper picked up because it was the only one
+     * rendered at the time — so this deliberately reads `hover-hide` rather
+     * than simply taking the first `typo-top` in the row, which is now the
+     * hover value and would misprice every trophy.
+     *
+     * Verified against six trophies whose stored TP predates this change:
+     * the four whose rarity has been stable since (50/100/250/500 TP) all
+     * reproduce exactly. The two that do not are both 2021 releases whose
+     * platinum has genuinely become more common since it was recorded —
+     * rarity drift in the source data, not a parse error.
+     */
+    private findRarityPercentage(rowInner: string): string | null {
+        const hoverHideCell = rowInner.search(/<td[^>]*\bclass="[^"]*\bhover-hide\b[^"]*"/);
+        if (hoverHideCell >= 0) {
+            const cell = this.balancedInner(rowInner, 'td', hoverHideCell);
+            const text = this.findTextByClass(cell, 'span', 'typo-top');
+            if (text) {
+                return text;
+            }
+        }
+
+        // Older/simpler markup renders a single rarity figure per row.
+        return this.findTextByClass(rowInner, 'span', 'typo-top');
     }
 
     // -- Tiny regex HTML helpers ------------------------------------------
@@ -192,6 +275,89 @@ export class PsnProfilesTrophySource implements TrophySource {
                 this.hasClassToken(this.extractAttr(match.attrs, 'class') ?? '', classToken),
             ) ?? null
         );
+    }
+
+    /**
+     * Inner content of the tag opening at `openIndex`, honouring nesting of
+     * the same tag name. The non-greedy `matchTags` below cannot do this —
+     * it stops at the first closing tag, which is wrong for every block on a
+     * real PSNProfiles page that wraps a label span inside a stat span, or a
+     * `<td>` inside a `<tr>` inside a `<table>`.
+     */
+    private balancedInner(html: string, tag: string, openIndex: number): string {
+        const contentStart = html.indexOf('>', openIndex) + 1;
+        const opening = new RegExp(`<${tag}\\b`, 'g');
+        const closing = new RegExp(`</${tag}>`, 'g');
+        let depth = 1;
+        let cursor = contentStart;
+
+        while (depth > 0) {
+            opening.lastIndex = cursor;
+            closing.lastIndex = cursor;
+            const nextOpen = opening.exec(html);
+            const nextClose = closing.exec(html);
+
+            // Unbalanced markup: treat the rest of the document as content
+            // rather than throwing — the callers all pattern-match on what
+            // they find, so a too-long slice fails their checks safely.
+            if (nextClose === null) {
+                return html.slice(contentStart);
+            }
+
+            if (nextOpen !== null && nextOpen.index < nextClose.index) {
+                depth++;
+                cursor = nextOpen.index + 1;
+                continue;
+            }
+
+            depth--;
+            if (depth === 0) {
+                return html.slice(contentStart, nextClose.index);
+            }
+            cursor = nextClose.index + 1;
+        }
+
+        return html.slice(contentStart);
+    }
+
+    /**
+     * Flattened text of the first `<tag>` whose class list includes
+     * `classToken` — tags stripped, entities and whitespace normalised, so
+     * `<nobr>2<sup>nd</sup> Sep 2021</nobr>` reads as `2nd Sep 2021`.
+     */
+    private findTextByClass(html: string, tag: string, classToken: string): string | null {
+        const opening = new RegExp(`<${tag}\\b([^>]*)>`, 'g');
+        let match: RegExpExecArray | null;
+
+        while ((match = opening.exec(html)) !== null) {
+            if (this.hasClassToken(this.extractAttr(match[1] ?? '', 'class') ?? '', classToken)) {
+                return this.textOf(this.balancedInner(html, tag, match.index));
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Drops `<!-- ... -->` before anything is scanned. Commented-out markup
+     * is still markup to a regex, so a stale block left in the page source
+     * would otherwise be indistinguishable from the live one — and would win,
+     * since these helpers all take the *first* match.
+     */
+    private stripComments(html: string): string {
+        return html.replace(/<!--[\s\S]*?-->/g, '');
+    }
+
+    /** Markup → plain text: drop tags, decode the few entities PSNProfiles emits, collapse whitespace. */
+    private textOf(html: string): string {
+        return html
+            .replace(/<[^>]*>/g, '')
+            .replace(/&nbsp;/g, ' ')
+            .replace(/&amp;/g, '&')
+            .replace(/&#39;/g, "'")
+            .replace(/&quot;/g, '"')
+            .replace(/\s+/g, ' ')
+            .trim();
     }
 
     /** Inner content of the first `<tag ...>...</tag>` (no nested same-name tags), or null if absent. */
@@ -219,11 +385,24 @@ export class PsnProfilesTrophySource implements TrophySource {
         return classAttr.split(/\s+/).includes(token);
     }
 
-    private parseCommaSeparatedInt(text: string | undefined): number | null {
+    /**
+     * Leading integer of a flattened stat, e.g. `26,475 World Rank` -> 26475.
+     * Anchored to the start and matched explicitly rather than relying on
+     * `parseInt` stopping at the first non-digit, so a stat box that ever
+     * renders its label *before* its number fails loudly (null) instead of
+     * silently returning a number parsed out of the wrong place.
+     */
+    private parseCommaSeparatedInt(text: string | null | undefined): number | null {
         if (!text) {
             return null;
         }
-        const value = parseInt(text.replace(/,/g, ''), 10);
+
+        const digits = text.trim().match(/^([\d,]+)/);
+        if (digits?.[1] === undefined) {
+            return null;
+        }
+
+        const value = parseInt(digits[1].replace(/,/g, ''), 10);
         return isNaN(value) ? null : value;
     }
 }

--- a/discord-bot/src/Infrastructure/Trophy/PsnProfilesTrophySource.ts
+++ b/discord-bot/src/Infrastructure/Trophy/PsnProfilesTrophySource.ts
@@ -342,22 +342,37 @@ export class PsnProfilesTrophySource implements TrophySource {
      * Drops `<!-- ... -->` before anything is scanned. Commented-out markup
      * is still markup to a regex, so a stale block left in the page source
      * would otherwise be indistinguishable from the live one — and would win,
-     * since these helpers all take the *first* match.
+     * since these helpers all take the *first* match. Repeats to a fixed
+     * point so a crafted `<!--<!---->` can't leave a dangling `<!--` behind.
      */
     private stripComments(html: string): string {
-        return html.replace(/<!--[\s\S]*?-->/g, '');
+        return this.replaceToFixedPoint(html, /<!--[\s\S]*?-->/g, '');
     }
 
     /** Markup → plain text: drop tags, decode the few entities PSNProfiles emits, collapse whitespace. */
     private textOf(html: string): string {
-        return html
-            .replace(/<[^>]*>/g, '')
+        return this.stripTags(html)
             .replace(/&nbsp;/g, ' ')
-            .replace(/&amp;/g, '&')
             .replace(/&#39;/g, "'")
             .replace(/&quot;/g, '"')
+            .replace(/&amp;/g, '&')
             .replace(/\s+/g, ' ')
             .trim();
+    }
+
+    /** Strips tags to a fixed point so a crafted `<scr<script>ipt>` can't leave a reassembled tag behind. */
+    private stripTags(html: string): string {
+        return this.replaceToFixedPoint(html, /<[^>]*>/g, '');
+    }
+
+    private replaceToFixedPoint(input: string, pattern: RegExp, replacement: string): string {
+        let previous: string;
+        let result = input;
+        do {
+            previous = result;
+            result = result.replace(pattern, replacement);
+        } while (result !== previous);
+        return result;
     }
 
     /** Inner content of the first `<tag ...>...</tag>` (no nested same-name tags), or null if absent. */

--- a/discord-bot/src/Ui/Cli/TrophiesCatchUpAnnounce.ts
+++ b/discord-bot/src/Ui/Cli/TrophiesCatchUpAnnounce.ts
@@ -1,0 +1,211 @@
+import { inject, injectable } from 'inversify';
+import dayjs from 'dayjs';
+import type { ConsoleCommand } from '../../Domain/Console/ConsoleCommand';
+import { TYPES } from '../../Infrastructure/DependencyInjection/types';
+import type { TrophyRepository } from '../../Domain/Trophy/TrophyRepository';
+import type { CatchUpSummary } from '../../Domain/Trophy/CatchUpSummary';
+import type { GuildClient } from '../../Domain/Community/GuildClient';
+import { CommunityChannels } from '../../Domain/Community/CommunityChannels';
+import type Logger from '../../Application/Logger/Logger';
+import { sleep } from '../../Application/Shared/sleep';
+
+/** The last platinum recorded before the crawl froze — see this class's doc comment. */
+const DEFAULT_SINCE = '2024-11-30';
+
+/**
+ * Discord's channel-message rate limit is generous but not unlimited, and
+ * this posts one message per member in a single burst. A second between
+ * sends keeps a 60-member run comfortably inside it.
+ */
+const SEND_INTERVAL_MS = 1000;
+
+/** Belt and braces on a one-shot mass mention: refuse to post more than this without being told to. */
+const DEFAULT_MAX_MESSAGES = 60;
+
+export interface CatchUpAnnounceArgs {
+    since: Date;
+    post: boolean;
+    maxMessages: number;
+}
+
+export function parseCatchUpAnnounceArgs(inputArgs: unknown): CatchUpAnnounceArgs {
+    const args = Array.isArray(inputArgs)
+        ? inputArgs.filter((arg) => arg !== undefined && arg !== null).map((arg) => String(arg))
+        : [];
+
+    let sinceArg = DEFAULT_SINCE;
+    let post = false;
+    let maxMessages = DEFAULT_MAX_MESSAGES;
+
+    for (const raw of args) {
+        if (raw === '--post') {
+            post = true;
+        } else if (raw.startsWith('--since=')) {
+            sinceArg = raw.slice('--since='.length);
+        } else if (raw.startsWith('--max=')) {
+            const parsed = Number(raw.slice('--max='.length));
+            if (!Number.isFinite(parsed) || parsed <= 0) {
+                throw new Error(`Invalid --max value: "${raw}"`);
+            }
+            maxMessages = Math.trunc(parsed);
+        } else {
+            throw new Error(
+                `Unknown argument "${raw}". Usage: trophies:catchup-announce ` +
+                    `[--since=YYYY-MM-DD] [--max=N] [--post]`,
+            );
+        }
+    }
+
+    const since = dayjs(sinceArg, 'YYYY-MM-DD', true);
+    if (!since.isValid()) {
+        throw new Error(`Invalid --since date "${sinceArg}", expected YYYY-MM-DD`);
+    }
+
+    return { since: since.startOf('day').toDate(), post, maxMessages };
+}
+
+/**
+ * `trophies:catchup-announce` — the one-off "the trophy hall is alive again"
+ * post.
+ *
+ * ## Why this is a console command and not part of the sync
+ *
+ * `trophies:sync` announces trophies *as it credits them*, and its flood
+ * guards are tuned for steady state: a profile gaining more than three
+ * trophies in one run collapses to a single summary, and the whole run is
+ * capped at ten messages. Those are the right defaults forever after — and
+ * exactly the wrong shape for the one moment when the crawl comes back from
+ * a 20-month outage, because the backfill is spread over many runs, so what
+ * a member would see is a few scattered "we synced 47 trophies" lines with
+ * no explanation of why their old platinums are suddenly being mentioned.
+ *
+ * So the backfill runs *silently* (`TROPHIES_ANNOUNCE_ENABLED` unset), and
+ * this command posts one deliberate message per member afterwards,
+ * summarising everything they earned during the outage. Then normal
+ * per-trophy announcements get switched on for good.
+ *
+ * ## Safety
+ *
+ * This mentions real people, once, in bulk — so unlike the rest of the
+ * console commands it **previews by default** and only posts when given
+ * `--post`, and it refuses to send more than `--max` messages (default 60)
+ * so a wrong `--since` cannot turn into a channel-wide spray. Members with
+ * no linked Discord account, or excluded profiles, are filtered out in SQL:
+ * there is nobody to mention.
+ *
+ * ```bash
+ * # preview (default)
+ * bun run:command trophies:catchup-announce --since=2024-11-30
+ * # send it
+ * bun run:command trophies:catchup-announce --since=2024-11-30 --post
+ * ```
+ */
+@injectable()
+export default class TrophiesCatchUpAnnounce implements ConsoleCommand {
+    public static commandName = 'trophies:catchup-announce';
+
+    constructor(
+        @inject(TYPES.TrophyRepository) private readonly trophyRepository: TrophyRepository,
+        @inject(TYPES.GuildClient) private readonly guildClient: GuildClient,
+        @inject(TYPES.Logger) private readonly logger: Logger,
+    ) {}
+
+    configureArgs(_inputArgs: any): void {}
+
+    public async run(inputArgs: any): Promise<number> {
+        const { since, post, maxMessages } = parseCatchUpAnnounceArgs(inputArgs);
+
+        const summaries = await this.trophyRepository.findCatchUpSummariesSince(since);
+
+        this.logger.info('trophies:catchup-announce.found', {
+            since: dayjs(since).format('YYYY-MM-DD'),
+            members: summaries.length,
+            totalTrophies: summaries.reduce((sum, s) => sum + s.numTrophies, 0),
+            totalPoints: summaries.reduce((sum, s) => sum + s.points, 0),
+            post,
+        });
+
+        if (summaries.length === 0) {
+            this.logger.info('trophies:catchup-announce.nothing-to-announce', {
+                since: dayjs(since).format('YYYY-MM-DD'),
+            });
+            return 0;
+        }
+
+        if (summaries.length > maxMessages) {
+            // Refused rather than truncated: a count this far above
+            // expectations usually means `--since` is wrong, and quietly
+            // posting the first N would be the worst of both outcomes.
+            this.logger.error('trophies:catchup-announce.too-many', {
+                members: summaries.length,
+                maxMessages,
+                message:
+                    'Refusing to post: more members than --max. Check --since, ' +
+                    'or raise --max deliberately.',
+            });
+            return 1;
+        }
+
+        let sent = 0;
+        let failed = 0;
+
+        for (const summary of summaries) {
+            const message = this.buildMessage(summary, since);
+
+            if (!post) {
+                this.logger.info('trophies:catchup-announce.preview', {
+                    psnProfile: summary.psnProfile,
+                    trophies: summary.numTrophies,
+                    points: summary.points,
+                    message,
+                });
+                continue;
+            }
+
+            try {
+                await this.guildClient.sendMessage(CommunityChannels.TROPHIES, message);
+                sent++;
+            } catch (error) {
+                // One member's message failing must not abandon the rest of
+                // the run — the whole point is that everybody hears about it.
+                failed++;
+                this.logger.error('trophies:catchup-announce.send-failed', {
+                    psnProfile: summary.psnProfile,
+                    error: error instanceof Error ? error.message : String(error),
+                });
+            }
+
+            await sleep(SEND_INTERVAL_MS);
+        }
+
+        this.logger.info('trophies:catchup-announce.finish', {
+            members: summaries.length,
+            sent,
+            failed,
+            previewOnly: !post,
+        });
+
+        return failed > 0 ? 1 : 0;
+    }
+
+    private buildMessage(summary: CatchUpSummary, since: Date): string {
+        const trophyWord = summary.numTrophies === 1 ? 'troféu platina' : 'troféus platina';
+
+        return (
+            `🏆 Parabéns <@${summary.userId}>! O ranking de troféus está de volta — ` +
+            `desde ${this.formatMonth(since)} conquistaste ` +
+            `**${this.formatNumber(summary.numTrophies)} ${trophyWord}**, ` +
+            `num total de **${this.formatNumber(summary.points)} TP**. ` +
+            `Já está tudo contabilizado: vê a tua posição com \`/trophy rank\`.`
+        );
+    }
+
+    /** Matches `RankPresenter`'s month formatting rather than pulling in a dayjs locale. */
+    private formatMonth(date: Date): string {
+        return date.toLocaleDateString('pt-PT', { month: 'long', year: 'numeric' });
+    }
+
+    private formatNumber(value: number): string {
+        return value.toLocaleString('pt-PT');
+    }
+}

--- a/discord-bot/tests/Integration/Domain/Trophy/PsnProfileUrl.test.ts
+++ b/discord-bot/tests/Integration/Domain/Trophy/PsnProfileUrl.test.ts
@@ -85,6 +85,56 @@ describe('extractPsnProfileFromUrl', () => {
             url: 'https://psnprofiles.com/games/some-game/Josh_Lopes',
             expected: null,
         },
+        // PSN online ID rules. The production row `sabathian>` (registered in
+        // 2022 by the old bot's raw url.split('/')) is why these exist:
+        // PSNProfiles normalises the stray character away when fetching, so
+        // nothing failed loudly — it just rendered as `sabathian>` on every
+        // leaderboard until someone looked.
+        {
+            description: 'username with a stray character is rejected, not stored',
+            url: 'https://psnprofiles.com/sabathian>',
+            expected: null,
+        },
+        {
+            description: 'the same stray character already percent-encoded is also rejected',
+            url: 'https://psnprofiles.com/sabathian%3E',
+            expected: null,
+        },
+        {
+            description: 'stray character in a trophy URL is rejected too',
+            url: 'https://psnprofiles.com/trophies/12-grand-theft-auto-iv/sabathian>',
+            expected: null,
+        },
+        {
+            description: 'the corrected name is accepted',
+            url: 'https://psnprofiles.com/sabathian',
+            expected: 'sabathian',
+        },
+        {
+            description: 'hyphens and underscores are legal in a PSN ID',
+            url: 'https://psnprofiles.com/Zephyr-pt',
+            expected: 'Zephyr-pt',
+        },
+        {
+            description: 'too short for a PSN ID (min 3)',
+            url: 'https://psnprofiles.com/ab',
+            expected: null,
+        },
+        {
+            description: 'too long for a PSN ID (max 16)',
+            url: 'https://psnprofiles.com/abcdefghijklmnopq',
+            expected: null,
+        },
+        {
+            description: 'a 16-character PSN ID is still legal',
+            url: 'https://psnprofiles.com/abcdefghijklmnop',
+            expected: 'abcdefghijklmnop',
+        },
+        {
+            description: 'must not start with a hyphen',
+            url: 'https://psnprofiles.com/-Zephyr',
+            expected: null,
+        },
     ];
 
     for (const { description, url, expected } of cases) {

--- a/discord-bot/tests/Integration/Infrastructure/DependencyInjection/TrophiesSyncJob.container.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/DependencyInjection/TrophiesSyncJob.container.test.ts
@@ -36,6 +36,18 @@ describe('DI container — TrophiesSyncJob / FixOldTrophies', () => {
 
         const jobRunner = myContainer.get(JobRunner);
 
-        expect(jobRunner.listJobs()).not.toContain('trophies:sync');
+        expect(jobRunner.listScheduledJobs()).not.toContain('trophies:sync');
+    });
+
+    test('trophies:sync is still registered, so it can be dry-run by hand', () => {
+        // The whole point of the opt-in gate is that an operator previews a
+        // run before scheduling it. That preview goes through
+        // `jobs:run trophies:sync --dry-run`, which resolves the job out of
+        // the JobRunner — so being unscheduled must not make it unreachable.
+        expect(process.env.TROPHIES_SYNC_ENABLED).not.toBe('true');
+
+        const jobRunner = myContainer.get(JobRunner);
+
+        expect(jobRunner.listJobs()).toContain('trophies:sync');
     });
 });

--- a/discord-bot/tests/Integration/Infrastructure/Http/BrowserFetchHttpClient.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Http/BrowserFetchHttpClient.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import BrowserFetchHttpClient from '../../../../src/Infrastructure/Http/BrowserFetchHttpClient.ts';
+import InMemoryLogger from '../../../Helper/InMemoryLogger.ts';
+import Logger from '../../../../src/Application/Logger/Logger.ts';
+
+/**
+ * The sidecar itself needs a browser and a residential IP, so it is not
+ * exercised here — these cover the contract the bot depends on: the target
+ * URL survives round-tripping through the query string, a non-2xx becomes a
+ * throw (RetryHttpClient's backoff keys off that, and a challenge page must
+ * never reach the parser as if it were a profile), and the write verbs stay
+ * refused rather than silently no-oping.
+ */
+describe('BrowserFetchHttpClient', () => {
+    const originalFetch = globalThis.fetch;
+    let requests: { url: string; init?: RequestInit }[];
+
+    function client(): BrowserFetchHttpClient {
+        return new BrowserFetchHttpClient(new Logger([new InMemoryLogger()]));
+    }
+
+    function stubFetch(response: Response) {
+        globalThis.fetch = (async (url: any, init?: RequestInit) => {
+            requests.push({ url: String(url), init });
+            return response;
+        }) as typeof fetch;
+    }
+
+    beforeEach(() => {
+        requests = [];
+        process.env.PSN_FETCH_URL = 'https://example.test/psn-fetch/';
+        process.env.PSN_FETCH_TOKEN = 'test-token';
+    });
+
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+        delete process.env.PSN_FETCH_URL;
+        delete process.env.PSN_FETCH_TOKEN;
+    });
+
+    test('encodes the target URL and sends the bearer token', async () => {
+        stubFetch(new Response('<html>ok</html>', { status: 200 }));
+
+        const body = await client().get(
+            'https://psnprofiles.com/Zephyr-pt?completion=platinum&page=1',
+        );
+
+        expect(body).toBe('<html>ok</html>');
+        expect(requests).toHaveLength(1);
+        // The trailing slash on PSN_FETCH_URL must not produce `//fetch`, and
+        // the target's own `?`/`&` must not leak into the outer query string.
+        expect(requests[0]!.url).toBe(
+            'https://example.test/psn-fetch/fetch?url=' +
+                encodeURIComponent('https://psnprofiles.com/Zephyr-pt?completion=platinum&page=1'),
+        );
+        expect((requests[0]!.init!.headers as Record<string, string>).Authorization).toBe(
+            'Bearer test-token',
+        );
+    });
+
+    test('throws on a non-2xx so the caller retries instead of parsing an error page', async () => {
+        stubFetch(new Response('challenge did not clear', { status: 502 }));
+
+        await expect(client().get('https://psnprofiles.com/Zephyr-pt')).rejects.toThrow(
+            /failed with status code 502/,
+        );
+    });
+
+    test('refuses the write verbs', async () => {
+        await expect(client().post()).rejects.toThrow(/read-only/);
+        await expect(client().put()).rejects.toThrow(/read-only/);
+        await expect(client().delete()).rejects.toThrow(/read-only/);
+    });
+});

--- a/discord-bot/tests/Integration/Infrastructure/Job/JobRunner.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Job/JobRunner.test.ts
@@ -269,6 +269,40 @@ describe('JobRunner', () => {
         expect(job.callCount).toBe(1);
     });
 
+    test('a manual-only job is runnable by hand but never started by a tick', async () => {
+        // The regression this locks down: gating registration on an env flag
+        // made the documented "dry-run it before you enable it" runbook
+        // impossible, because the job was not in the runner's map at all and
+        // `jobs:run trophies:sync --dry-run` failed with `Unknown job`.
+        const job = new ScriptedJob('manual-only', '* * * * *');
+        const runner = createRunner(jobStateRepository, reporter);
+        runner.register(job, { scheduled: false });
+
+        expect(runner.listJobs()).toContain('manual-only');
+        expect(runner.listScheduledJobs()).not.toContain('manual-only');
+
+        // Due by its cron, but the ticker must leave it alone.
+        runner.tickOnce(new Date());
+        await runner.waitForIdle();
+        expect(job.callCount).toBe(0);
+
+        const result = await runner.runNow('manual-only', { dryRun: true });
+        expect(job.callCount).toBe(1);
+        expect(result.failed).toBe(0);
+    });
+
+    test('a job registered without options stays scheduled by default', async () => {
+        const job = new ScriptedJob('scheduled-by-default', '* * * * *');
+        const runner = createRunner(jobStateRepository, reporter);
+        runner.register(job);
+
+        expect(runner.listScheduledJobs()).toContain('scheduled-by-default');
+
+        runner.tickOnce(new Date());
+        await runner.waitForIdle();
+        expect(job.callCount).toBe(1);
+    });
+
     test('runNow rejects an unknown job name', async () => {
         const runner = createRunner(jobStateRepository, reporter);
 

--- a/discord-bot/tests/Integration/Infrastructure/Orm/OrmTrophyRepository.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Orm/OrmTrophyRepository.test.ts
@@ -371,4 +371,112 @@ describe('OrmTrophyRepository Integration Test', () => {
             expect(results).toHaveLength(2);
         });
     });
+
+    describe('findCatchUpSummariesSince (backfill announcement)', () => {
+        const SINCE = new Date('2024-11-30T00:00:00Z');
+
+        test('aggregates per member and filters to trophies earned on or after `since`', async () => {
+            const profile = await createTrophyProfile(undefined, 'user-a', 'HunterA');
+            // Before the window — must not be counted.
+            await createTrophy(
+                undefined,
+                profile.id.toString(),
+                'https://p/1',
+                500,
+                new Date('2024-06-01'),
+            );
+            // Inside the window.
+            await createTrophy(
+                undefined,
+                profile.id.toString(),
+                'https://p/2',
+                250,
+                new Date('2025-03-04'),
+            );
+            await createTrophy(
+                undefined,
+                profile.id.toString(),
+                'https://p/3',
+                800,
+                new Date('2026-01-20'),
+            );
+
+            const summaries = await trophyRepository.findCatchUpSummariesSince(SINCE);
+
+            expect(summaries).toHaveLength(1);
+            expect(summaries[0]!.userId).toBe('user-a');
+            expect(summaries[0]!.numTrophies).toBe(2);
+            expect(summaries[0]!.points).toBe(1050);
+            expect(summaries[0]!.firstCompletionDate.toISOString().slice(0, 10)).toBe('2025-03-04');
+            expect(summaries[0]!.lastCompletionDate.toISOString().slice(0, 10)).toBe('2026-01-20');
+        });
+
+        test('orders by points so the biggest hauls are announced first', async () => {
+            const small = await createTrophyProfile(undefined, 'user-small', 'Small');
+            await createTrophy(
+                undefined,
+                small.id.toString(),
+                'https://s/1',
+                50,
+                new Date('2025-05-05'),
+            );
+            const big = await createTrophyProfile(undefined, 'user-big', 'Big');
+            await createTrophy(
+                undefined,
+                big.id.toString(),
+                'https://b/1',
+                2000,
+                new Date('2025-05-05'),
+            );
+
+            const summaries = await trophyRepository.findCatchUpSummariesSince(SINCE);
+
+            expect(summaries.map((s) => s.userId)).toEqual(['user-big', 'user-small']);
+        });
+
+        test('skips excluded profiles and profiles with nobody to mention', async () => {
+            const excluded = await createTrophyProfile(
+                undefined,
+                'user-excluded',
+                'Excluded',
+                false,
+                false,
+                true,
+            );
+            await createTrophy(
+                undefined,
+                excluded.id.toString(),
+                'https://e/1',
+                500,
+                new Date('2025-05-05'),
+            );
+
+            // No linked Discord account — there is no one to @mention.
+            const orphan = await createTrophyProfile(undefined, '', 'Orphan');
+            await createTrophy(
+                undefined,
+                orphan.id.toString(),
+                'https://o/1',
+                500,
+                new Date('2025-05-05'),
+            );
+
+            const summaries = await trophyRepository.findCatchUpSummariesSince(SINCE);
+
+            expect(summaries).toHaveLength(0);
+        });
+
+        test('returns nothing when no trophies fall inside the window', async () => {
+            const profile = await createTrophyProfile(undefined, 'user-old', 'OldOnly');
+            await createTrophy(
+                undefined,
+                profile.id.toString(),
+                'https://x/1',
+                500,
+                new Date('2024-01-01'),
+            );
+
+            expect(await trophyRepository.findCatchUpSummariesSince(SINCE)).toHaveLength(0);
+        });
+    });
 });

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/PsnProfilesTrophySource.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/PsnProfilesTrophySource.test.ts
@@ -49,7 +49,7 @@ describe('PsnProfilesTrophySource', () => {
     describe('getPlatinumTrophyData', () => {
         test('extracts rarity percentage and completion date from a completed row', async () => {
             const trophyUrl =
-                'https://psnprofiles.com/trophies/11783-assassins-creed-valhalla/Josh_Lopes';
+                'https://psnprofiles.com/trophies/12-grand-theft-auto-iv/Zephyr-pt';
             const httpClient = new FakeHttpClient({
                 [trophyUrl]: fixture('trophy-completed.html'),
             });
@@ -57,8 +57,12 @@ describe('PsnProfilesTrophySource', () => {
 
             const data = await source.getPlatinumTrophyData(trophyUrl);
 
-            expect(data.percentage).toBe(52.03);
-            expect(data.completionDate.toISOString().slice(0, 10)).toBe('2021-06-29');
+            // The captured row carries both rarity figures; 0.97% is the
+            // site rarity PSNProfiles shows by default and the one the TP
+            // ladder is calibrated against. Reading the hover value (0.3%)
+            // instead would price this trophy at 2000 TP rather than 1250.
+            expect(data.percentage).toBe(0.97);
+            expect(data.completionDate.toISOString().slice(0, 10)).toBe('2021-09-02');
         });
 
         test('applies the blank-first-row workaround and reads the second row', async () => {
@@ -91,14 +95,14 @@ describe('PsnProfilesTrophySource', () => {
     describe('getProfileRank', () => {
         test('extracts world rank and country rank, stripping thousands separators', async () => {
             const httpClient = new FakeHttpClient({
-                'https://psnprofiles.com/Josh_Lopes': fixture('profile-rank.html'),
+                'https://psnprofiles.com/Zephyr-pt': fixture('profile-rank.html'),
             });
             const source = new PsnProfilesTrophySource(httpClient);
 
-            const rank = await source.getProfileRank('Josh_Lopes');
+            const rank = await source.getProfileRank('Zephyr-pt');
 
-            expect(rank.worldRank).toBe(712304);
-            expect(rank.countryRank).toBe(84512);
+            expect(rank.worldRank).toBe(26475);
+            expect(rank.countryRank).toBe(331);
         });
 
         test('returns nulls for both ranks when the profile has no visible rank (banned)', async () => {

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/PsnProfilesTrophySource.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/PsnProfilesTrophySource.test.ts
@@ -48,8 +48,7 @@ class FakeHttpClient implements HttpClient {
 describe('PsnProfilesTrophySource', () => {
     describe('getPlatinumTrophyData', () => {
         test('extracts rarity percentage and completion date from a completed row', async () => {
-            const trophyUrl =
-                'https://psnprofiles.com/trophies/12-grand-theft-auto-iv/Zephyr-pt';
+            const trophyUrl = 'https://psnprofiles.com/trophies/12-grand-theft-auto-iv/Zephyr-pt';
             const httpClient = new FakeHttpClient({
                 [trophyUrl]: fixture('trophy-completed.html'),
             });

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/profile-rank-banned.html
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/profile-rank-banned.html
@@ -1,3 +1,12 @@
-<div class="stats">
-    <span class="level">42</span>
-</div>
+<!-- The same real stats block as profile-rank.html with both rank spans removed,
+     which is what PSNProfiles serves for a banned or private profile. This shape
+     is what TrophiesSyncJob reads as 'auto-ban and exclude this member', so it is
+     worth it being genuine markup rather than a stub. -->
+<div class="stats flex">
+		<span class="stat grow">478<span>Games Played</span></span>
+		<span class="stat grow">202<span>Completed Games</span></span>	
+		<span class="stat grow">62.30%<span>Completion</span></span>					
+		<span class="stat grow">8,258<span>Unearned Trophies</span></span>
+		<span class="stat grow">2.22<span>Trophies Per Day</span></span>
+		<span class="stat grow">60,834<span>Views</span></span>
+		

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/profile-rank.html
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/profile-rank.html
@@ -1,4 +1,22 @@
-<div class="stats">
-    <span class="rank">712,304</span>
-    <span class="country-rank">84,512</span>
-</div>
+<!-- Captured verbatim from https://psnprofiles.com/Zephyr-pt (2026-08-21).
+     Trimmed to the stats block; markup inside is untouched. The nested
+     <a> and label <span> are exactly why the old hand-written fixture
+     (a bare <span class="rank">712,304</span>) let a broken parser pass. -->
+<div class="stats flex">
+		<span class="stat grow">478<span>Games Played</span></span>
+		<span class="stat grow">202<span>Completed Games</span></span>	
+		<span class="stat grow">62.30%<span>Completion</span></span>					
+		<span class="stat grow">8,258<span>Unearned Trophies</span></span>
+		<span class="stat grow">2.22<span>Trophies Per Day</span></span>
+		<span class="stat grow">60,834<span>Views</span></span>
+		
+					<span class="rank stat grow red">
+				<a href="/leaderboard/all?page=530&amp;h=Zephyr-pt#Zephyr-pt" rel="nofollow">
+					26,475<span>World Rank</span>
+				</a>
+			</span>
+			<span class="country-rank stat grow red">
+				<a href="/leaderboard/all/pt?page=7&amp;h=Zephyr-pt#Zephyr-pt" rel="nofollow">
+					331<span>Country Rank</span>
+				</a>
+			</span>

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/trophy-blank-first-row.html
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/trophy-blank-first-row.html
@@ -14,6 +14,11 @@
                     <span class="typo-top">8.42%</span>
                     <span class="typo-bottom">Very Rare</span>
                 </td>
+                <td style="padding-right: 10px">
+                    <span class="separator left">
+                        <img title="Platinum" src="/lib/img/icons/40-platinum.png">
+                    </span>
+                </td>
                 <td class="hover-hide">
                     <span class="typo-top-date">1st Jan 2022</span>
                     <span class="typo-bottom">9:00am</span>

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/trophy-completed.html
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/trophy-completed.html
@@ -1,23 +1,145 @@
-<div class="box no-top-border">
-    <table>
-        <thead>
-            <tr>
-                <th>Trophy</th>
-                <th>Rarity</th>
-                <th>Earned</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr class="completed">
-                <td class="hover-hide">
-                    <span class="typo-top">52.03%</span>
-                    <span class="typo-bottom">Ultra Rare</span>
-                </td>
-                <td class="hover-hide">
-                    <span class="typo-top-date">29th Jun 2021</span>
-                    <span class="typo-bottom">10:14pm</span>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-</div>
+<!-- Captured verbatim from https://psnprofiles.com/trophies/12-grand-theft-auto-iv/Zephyr-pt
+     (2026-08-21). The two <tbody> blocks above the trophy table are the real
+     decoys the parser must skip: a profile-summary table and a base-game/DLC
+     breakdown, neither carrying a completion date. The platinum row keeps both
+     rarity cells (hover-show 0.3%, hover-hide 0.97%) so a regression that reads
+     the wrong one changes the computed TP from 1250 to 2000 and fails loudly. -->
+<table><tbody><tr class="platinum">
+
+                    <td>
+                        <a href="/Zephyr-pt">
+                            <img class="trophy" src="https://i.psnprofiles.com/avatars/m/G8ec8ea704.png">
+                        </a>
+                    </td>
+
+                    <td style="width: 100%;">
+                        <a class="title" href="/Zephyr-pt" rel="nofollow">Zephyr-pt</a><br>
+                        <span class="small-info">
+                            <b>56</b> of <b>66</b> Trophies
+
+                                                        <br>January 7<sup>th</sup> 2025
+                                                    </span>
+                    </td>
+
+                    <td>
+                        <center style="padding: 0 10px;border-right:1px solid #dddddd;">
+                                                        <span class="game-rank A">A</span><br><span class="typo-bottom">RANK</span>
+                                                    </center>
+                    </td>
+
+                    <td>
+                        <span class="separator">
+                                                                                    <img width="21" src="/lib/img/icons/platinum-icon.png">
+                                                                                </span>
+                    </td>
+
+                    <td>
+                        <span class="separator left">
+                            <div class="trophy-count">
+                                <ul class="floatr">
+                                    <li class="icon-sprite gold">3</li>
+                                    <li class="icon-sprite silver">5</li>
+                                    <li class="icon-sprite bronze">47</li>
+                                </ul>
+                                <div class="progress-bar">
+                                    <span>88%</span>
+                                    <div style="width: 88%;"></div>
+                                </div>
+                            </div>
+                        </span>
+                    </td>
+                </tr></tbody></table>
+<table><tbody><tr class="completed platinum">
+                            <td style="padding-right: 10px; width: 1%;">
+                                <a href="https://img.psnprofiles.com/game/l/12/086559ba-4ee8-403e-95e2-5be8c8a8f2a4.png">
+                                    <picture class="game">
+                                        <source srcset="https://img.psnprofiles.com/game/s/12/086559ba-4ee8-403e-95e2-5be8c8a8f2a4.png, https://img.psnprofiles.com/game/m/12/086559ba-4ee8-403e-95e2-5be8c8a8f2a4.png 1.1x">
+                                        <img src="https://img.psnprofiles.com/game/s/12/086559ba-4ee8-403e-95e2-5be8c8a8f2a4.png">
+                                    </picture>
+                                </a>
+                            </td>
+                                                        <td style="padding: 10px 10px 10px 0; width: 100%;">
+                                <span class="title">Base Game</span><br>
+                                <span class="small-info"><b>51</b> of <b>51</b> Trophies</span>
+                            </td>
+                            <td>
+                                <span class="separator">
+                                                                                                            <img width="21" src="/lib/img/icons/platinum-icon.png">
+                                                                                                        </span>
+                            </td>
+                            <td>
+                                <span class="separator left">
+                                    <div class="trophy-count">
+                                        <ul class="floatr">
+                                            <li class="icon-sprite gold">3</li>
+                                            <li class="icon-sprite silver">5</li>
+                                            <li class="icon-sprite bronze">42</li>
+                                        </ul>
+                                        <div class="progress-bar">
+                                            <span>100%</span>
+                                            <div style="width: 100%;"></div>
+                                        </div>
+                                    </div>
+                                </span>
+                            </td>
+                                                    </tr></tbody></table>
+<table><tbody>
+<tr class="completed">
+                        <td>
+                            <a href="/trophy/12-grand-theft-auto-iv/1-taking-a-liberty" class="">
+                                <picture class="trophy earned">
+                                                                        <source srcset="https://img.psnprofiles.com/trophy/s/12/6ee8937a-1916-4711-8767-12d2e0fa3783.png, https://img.psnprofiles.com/trophy/m/12/6ee8937a-1916-4711-8767-12d2e0fa3783.png 1.1x">
+                                    <img src="https://img.psnprofiles.com/trophy/s/12/6ee8937a-1916-4711-8767-12d2e0fa3783.png">
+                                                                    </picture>
+                            </a>
+                        </td>
+                        <td style="width: 100%;">
+                            <a class="title" href="/trophy/12-grand-theft-auto-iv/1-taking-a-liberty">Taking A Liberty</a><br>Sorry for taking liberties with your time.
+                                                                                                                                                                                                                            </td>
+
+                        
+                        
+                        <td>
+                            <span class="separator right" <center="">
+                                    <span class="typo-top-date">
+                                        <nobr>2<sup>nd</sup> Sep 2021</nobr>
+                                    </span><br>
+                                    <span class="typo-bottom-date">
+                                        <nobr>1:40:45 AM</nobr>
+                                    </span>
+                                
+                                                                                            </span>
+                        </td>
+                        
+                                                <td class="hover-show">
+                                                        <span class="separator rarity">
+                                <span class="typo-top">
+                                    <nobr><img class="icon-sprite rarity ultra-rare" src="/lib/img/layout/spacer.png">0.3%</nobr>
+                                </span><br><span class="typo-bottom">
+                                    <nobr>Ultra Rare</nobr>
+                                </span>
+                            </span>
+                        </td>
+
+                                                <td class="hover-hide">
+                                                        <span class="separator rarity">
+                                <span class="typo-top">0.97%</span><br><span class="typo-bottom">
+                                    <nobr>Ultra Rare</nobr>
+                                </span>
+                            </span>
+                        </td>
+
+                                                <td style="padding-right: 10px">
+                            <span class="separator left">
+                                                                <img title="Platinum" src="/lib/img/icons/40-platinum.png">
+                                                            </span>
+                        </td>
+                        
+
+                        
+
+
+                        
+
+                    </tr>
+</tbody></table>

--- a/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/trophy-not-earned.html
+++ b/discord-bot/tests/Integration/Infrastructure/Trophy/fixtures/trophy-not-earned.html
@@ -13,6 +13,11 @@
                     <span class="typo-top">12.10%</span>
                     <span class="typo-bottom">Rare</span>
                 </td>
+                <td style="padding-right: 10px">
+                    <span class="separator left">
+                        <img title="Platinum" src="/lib/img/icons/40-platinum.png">
+                    </span>
+                </td>
                 <td class="hover-hide">
                     <span class="typo-bottom">Not earned</span>
                 </td>

--- a/discord-bot/tests/Integration/Ui/Cli/TrophiesCatchUpAnnounce.test.ts
+++ b/discord-bot/tests/Integration/Ui/Cli/TrophiesCatchUpAnnounce.test.ts
@@ -1,0 +1,156 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { PrismaClient } from '@prisma/client';
+import { myContainer } from '../../../../src/Infrastructure/DependencyInjection/inversify.config';
+import { TYPES } from '../../../../src/Infrastructure/DependencyInjection/types';
+import type { TrophyRepository } from '../../../../src/Domain/Trophy/TrophyRepository';
+import type Logger from '../../../../src/Application/Logger/Logger';
+import { InMemoryGuildClient } from '../../../../src/Infrastructure/Community/InMemory/InMemoryGuildClient';
+import TrophiesCatchUpAnnounce, {
+    parseCatchUpAnnounceArgs,
+} from '../../../../src/Ui/Cli/TrophiesCatchUpAnnounce';
+import { CommunityChannels } from '../../../../src/Domain/Community/CommunityChannels';
+import DatabaseUtil from '../../../Helper/DatabaseUtil';
+import { createTrophyProfile, createTrophy } from '../../../Helper/StaticFixtures';
+
+/**
+ * The one-off "the trophy hall is alive again" post. It mentions real people
+ * in bulk exactly once, so the behaviour that actually matters here is the
+ * safety rails: preview by default, and refuse rather than truncate when the
+ * blast radius looks wrong.
+ */
+describe('TrophiesCatchUpAnnounce', () => {
+    let trophyRepository: TrophyRepository;
+    let guildClient: InMemoryGuildClient;
+    let command: TrophiesCatchUpAnnounce;
+    let ormClient: PrismaClient;
+
+    beforeEach(async () => {
+        trophyRepository = myContainer.get<TrophyRepository>(TYPES.TrophyRepository);
+        guildClient = new InMemoryGuildClient();
+        command = new TrophiesCatchUpAnnounce(
+            trophyRepository,
+            guildClient,
+            myContainer.get<Logger>(TYPES.Logger),
+        );
+        ormClient = myContainer.get<PrismaClient>(TYPES.OrmClient);
+
+        await DatabaseUtil.truncateAllTables();
+    });
+
+    afterEach(async () => {
+        await ormClient.$disconnect();
+    });
+
+    async function seedMember(userId: string, psnProfile: string, points: number[]) {
+        const profile = await createTrophyProfile(undefined, userId, psnProfile);
+        for (const [index, value] of points.entries()) {
+            await createTrophy(
+                undefined,
+                profile.id.toString(),
+                `https://psnprofiles.com/trophies/${psnProfile}-${index}`,
+                value,
+                new Date('2025-06-15'),
+            );
+        }
+    }
+
+    describe('argument parsing', () => {
+        test('previews by default — posting is opt-in', () => {
+            expect(parseCatchUpAnnounceArgs([]).post).toBe(false);
+            expect(parseCatchUpAnnounceArgs(['--post']).post).toBe(true);
+        });
+
+        test('accepts an explicit --since', () => {
+            expect(
+                parseCatchUpAnnounceArgs(['--since=2025-01-31']).since.toISOString().slice(0, 10),
+            ).toBe('2025-01-31');
+        });
+
+        test('rejects a malformed date rather than silently scanning from the epoch', () => {
+            expect(() => parseCatchUpAnnounceArgs(['--since=not-a-date'])).toThrow(
+                /Invalid --since/,
+            );
+            expect(() => parseCatchUpAnnounceArgs(['--since=31-01-2025'])).toThrow(
+                /Invalid --since/,
+            );
+        });
+
+        test('rejects unknown arguments instead of ignoring them', () => {
+            expect(() => parseCatchUpAnnounceArgs(['--yolo'])).toThrow(/Unknown argument/);
+        });
+    });
+
+    test('posts one message per member, mentioning them with their totals', async () => {
+        await seedMember('user-a', 'HunterA', [500, 250]);
+
+        const exitCode = await command.run(['--since=2024-11-30', '--post']);
+
+        expect(exitCode).toBe(0);
+        expect(guildClient.sentMessages).toHaveLength(1);
+        const sent = guildClient.sentMessages[0]!;
+        expect(sent.channel).toBe(CommunityChannels.TROPHIES);
+        expect(sent.message).toContain('<@user-a>');
+        expect(sent.message).toContain('**2 troféus platina**');
+        expect(sent.message).toContain('**750 TP**');
+    });
+
+    test('says "troféu" in the singular for a member with exactly one', async () => {
+        await seedMember('user-solo', 'Solo', [800]);
+
+        await command.run(['--since=2024-11-30', '--post']);
+
+        expect(guildClient.sentMessages[0]!.message).toContain('**1 troféu platina**');
+    });
+
+    test('without --post it previews and sends nothing', async () => {
+        await seedMember('user-a', 'HunterA', [500]);
+
+        const exitCode = await command.run(['--since=2024-11-30']);
+
+        expect(exitCode).toBe(0);
+        expect(guildClient.sentMessages).toHaveLength(0);
+    });
+
+    test('refuses to post at all when more members match than --max', async () => {
+        // A --since far enough back to sweep in everybody is the realistic
+        // way to get this wrong, and posting "just the first few" would be
+        // the worst outcome — so it must send nothing.
+        await seedMember('user-a', 'A', [500]);
+        await seedMember('user-b', 'B', [500]);
+        await seedMember('user-c', 'C', [500]);
+
+        const exitCode = await command.run(['--since=2024-11-30', '--max=2', '--post']);
+
+        expect(exitCode).toBe(1);
+        expect(guildClient.sentMessages).toHaveLength(0);
+    });
+
+    test('a failed send does not abandon the rest of the run', async () => {
+        await seedMember('user-a', 'AAA', [2000]);
+        await seedMember('user-b', 'BBB', [50]);
+        guildClient.failNextSendWith = new Error('Discord is having a moment');
+
+        const exitCode = await command.run(['--since=2024-11-30', '--post']);
+
+        // Non-zero so an operator notices, but the second member still heard.
+        expect(exitCode).toBe(1);
+        expect(guildClient.sentMessages).toHaveLength(1);
+        expect(guildClient.sentMessages[0]!.message).toContain('<@user-b>');
+    });
+
+    test('is a no-op when nothing was earned in the window', async () => {
+        const profile = await createTrophyProfile(undefined, 'user-old', 'OldOnly');
+        await createTrophy(
+            undefined,
+            profile.id.toString(),
+            'https://psnprofiles.com/trophies/old',
+            500,
+            new Date('2024-01-01'),
+        );
+
+        const exitCode = await command.run(['--since=2024-11-30', '--post']);
+
+        expect(exitCode).toBe(0);
+        expect(guildClient.sentMessages).toHaveLength(0);
+    });
+});

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ short version.
 | [architecture.md](architecture.md)                   | You are about to change `discord-bot/` code                                |
 | [operations.md](operations.md)                       | You need to build, release, deploy, or debug the running bot               |
 | [known-issues.md](known-issues.md)                   | You want the itemised list of what is broken or rotten, with severities    |
+| [psn-crawl.md](psn-crawl.md)                         | You are touching the trophy crawl, or `/trophy rank` has stopped updating  |
 | [revival-plan.md](revival-plan.md)                   | You want the original narrative sequencing (superseded by the global plan) |
 | [session-log-2026-08-19.md](session-log-2026-08-19.md) | You want the record of how all of this was found, and why each call was made |
 | [plans/](plans/00-overview.md)                       | You are an agent about to build one of the workstreams                     |

--- a/docs/psn-crawl.md
+++ b/docs/psn-crawl.md
@@ -218,6 +218,39 @@ docker exec gop-bot bun run:command jobs:run trophies:sync --dry-run --limit=20
 TROPHIES_SYNC_ENABLED=true
 ```
 
+### Coming back from an outage
+
+The order above matters when the crawl has been down for a long time. Leave
+`TROPHIES_ANNOUNCE_ENABLED` **unset** while the backfill runs.
+
+The steady-state announcement guards are tuned for steady state: a profile
+gaining more than 3 trophies in one run collapses to a single summary, and
+the whole run is capped at 10 messages. Since a backfill is spread over many
+10-minute runs, leaving announcements on would dribble out disconnected "we
+synced 47 trophies" lines with no explanation of why months-old platinums are
+suddenly being mentioned.
+
+Instead, once the backfill has caught up, post one deliberate message per
+member:
+
+```bash
+# preview — prints exactly what would be posted, sends nothing
+bun run:command trophies:catchup-announce --since=2024-11-30
+
+# send it
+bun run:command trophies:catchup-announce --since=2024-11-30 --post
+```
+
+Each member gets: *"🏆 Parabéns @X! O ranking de troféus está de volta —
+desde novembro de 2024 conquistaste **N troféus platina**, num total de
+**X TP**."*
+
+It previews by default and refuses to post at all if more members match than
+`--max` (default 60), because the realistic way to get this wrong is a
+`--since` that sweeps in everybody, and posting "just the first few" would be
+the worst outcome. **Then** set `TROPHIES_ANNOUNCE_ENABLED=true` so
+individual trophies are announced from that point on.
+
 `trophies:sync` is always *registered* (so it can be dry-run by hand) but only
 *scheduled* when that flag is `true`. Those are two different things, and
 conflating them is what made the runbook impossible before 2026-08-22: the

--- a/docs/psn-crawl.md
+++ b/docs/psn-crawl.md
@@ -1,0 +1,311 @@
+# The PSN trophy crawl
+
+How `/trophy rank` gets its data: what runs, where it runs, why it is split
+across two machines, and what to do when it breaks.
+
+Written 2026-08-22, when the crawl was repaired after being dead since
+2024-12-02.
+
+---
+
+## 1. What the feature is
+
+Members register a PSNProfiles account (`/trophy profile add <url>`). A job
+walks each registered profile, finds the **platinum** trophies they have
+earned, converts each platinum's *rarity* into "trophy points" (TP), and
+stores them. `/trophy rank` then aggregates TP per profile into a
+leaderboard — monthly, since-creation and lifetime.
+
+The rarity → TP ladder (`Domain/Trophy/TrophyPoints.ts`, inherited verbatim
+from the old bot):
+
+| Platinum rarity | TP   |
+| --------------- | ---- |
+| > 30.01%        | 50   |
+| > 15.01%        | 100  |
+| > 8.01%         | 250  |
+| > 5.01%         | 500  |
+| > 2.01%         | 800  |
+| > 0.6%          | 1250 |
+| ≤ 0.6%          | 2000 |
+
+Rarity is read *at the time the trophy is first seen* and never revisited, so
+TP is a snapshot. This matters: a platinum earned four days after a game's
+launch was ultra-rare then and may be common now. Two of the six trophies
+used to validate the parser show exactly this drift, and it is correct
+behaviour, not a bug.
+
+## 2. Why it is split across two machines
+
+PSNProfiles has **no public API**, so this is a scraper — and since roughly
+2025 the site sits behind a Cloudflare managed challenge. The challenge is a
+JavaScript interstitial ("Just a moment…"), not a flat block, so clearing it
+requires something that actually executes it.
+
+Measured against the live site on **2026-08-21**, six pages per cell, across
+all three page types the job uses:
+
+| Client                             | HTZ1 (Hetzner) | Home connection |
+| ---------------------------------- | -------------- | --------------- |
+| `fetch` / curl, any User-Agent     | 0/6            | 0/6             |
+| curl-impersonate (real Chrome JA3) | 0/2            | —               |
+| FlareSolverr                       | 0/3 (timeouts) | —               |
+| Playwright, headless               | 0/6            | —               |
+| Playwright, headed under xvfb      | 0/6            | 1/6             |
+| **patchright, headed under xvfb**  | 0/6            | **6/6**         |
+
+**Two conditions must hold at once:**
+
+1. **A patched browser.** Stock Playwright leaks automation over CDP
+   (`Runtime.enable`). It clears the *first* navigation of a fresh profile
+   and is challenged on every one after — which is what the misleading 1/6
+   is. `patchright` closes those leaks.
+2. **A non-datacenter IP.** Everything from Hetzner failed, 0/12 across both
+   browsers. This is why the fetcher cannot live beside the bot.
+
+Two theories the evidence **disproved**, recorded so nobody burns a day
+re-testing them:
+
+- **It is not TLS/JA3 fingerprinting.** curl-impersonate with a genuine
+  Chrome fingerprint still got 403.
+- **It is not a WebGL/GPU check.** The passing runs reported `SwiftShader`,
+  i.e. software rendering, the same as several failing ones.
+
+So the crawl runs in two halves:
+
+```
+┌─────────────────── HTZ1 (Hetzner, Portainer stack 46) ───────────────────┐
+│  gop-bot                                                                 │
+│    TrophiesSyncJob  ──▶  PsnProfilesTrophySource                         │
+│                            └─▶ BrowserFetchHttpClient ──┐                │
+│  gop-db (MariaDB)  ◀── writes trophies/flags            │                │
+└─────────────────────────────────────────────────────────┼────────────────┘
+                                                          │ HTTPS + bearer
+                                                          ▼
+                              https://tedrelayer.tail6bf1c8.ts.net/psn-fetch
+                                        (Tailscale Funnel)
+┌─────────────────── TedRelayer (home, residential IP) ────────────────────┐
+│  gop-psn-fetch                                                           │
+│    Node HTTP server ──▶ patchright Chromium (headed, xvfb, persistent)    │
+│                                    └─▶ https://psnprofiles.com            │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## 3. The pieces
+
+### `TrophiesSyncJob` — `discord-bot/src/Infrastructure/Job/Jobs/`
+
+Runs every 10 minutes **when scheduled**. Per profile:
+
+1. Fetch the profile page and read world/country rank.
+   **If both ranks are absent, the profile is flagged `isBanned + isExcluded`** —
+   that is how a banned or private PSN account is detected.
+2. Check the linked Discord user is still in the guild. If not, flag
+   `hasLeft + isExcluded`.
+3. Walk the platinum list newest-first, and for each unseen trophy fetch its
+   page, compute TP from rarity, and store it. In normal ("catch-up") mode it
+   **stops at the first trophy already stored**, so a steady-state run is
+   cheap.
+
+Two safety mechanisms worth knowing about:
+
+- **The moderation safety valve.** If a single run would flag more than
+  `MODERATION_SAFETY_VALVE_THRESHOLD` profiles, it commits *none* of them and
+  reports instead. This exists because a parser regression looks exactly like
+  a mass exodus — and it earned its keep: before the 2026-08-22 fix,
+  `parseProfileRank` returned null for every profile, so the first scheduled
+  run would have tried to ban and exclude all 72 active members.
+- **A work budget** (`--limit`, default 200) bounds the requests any single
+  run makes.
+
+### `PsnProfilesTrophySource` — `discord-bot/src/Infrastructure/Trophy/`
+
+Parses PSNProfiles HTML with scoped regexes (no HTML-parser dependency, by
+design). The three things it extracts, and the traps in each:
+
+| What | Where | Trap |
+| ---- | ----- | ---- |
+| World/country rank | `<span class="rank">` in the stats block | The number is nested inside an `<a>` **and** a label `<span>`; a non-greedy match stops at the label's closing tag |
+| Platinum URLs | `<tr class="platinum">` rows on the list page | — |
+| Rarity + date | the platinum's `<tr>` on a trophy page | A real page has **13** `<tbody>` elements; the first two are decoys with no completion date |
+
+Three further details that are easy to get wrong:
+
+- **Which rarity.** Each trophy row carries *two* percentages: PSNProfiles'
+  own site rarity (in `td.hover-hide`, shown by default) and Sony's global
+  figure (in `td.hover-show`, revealed on hover). The TP ladder is calibrated
+  against the **site rarity**. Reading the other one repriced GTA IV's
+  platinum from 1250 TP to 2000.
+- **Dates carry markup.** `2<sup>nd</sup> Sep 2021` must be flattened to text
+  before `dayjs` sees it.
+- **Comments are stripped first.** Commented-out markup is still markup to a
+  regex, and these helpers all take the *first* match.
+
+The platinum row is located by `title="Platinum"`, which appears exactly once
+per page — deliberately **not** by "has a completion date", because an
+unearned platinum has no date and must still be found so the job raises
+`TrophyNotEarnedYet` (skipped) rather than a generic error (counted failed).
+
+### `BrowserFetchHttpClient` — `discord-bot/src/Infrastructure/Http/`
+
+Swaps the direct `fetch` for a call to the sidecar. Bound **only** to the
+trophy source, and **only** when `PSN_FETCH_URL` and `PSN_FETCH_TOKEN` are
+both set; otherwise the trophy source gets the ordinary client. That is why
+the test suite and local development need no browser and no network access.
+
+### `psn-fetch` — `infrastructure/psn-fetch/`
+
+A ~180-line Node HTTP server wrapping one long-lived patchright Chromium.
+One endpoint: `GET /fetch?url=…`. Because it is a browser reachable over
+HTTP, it is deliberately narrow:
+
+- **One allowed origin** (`https://psnprofiles.com`), checked before a page
+  is opened, so a leaked token cannot make it an SSRF pivot into the home
+  network.
+- **Bearer token**, compared in constant time.
+- **GET only**; no eval, no screenshot, no navigation to arbitrary hosts.
+- **Serialised** behind a queue with a minimum 1.5s gap. The throttle lives
+  here, next to the browser that owns the Cloudflare clearance cookie, so two
+  bot processes cannot double the request rate against a site with no API.
+- **Persistent browser profile** on a Docker volume — it keeps the clearance
+  cookie, which is why a typical request takes ~1s and never sees a
+  challenge.
+
+## 4. Setup
+
+### The sidecar (TedRelayer)
+
+```bash
+cd ~/psn-fetch                 # server.js, Dockerfile, docker-compose.yml, .env
+docker compose up -d --build
+docker compose logs -f
+```
+
+`.env` holds `PSN_FETCH_TOKEN` (mode 600). Published through the Tailscale
+Funnel that host already had enabled, on its own path so the existing
+Jellyfin route on `/` is untouched:
+
+```bash
+sudo tailscale funnel --bg --set-path /psn-fetch http://127.0.0.1:8791
+tailscale serve status
+```
+
+Funnel was chosen because HTZ1 has no passwordless sudo (ruling out both a
+`sshd_config` change for a reverse tunnel and a Tailscale install) and because
+home ingress is deliberately closed — HTZ1 cannot reach TedRelayer's SSH at
+all, which is correct and was left that way. Funnel needs no router port and
+no root on HTZ1.
+
+**This does expose the service to the public internet.** It is token-protected
+and origin-locked. The tailnet-only alternative is a Tailscale sidecar
+container on HTZ1 joined to `game-on-portugal_internal` plus `tailscale serve`
+instead of `funnel` — more moving parts, no public exposure.
+
+### The bot (HTZ1, Portainer stack 46)
+
+```
+PSN_FETCH_URL   = https://tedrelayer.tail6bf1c8.ts.net/psn-fetch
+PSN_FETCH_TOKEN = <same token as the sidecar's .env>
+```
+
+Then, and only in this order:
+
+```bash
+# 1. Preview. Read the report — especially newlyFlagged.
+docker exec gop-bot bun run:command jobs:run trophies:sync --dry-run --limit=20
+
+# 2. If the report looks right, schedule it (every 10 minutes).
+TROPHIES_SYNC_ENABLED=true
+```
+
+`trophies:sync` is always *registered* (so it can be dry-run by hand) but only
+*scheduled* when that flag is `true`. Those are two different things, and
+conflating them is what made the runbook impossible before 2026-08-22: the
+job was absent from the runner entirely, so the dry-run command the boot log
+tells you to use failed with `Unknown job`.
+
+Announcements to the trophies channel are a **separate** opt-in:
+`TROPHIES_ANNOUNCE_ENABLED=true`.
+
+## 5. Verifying it
+
+```bash
+# Is the sidecar alive?
+curl -s https://tedrelayer.tail6bf1c8.ts.net/psn-fetch/health
+# {"ok":true,"browser":true}
+
+# Can it still get through Cloudflare? (expect 2)
+curl -s -H "Authorization: Bearer $PSN_FETCH_TOKEN" \
+  "https://tedrelayer.tail6bf1c8.ts.net/psn-fetch/fetch?url=https%3A%2F%2Fpsnprofiles.com%2FZephyr-pt" \
+  | grep -c 'World Rank'
+
+# Did the last run go well?
+docker exec gop-db sh -c 'mariadb -uroot -p$MARIADB_ROOT_PASSWORD discord-bot \
+  -e "SELECT job_name,last_run_at,status,summary FROM job_runs WHERE job_name=\"trophies:sync\"\G"'
+```
+
+## 6. When it breaks
+
+**Symptom: every profile fails, `failedProfiles` full of HTTP errors.**
+The sidecar is down, unreachable, or Cloudflare has moved. Check `/health`
+first, then the curl above. If the curl returns 0, re-run the comparison
+table in §2 *before* assuming the parser broke — the two are easy to confuse
+and the fix is completely different.
+
+**Symptom: a large `newlyFlagged` list, or the safety valve tripped.**
+Treat as a parser regression until proven otherwise. "No visible rank" is the
+auto-ban signal, so anything that breaks rank parsing looks like the whole
+community being banned. Do **not** clear the flags without checking a profile
+page by hand; `isExcluded` has no automatic un-flagging.
+
+**Symptom: trophies silently skipped, `changed: 0` forever.**
+Likely `parsePlatinumTrophyData` raising `TrophyNotEarnedYet` for trophies
+that *were* earned — i.e. it found the wrong row. Check whether PSNProfiles
+added another table above the trophy list.
+
+**Recovering from bad flags:**
+
+```sql
+-- Inspect first. Only un-flag what you have actually verified by hand.
+SELECT id, psnProfile, isBanned, hasLeft, isExcluded, updatedAt
+FROM trophyprofiles WHERE isExcluded = 1 ORDER BY updatedAt DESC;
+```
+
+**Re-scanning one profile from scratch** (ignores catch-up, re-walks
+everything):
+
+```bash
+TROPHIES_SYNC_ALL=true TROPHIES_SYNC_PROFILE=Zephyr-pt \
+  bun run:command jobs:run trophies:sync --dry-run
+```
+
+## 7. Fragility, honestly
+
+This works by getting past bot protection that PSNProfiles chose to turn on.
+It works today. It is not guaranteed to keep working, and it will need
+occasional attention.
+
+Consequences worth accepting deliberately:
+
+- **The pinned versions are load-bearing.** The Playwright base image and the
+  patchright version are pinned because the whole point of that image is a
+  browser fingerprint known to clear the challenge. An unattended bump is
+  exactly the change that would silently break it.
+- **The sidecar must stay on a residential connection.** Moving it to any
+  datacenter — including HTZ1, where everything else lives — puts it back to
+  0/6.
+- **It is a scraper against a site with no API.** The 1.5s serialised throttle
+  and the descriptive User-Agent are deliberate; keep them.
+
+If the crawl ever becomes unmaintainable, the fallback is Sony's official PSN
+API via an NPSSO token. It was rejected here because every one of the 4,971
+existing trophy rows is keyed by its psnprofiles.com URL, so switching source
+means either a data migration or re-importing everything as duplicates — plus
+an NPSSO token expires roughly every two months and needs manual refresh.
+That trade-off may look different if the scraper starts failing weekly.
+
+## 8. Related
+
+- [`infrastructure/psn-fetch/README.md`](../infrastructure/psn-fetch/README.md) — sidecar specifics
+- [`operations.md`](operations.md) — deploying and debugging the bot generally
+- [`plans/GLOBAL-PLAN.md`](plans/GLOBAL-PLAN.md) — M7 is the trophy milestone

--- a/infrastructure/psn-fetch/Dockerfile
+++ b/infrastructure/psn-fetch/Dockerfile
@@ -1,0 +1,35 @@
+# Chromium and its system libraries come from the Playwright base image;
+# patchright drives a patched build of the same browser. Pinned rather than
+# :latest because the whole point of this image is a browser fingerprint that
+# is known to clear the challenge — an unattended base bump is exactly the
+# kind of change that would silently break it.
+FROM mcr.microsoft.com/playwright:v1.49.0-noble
+
+WORKDIR /app
+
+# xvfb is load-bearing, not a convenience: headless Chromium is detected and
+# refused, so the browser runs headed against a virtual display.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends xvfb tini \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY package.json ./
+RUN npm install --omit=dev && npx patchright install chromium
+
+COPY server.js ./
+
+ENV PORT=8791 \
+    PROFILE_DIR=/data/profile
+
+# /data holds the persistent browser profile — and with it the Cloudflare
+# clearance cookie, which is what keeps most requests from being challenged
+# at all. Losing it is survivable but makes the first requests after a
+# restart much slower.
+VOLUME ["/data"]
+
+EXPOSE 8791
+
+# tini reaps the Chromium children xvfb-run leaves behind; without it a
+# long-lived container accumulates zombies.
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["xvfb-run", "-a", "--server-args=-screen 0 1440x900x24", "node", "/app/server.js"]

--- a/infrastructure/psn-fetch/Dockerfile
+++ b/infrastructure/psn-fetch/Dockerfile
@@ -25,9 +25,18 @@ ENV PORT=8791 \
 # clearance cookie, which is what keeps most requests from being challenged
 # at all. Losing it is survivable but makes the first requests after a
 # restart much slower.
+RUN mkdir -p /data && chown -R pwuser:pwuser /app /data
 VOLUME ["/data"]
 
+# pwuser is the non-root user baked into the Playwright base image. Chromium
+# runs with --no-sandbox already (server.js), so dropping root here costs
+# nothing — the setuid sandbox that would otherwise want root was never in use.
+USER pwuser
+
 EXPOSE 8791
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||8791)+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
 # tini reaps the Chromium children xvfb-run leaves behind; without it a
 # long-lived container accumulates zombies.

--- a/infrastructure/psn-fetch/README.md
+++ b/infrastructure/psn-fetch/README.md
@@ -1,0 +1,102 @@
+# psn-fetch
+
+A browser-backed, read-only fetch proxy for `psnprofiles.com`. It exists for
+one reason: **the bot cannot fetch PSNProfiles itself any more.**
+
+## The problem
+
+PSNProfiles sits behind a Cloudflare managed challenge. It is not an IP ban —
+it is a JavaScript interstitial ("Just a moment…"), so clearing it needs
+something that actually executes the challenge. Measured against the live site
+on **2026-08-21**, six pages per cell, across all three page types the sync
+job uses (profile, platinum list, trophy detail):
+
+| Client                             | HTZ1 (Hetzner) | TedRelayer (home) |
+| ---------------------------------- | -------------- | ----------------- |
+| `fetch` / curl, any User-Agent     | 0/6            | 0/6               |
+| curl-impersonate (real Chrome JA3) | 0/2            | —                 |
+| FlareSolverr                       | 0/3 (timeouts) | —                 |
+| Playwright, headless               | 0/6            | —                 |
+| Playwright, headed under xvfb      | 0/6            | 1/6               |
+| **patchright, headed under xvfb**  | 0/6            | **6/6**           |
+
+Two conditions have to hold **at the same time**, which is why every simpler
+fix failed:
+
+1. **A patched browser.** Stock Playwright leaks automation over CDP
+   (`Runtime.enable`). It clears the *first* navigation of a fresh profile and
+   is challenged on every one after — hence the misleading 1/6. `patchright`
+   closes those leaks.
+2. **A non-datacenter IP.** Hetzner's range failed 0/12 regardless of client.
+   This is the reason this service cannot live next to the bot on HTZ1.
+
+Two plausible theories that the evidence **killed**, recorded so nobody
+re-tests them: TLS/JA3 impersonation alone changed nothing, and the passing
+runs were software-rendered (SwiftShader), so it is not a WebGL/GPU check.
+
+## Where it runs, and how the bot reaches it
+
+The service runs on **TedRelayer** (home network) and is published through the
+Tailscale Funnel that host already had enabled, on a dedicated path:
+
+```
+https://tedrelayer.tail6bf1c8.ts.net/psn-fetch  ->  127.0.0.1:8791
+```
+
+Chosen over the alternatives because HTZ1 has no passwordless sudo (so no
+`sshd_config` change for a reverse tunnel, and no Tailscale install), and
+because home ingress is deliberately closed — HTZ1 cannot reach TedRelayer's
+SSH at all, which is correct and was left alone. Funnel needs no inbound port
+on the router and no root on HTZ1.
+
+**This does put the service on the public internet**, so it is hardened
+accordingly: bearer token compared in constant time, a hard allowlist of one
+origin (`https://psnprofiles.com`), `GET` only, and no eval/screenshot
+surface. If you would rather it were not public, the alternative is a
+Tailscale sidecar container on HTZ1 joined to `game-on-portugal_internal` plus
+`tailscale serve` (tailnet-only) instead of Funnel — more moving parts, no
+public exposure.
+
+## Operating it
+
+```bash
+# on TedRelayer
+cd ~/psn-fetch
+docker compose up -d --build
+docker compose logs -f
+
+curl -s https://tedrelayer.tail6bf1c8.ts.net/psn-fetch/health
+curl -s -H "Authorization: Bearer $PSN_FETCH_TOKEN" \
+  "https://tedrelayer.tail6bf1c8.ts.net/psn-fetch/fetch?url=https%3A%2F%2Fpsnprofiles.com%2FZephyr-pt" \
+  | grep -c 'World Rank'   # expect 2
+
+# remove the public route again
+sudo tailscale serve --https=443 --set-path /psn-fetch off
+```
+
+The token lives in `~/psn-fetch/.env` (mode 600) on TedRelayer and in the bot's
+environment as `PSN_FETCH_TOKEN`. Rotating it means changing both.
+
+## Politeness
+
+Requests are serialised behind a queue with a minimum 1.5s gap, and the
+throttle lives **here** rather than in the bot on purpose: the browser in this
+container owns the Cloudflare clearance cookie, so two bot processes sharing
+this service must not be able to double the request rate against a site with
+no public API. The persistent profile volume keeps that cookie across
+restarts, which is why most requests never see a challenge at all (~1s).
+
+## Known fragility
+
+This depends on beating bot protection that PSNProfiles deliberately turned
+on. It works today; it is not guaranteed to keep working, and the pinned base
+image and pinned patchright version are load-bearing — an unattended bump is
+exactly the kind of change that would silently break the fingerprint. If the
+sync starts failing wholesale, re-run the table above before assuming the
+parser broke.
+
+**This host is scheduled for decommission on 2026-09-02** (GLOBAL-PLAN M2.5)
+and its NVMe has 2,200+ unrecoverable read errors. The service is stateless
+apart from the browser profile, so it can move to any always-on machine on a
+residential connection — but if TedRelayer goes away without this moving, the
+leaderboard silently stops updating again.

--- a/infrastructure/psn-fetch/docker-compose.yml
+++ b/infrastructure/psn-fetch/docker-compose.yml
@@ -1,0 +1,31 @@
+# psn-fetch runs on a residential connection (TedRelayer), NOT on HTZ1:
+# Hetzner's IP range fails the Cloudflare challenge 0/12 regardless of how
+# good the browser is. See infrastructure/psn-fetch/README.md.
+services:
+  psn-fetch:
+    build: .
+    image: gop-psn-fetch:1.0.0
+    container_name: gop-psn-fetch
+    restart: unless-stopped
+    environment:
+      PSN_FETCH_TOKEN: ${PSN_FETCH_TOKEN:?PSN_FETCH_TOKEN is required}
+      MIN_REQUEST_INTERVAL_MS: 1500
+    volumes:
+      - psn-fetch-profile:/data
+    # Bound to loopback on purpose. The bot reaches this through the reverse
+    # SSH tunnel documented in the README, so the port is never exposed to
+    # the LAN, let alone forwarded at the router.
+    ports:
+      - "127.0.0.1:8791:8791"
+    # Chromium needs more than the default 64MB of /dev/shm or it crashes
+    # part-way through rendering a large trophy page.
+    shm_size: "1gb"
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:8791/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+volumes:
+  psn-fetch-profile:

--- a/infrastructure/psn-fetch/package.json
+++ b/infrastructure/psn-fetch/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "psn-fetch",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Browser-backed read-only fetch proxy for PSNProfiles (Cloudflare challenge)",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "patchright": "^1.49.0"
+  }
+}

--- a/infrastructure/psn-fetch/server.js
+++ b/infrastructure/psn-fetch/server.js
@@ -1,0 +1,186 @@
+'use strict';
+
+/**
+ * psn-fetch — a browser-backed read-only fetch proxy for PSNProfiles.
+ *
+ * The bot cannot fetch psnprofiles.com itself: the site is behind a
+ * Cloudflare managed challenge that needs a real browser to execute, and
+ * that will not clear from a datacenter IP at all. This service is the
+ * narrow escape hatch — it runs a patched Chromium on a residential
+ * connection, and exposes exactly one verb: "give me the HTML at this
+ * psnprofiles.com URL".
+ *
+ * Deliberate constraints, because this is a browser reachable over HTTP:
+ *
+ *  - **One allowed origin.** Anything not on https://psnprofiles.com is
+ *    refused before a page is opened, so a leaked token cannot turn this
+ *    into an SSRF pivot into the home network.
+ *  - **Bearer token required**, compared with a timing-safe equality.
+ *  - **GET only, HTML out.** No POST/eval/screenshot surface.
+ *  - **Serialised.** One navigation at a time behind a queue, with a
+ *    minimum interval between requests. The throttle lives here rather
+ *    than in the bot because the browser here owns the Cloudflare
+ *    clearance cookie; two bot processes sharing this service must not be
+ *    able to double the request rate against a site with no public API.
+ */
+
+const http = require('http');
+const crypto = require('crypto');
+const { chromium } = require('patchright');
+
+const PORT = Number(process.env.PORT || 8791);
+const TOKEN = process.env.PSN_FETCH_TOKEN || '';
+const ALLOWED_ORIGIN = 'https://psnprofiles.com';
+const MIN_REQUEST_INTERVAL_MS = Number(process.env.MIN_REQUEST_INTERVAL_MS || 1500);
+const NAV_TIMEOUT_MS = Number(process.env.NAV_TIMEOUT_MS || 60000);
+const CHALLENGE_TIMEOUT_MS = Number(process.env.CHALLENGE_TIMEOUT_MS || 45000);
+const PROFILE_DIR = process.env.PROFILE_DIR || '/data/profile';
+
+if (!TOKEN) {
+  console.error('PSN_FETCH_TOKEN is required');
+  process.exit(1);
+}
+
+function log(event, fields = {}) {
+  console.log(JSON.stringify({ ts: new Date().toISOString(), event, ...fields }));
+}
+
+/** Constant-time compare, so a wrong token cannot be discovered byte by byte. */
+function tokenMatches(presented) {
+  const a = Buffer.from(presented || '');
+  const b = Buffer.from(TOKEN);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+let browserContext = null;
+let lastRequestAt = 0;
+/** Serialises navigations: each request chains onto the previous one. */
+let queue = Promise.resolve();
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function getContext() {
+  if (browserContext) return browserContext;
+
+  // Headed (under xvfb) and persistent, both load-bearing: headless is
+  // detected outright, and a persistent profile keeps the clearance cookie
+  // so most requests skip the challenge entirely.
+  browserContext = await chromium.launchPersistentContext(PROFILE_DIR, {
+    headless: false,
+    viewport: { width: 1440, height: 900 },
+    locale: 'en-US',
+    timezoneId: 'Europe/Lisbon',
+    args: ['--no-sandbox', '--disable-blink-features=AutomationControlled'],
+  });
+
+  browserContext.on('close', () => {
+    log('browser.closed');
+    browserContext = null;
+  });
+
+  log('browser.launched');
+  return browserContext;
+}
+
+async function fetchPage(url) {
+  const elapsed = Date.now() - lastRequestAt;
+  if (elapsed < MIN_REQUEST_INTERVAL_MS) {
+    await sleep(MIN_REQUEST_INTERVAL_MS - elapsed);
+  }
+  lastRequestAt = Date.now();
+
+  const ctx = await getContext();
+  const page = await ctx.newPage();
+  try {
+    const response = await page.goto(url, {
+      waitUntil: 'domcontentloaded',
+      timeout: NAV_TIMEOUT_MS,
+    });
+
+    // The interstitial resolves itself; poll the title until it clears
+    // rather than sleeping a fixed amount, so the common (already-cleared)
+    // case stays fast.
+    const deadline = Date.now() + CHALLENGE_TIMEOUT_MS;
+    let title = await page.title();
+    while (title.includes('Just a moment') && Date.now() < deadline) {
+      await page.waitForTimeout(1500);
+      title = await page.title();
+    }
+
+    if (title.includes('Just a moment')) {
+      throw new Error('Cloudflare challenge did not clear');
+    }
+
+    const status = response ? response.status() : 0;
+    const html = await page.content();
+    return { status, html, title };
+  } finally {
+    await page.close().catch(() => {});
+  }
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+
+  if (url.pathname === '/health') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, browser: browserContext !== null }));
+    return;
+  }
+
+  if (url.pathname !== '/fetch' || req.method !== 'GET') {
+    res.writeHead(404).end('not found');
+    return;
+  }
+
+  const auth = req.headers.authorization || '';
+  if (!tokenMatches(auth.replace(/^Bearer\s+/i, ''))) {
+    log('auth.rejected', { remote: req.socket.remoteAddress });
+    res.writeHead(401).end('unauthorized');
+    return;
+  }
+
+  const target = url.searchParams.get('url') || '';
+  let parsed;
+  try {
+    parsed = new URL(target);
+  } catch {
+    res.writeHead(400).end('bad url');
+    return;
+  }
+
+  if (parsed.origin !== ALLOWED_ORIGIN) {
+    log('origin.rejected', { target });
+    res.writeHead(403).end(`only ${ALLOWED_ORIGIN} is allowed`);
+    return;
+  }
+
+  queue = queue
+    .then(async () => {
+      const startedAt = Date.now();
+      try {
+        const { status, html } = await fetchPage(parsed.toString());
+        log('fetch.ok', { url: target, status, ms: Date.now() - startedAt, bytes: html.length });
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(html);
+      } catch (error) {
+        log('fetch.failed', { url: target, ms: Date.now() - startedAt, error: error.message });
+        // 502: the failure is upstream (challenge/navigation), not the
+        // caller's request being malformed. RetryHttpClient backs off on it.
+        res.writeHead(502).end(error.message);
+      }
+    })
+    // Keep the chain alive: a rejected link would strand every later request.
+    .catch(() => {});
+});
+
+server.listen(PORT, () => log('listening', { port: PORT }));
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, async () => {
+    log('shutdown', { signal });
+    server.close();
+    if (browserContext) await browserContext.close().catch(() => {});
+    process.exit(0);
+  });
+}


### PR DESCRIPTION
Follow-up to #75 (merged, released 1.3.1). Two commits that didn't make that squash, plus the thing that actually makes the community *notice* the leaderboard is back.

## 1. The catch-up announcement

`trophies:catchup-announce` — a one-off console command that posts a single per-member summary of everything earned during the outage:

> 🏆 Parabéns @Zephyr-pt! O ranking de troféus está de volta — desde novembro de 2024 conquistaste **12 troféus platina**, num total de **7.850 TP**. Já está tudo contabilizado: vê a tua posição com `/trophy rank`.

**Why this isn't just "turn announcements on".** `trophies:sync` already announces trophies as it credits them, but its flood guards are tuned for steady state: more than 3 trophies for one profile in a run collapses to a single summary, and a whole run is capped at 10 messages. A backfill is spread across many 10-minute runs, so leaving those on during one produces scattered *"Sincronizámos 47 troféus novos"* lines with no explanation of why months-old platinums are suddenly being mentioned. Run the backfill silently, post this once, then switch normal announcements on for good.

**Safety rails**, because this mentions real people in bulk exactly once:

- **Previews by default.** Sends only with `--post`.
- **Refuses rather than truncates** when more members match than `--max` (default 60). The realistic way to get this wrong is a `--since` that sweeps in everybody, and posting "just the first few" is the worst of both outcomes.
- **A failed send doesn't abandon the run** — one Discord hiccup can't silence everyone after it. Exit code is non-zero so it's noticed.

`findCatchUpSummariesSince` aggregates in SQL and filters on `completionDate`, not `createdAt`, deliberately: the message tells a member what *they* achieved in that window, not when the bot happened to notice. Excluded profiles and profiles with no linked Discord account are dropped in the query — there's nobody to mention.

## 2. Malformed PSN online IDs (missed the #75 squash)

`extractPsnProfileFromUrl` returned the username path segment unvalidated. Production had one casualty: **`sabathian>`**, registered in 2022 by the old bot's raw `url.split('/')`, rendering as `sabathian>` on every leaderboard. PSNProfiles normalises the stray character away when fetching, so nothing ever failed loudly — it just looked wrong. (My earlier claim that it would 404 on every sync was wrong; I checked, and both spellings resolve.)

Now decodes the segment (a pasted `.../sabathian>` arrives as `sabathian%3E` after `new URL()`) and validates against PSN's own rules: 3–16 chars, leading letter or digit, then letters, digits, `-`, `_`. **All 118 production profiles pass** once the bad row is fixed, so it rejects nothing legitimate.

**The production row is already corrected** — `sabathian`, with its 165 trophies and 45,950 points intact and still linked.

## 3. `docs/psn-crawl.md` (also missed the squash)

How the crawl works, why it's split across two machines, the measurement table behind that split — including the two fingerprinting theories the evidence **disproved**, recorded so nobody re-tests them — the parser's traps, setup, verification, and a "when it breaks" section. Indexed in `docs/README.md`.

## Verification

`bun run typecheck` clean, **571 tests pass**, Prettier clean.

## Going live

Production has the #75 fix deployed but the crawl is still dormant — every switch is off, and the DB is unchanged (4,971 trophies, newest 2024-11-29). The sequence:

1. Set `PSN_FETCH_URL` / `PSN_FETCH_TOKEN` on `gop-bot`.
2. `jobs:run trophies:sync --dry-run --limit=20` — read the report, especially `newlyFlagged`.
3. `TROPHIES_SYNC_ENABLED=true`, leaving announcements **off**. Let the backfill catch up.
4. `trophies:catchup-announce --since=2024-11-30` (preview), then `--post`.
5. Set `DISCORD_CHANNEL_TROPHIES` (`#ps-trophy-hall` — it has never had a value, and announcements throw without one) and `TROPHIES_ANNOUNCE_ENABLED=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)