### PR TITLE
feat(portal-web): redesign the portal around collectible cards, add hunter pages and real filters

### DIFF
--- a/portal/api/src/repositories/trophies.ts
+++ b/portal/api/src/repositories/trophies.ts
@@ -164,7 +164,7 @@ async function rankOf(psnProfile: string, points: number, trophyCount: number): 
       ) ranked
       WHERE ranked.points > ?
          OR (ranked.points = ? AND ranked.trophyCount > ?)
-         OR (ranked.points = ? AND ranked.trophyCount = ? AND ranked.psnProfile < ?)
+         OR (ranked.points = ? AND ranked.trophyCount = ? AND (ranked.psnProfile IS NULL OR ranked.psnProfile < ?))
     `,
     points,
     points,

--- a/portal/api/src/repositories/trophies.ts
+++ b/portal/api/src/repositories/trophies.ts
@@ -1,5 +1,5 @@
 import { prisma } from "../db";
-import { publicTrophyProfileFilter } from "./visibility";
+import { optedOutDiscordIds, publicTrophyProfileFilter } from "./visibility";
 
 // Trophy leaderboard. Mirrors the aggregation/sort in the bot's
 // OrmTrophyRepository.queryRankedHunters (discord-bot/src/Infrastructure/Orm/OrmTrophyRepository.ts)
@@ -62,4 +62,117 @@ export async function getLeaderboard(limit: number): Promise<LeaderboardEntry[]>
     points: Number(row.points),
     trophyCount: Number(row.trophyCount),
   }));
+}
+
+// ---------------------------------------------------------------------------
+// M11 — one hunter's own platinum list, for the portal's hunter detail view.
+// ---------------------------------------------------------------------------
+
+export interface HunterTrophy {
+  /** The PSNProfiles trophy URL, e.g. `.../trophies/11783-assassins-creed-valhalla/Someone`. */
+  url: string | null;
+  points: number;
+  completionDate: Date | null;
+}
+
+export interface Hunter {
+  psnProfile: string;
+  rank: number;
+  points: number;
+  trophyCount: number;
+  trophies: HunterTrophy[];
+}
+
+/**
+ * Everything the portal can honestly say about one trophy hunter.
+ *
+ * The game a trophy belongs to is **not** a column — it is only recoverable
+ * from `trophies.url`'s slug (`/trophies/<id>-<game-slug>/<profile>`), which
+ * is what `PsnProfilesTrophySource.parseProfileTrophies` captured when the
+ * trophy was claimed. That parsing is deliberately left to the client
+ * (`portal/web/src/lib/psn.ts`) rather than done here: it is presentation of
+ * an already-public URL, it needs no database access, and keeping it
+ * client-side means a slug format change is a display bug rather than an API
+ * contract change.
+ *
+ * Same visibility contract as `getLeaderboard` — an excluded or opted-out
+ * profile is not found at all, so this endpoint can never be used to look up
+ * someone who chose not to appear on the leaderboard.
+ */
+export async function getHunter(psnProfile: string): Promise<Hunter | null> {
+  const optedOut = await optedOutDiscordIds();
+
+  const profile = await prisma.trophyProfile.findFirst({
+    where: {
+      psnProfile,
+      isExcluded: false,
+      ...(optedOut.length > 0 ? { OR: [{ userId: null }, { userId: { notIn: optedOut } }] } : {}),
+    },
+    select: { id: true, psnProfile: true },
+  });
+
+  if (!profile?.psnProfile) return null;
+
+  const rows = await prisma.trophies.findMany({
+    where: { trophyProfile: profile.id },
+    orderBy: [{ completionDate: "desc" }, { createdAt: "desc" }],
+    select: { url: true, points: true, completionDate: true },
+  });
+
+  // INNER JOIN semantics, same as the leaderboard: a profile with zero
+  // trophies is not a zero-point hunter, it is not a hunter.
+  if (rows.length === 0) return null;
+
+  const trophies = rows.map((row) => ({
+    url: row.url,
+    points: row.points ?? 0,
+    completionDate: row.completionDate,
+  }));
+  const points = trophies.reduce((sum, trophy) => sum + trophy.points, 0);
+
+  return {
+    psnProfile: profile.psnProfile,
+    rank: await rankOf(profile.psnProfile, points, trophies.length),
+    points,
+    trophyCount: trophies.length,
+    trophies,
+  };
+}
+
+/**
+ * The hunter's position in the same ordering `getLeaderboard` uses, computed
+ * as "how many profiles sort strictly before this one, plus one".
+ *
+ * The comparison mirrors that query's `ORDER BY points DESC, trophyCount
+ * DESC, psnProfile ASC` exactly, tie-break included — otherwise a hunter's
+ * detail page could claim a rank the leaderboard doesn't give them. Counting
+ * rather than paginating the whole board keeps this O(profiles) in SQL
+ * instead of pulling every hunter over the wire to find one index.
+ */
+async function rankOf(psnProfile: string, points: number, trophyCount: number): Promise<number> {
+  const rows = await prisma.$queryRawUnsafe<{ better: bigint | number }[]>(
+    `
+      SELECT CAST(COUNT(*) AS SIGNED) AS better FROM (
+        SELECT
+          tp.psnProfile AS psnProfile,
+          COALESCE(SUM(t.points), 0) AS points,
+          COUNT(t.id) AS trophyCount
+        FROM trophyprofiles tp
+        INNER JOIN trophies t ON t.trophyProfile = tp.id
+        WHERE ${publicTrophyProfileFilter()}
+        GROUP BY tp.id, tp.psnProfile
+      ) ranked
+      WHERE ranked.points > ?
+         OR (ranked.points = ? AND ranked.trophyCount > ?)
+         OR (ranked.points = ? AND ranked.trophyCount = ? AND ranked.psnProfile < ?)
+    `,
+    points,
+    points,
+    trophyCount,
+    points,
+    trophyCount,
+    psnProfile,
+  );
+
+  return Number(rows[0]?.better ?? 0) + 1;
 }

--- a/portal/api/src/routes/trophies.ts
+++ b/portal/api/src/routes/trophies.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { getLeaderboard } from "../repositories/trophies";
+import { getHunter, getLeaderboard } from "../repositories/trophies";
 
 export const trophies = new Hono();
 
@@ -9,4 +9,14 @@ trophies.get("/trophies/leaderboard", async (c) => {
 
   const leaderboard = await getLeaderboard(limit);
   return c.json({ leaderboard, limit });
+});
+
+// M11 — one hunter's platinum list, behind the same visibility filter as the
+// leaderboard: a profile that is excluded or has opted out 404s here exactly
+// as it is absent there, so this route can never be used to look someone up
+// who chose not to be listed.
+trophies.get("/trophies/hunters/:psnProfile", async (c) => {
+  const hunter = await getHunter(c.req.param("psnProfile"));
+  if (!hunter) return c.json({ error: "not found" }, 404);
+  return c.json({ hunter });
 });

--- a/portal/api/tests/trophies.test.ts
+++ b/portal/api/tests/trophies.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { buildApp } from "../src/app";
 import { prisma } from "../src/db";
-import type { LeaderboardEntry } from "../src/repositories/trophies";
+import type { Hunter, LeaderboardEntry } from "../src/repositories/trophies";
 import { cleanupByIdPrefix, uniqueId } from "./helpers";
 
 interface LeaderboardResponse {
@@ -33,8 +33,20 @@ beforeAll(async () => {
 
   await prisma.trophies.createMany({
     data: [
-      { id: uniqueId(PREFIX), trophyProfile: topProfileId, points: 90 },
-      { id: uniqueId(PREFIX), trophyProfile: topProfileId, points: 30 },
+      {
+        id: uniqueId(PREFIX),
+        trophyProfile: topProfileId,
+        points: 90,
+        url: "https://psnprofiles.com/trophies/11783-assassins-creed-valhalla/TopHunter",
+        completionDate: new Date("2024-03-02T00:00:00Z"),
+      },
+      {
+        id: uniqueId(PREFIX),
+        trophyProfile: topProfileId,
+        points: 30,
+        url: "https://psnprofiles.com/trophies/12-grand-theft-auto-iv/TopHunter",
+        completionDate: new Date("2023-01-05T00:00:00Z"),
+      },
       // Excluded profile has trophies, but must never appear in the leaderboard.
       { id: uniqueId(PREFIX), trophyProfile: bannedProfileId, points: 500 },
     ],
@@ -62,5 +74,40 @@ describe("GET /api/trophies/leaderboard", () => {
     expect(top?.points).toBe(120);
     expect(top?.trophyCount).toBe(2);
     expect(top).not.toHaveProperty("userId");
+  });
+});
+
+describe("GET /api/trophies/hunters/:psnProfile", () => {
+  test("returns the hunter's own platinum list, newest first, without leaking userId", async () => {
+    const res = await app.request("/api/trophies/hunters/TopHunter");
+    expect(res.status).toBe(200);
+
+    const { hunter } = (await res.json()) as { hunter: Hunter };
+
+    expect(hunter.psnProfile).toBe("TopHunter");
+    expect(hunter.points).toBe(120);
+    expect(hunter.trophyCount).toBe(2);
+    expect(hunter.rank).toBeGreaterThanOrEqual(1);
+    expect(hunter).not.toHaveProperty("userId");
+
+    // Ordered by completionDate DESC — the 2024 platinum comes before the 2023 one.
+    expect(hunter.trophies.map((t) => t.points)).toEqual([90, 30]);
+    // The URL is what makes the game recoverable client-side (src/lib/psn.ts).
+    expect(hunter.trophies[0]?.url).toContain("11783-assassins-creed-valhalla");
+  });
+
+  test("404s for an excluded profile, so it cannot be used to route around the leaderboard filter", async () => {
+    const res = await app.request("/api/trophies/hunters/BannedPlayer");
+    expect(res.status).toBe(404);
+  });
+
+  test("404s for a profile with no trophies, matching the leaderboard's INNER JOIN semantics", async () => {
+    const res = await app.request("/api/trophies/hunters/NoTrophiesYet");
+    expect(res.status).toBe(404);
+  });
+
+  test("404s for an unknown profile", async () => {
+    const res = await app.request("/api/trophies/hunters/does-not-exist-at-all");
+    expect(res.status).toBe(404);
   });
 });

--- a/portal/web/bun.lock
+++ b/portal/web/bun.lock
@@ -5,7 +5,10 @@
     "": {
       "name": "web",
       "dependencies": {
+        "@fontsource-variable/big-shoulders-display": "5.3.0",
         "@fontsource-variable/inter": "5.3.0",
+        "@fontsource-variable/jetbrains-mono": "5.3.0",
+        "@fontsource-variable/space-grotesk": "5.3.0",
         "@fontsource/archivo-black": "5.3.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -25,7 +28,13 @@
     },
   },
   "packages": {
+    "@fontsource-variable/big-shoulders-display": ["@fontsource-variable/big-shoulders-display@5.3.0", "", {}, "sha512-7k1REXMZFEa7gSWOURbmCJW5Gv9D0EbEFQgosZidM8Ob/qpPlK96vqyIzCTnNZ/C0XFZWxeKU53D3QdeHctYCA=="],
+
     "@fontsource-variable/inter": ["@fontsource-variable/inter@5.3.0", "", {}, "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA=="],
+
+    "@fontsource-variable/jetbrains-mono": ["@fontsource-variable/jetbrains-mono@5.3.0", "", {}, "sha512-F32xpS2NsGYoQi2ADSkKTgpJj7ozajsGgDJ8woTnqjmIB+dxDIqImjl4pXZVEExu8UFZ2ndhmX18EBS/hdz3Lw=="],
+
+    "@fontsource-variable/space-grotesk": ["@fontsource-variable/space-grotesk@5.3.0", "", {}, "sha512-2IxmvfB08i9vnGB3Ym/AXvhRE+8XOjWMXIyDum03c+tPwH0FUoMNQfGpU8NXPxjbws0Vvss3AH0Zqt4oJBBAdw=="],
 
     "@fontsource/archivo-black": ["@fontsource/archivo-black@5.3.0", "", {}, "sha512-7EsTIQ+Blf96ktpzTUpI7msi+u9/AJxM/GZxOSkEubVd1jSTrFSTNxMgfpX/8rQsjZ+19a+qvRbtcTEp5J/72g=="],
 

--- a/portal/web/package.json
+++ b/portal/web/package.json
@@ -12,7 +12,10 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@fontsource-variable/big-shoulders-display": "5.3.0",
     "@fontsource-variable/inter": "5.3.0",
+    "@fontsource-variable/jetbrains-mono": "5.3.0",
+    "@fontsource-variable/space-grotesk": "5.3.0",
     "@fontsource/archivo-black": "5.3.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/portal/web/src/App.tsx
+++ b/portal/web/src/App.tsx
@@ -3,6 +3,7 @@ import { Layout } from "./components/Layout";
 import { AdminAuthProvider } from "./lib/AdminAuthContext";
 import { ComoParticipar } from "./pages/ComoParticipar";
 import { HallOfFame } from "./pages/HallOfFame";
+import { HunterDetail } from "./pages/HunterDetail";
 import { Home } from "./pages/Home";
 import { Marketplace } from "./pages/Marketplace";
 import { MarketplaceDetail } from "./pages/MarketplaceDetail";
@@ -44,6 +45,9 @@ export default function App() {
         <Route path="screenshots" element={<Screenshots />} />
         <Route path="screenshots/hall-of-fame" element={<HallOfFame />} />
         <Route path="trophies" element={<Trophies />} />
+        {/* M11 — one hunter's own platinum list. Placed after the
+            index route so "/trophies" still resolves to the board. */}
+        <Route path="trophies/:psnProfile" element={<HunterDetail />} />
         <Route path="como-participar" element={<ComoParticipar />} />
         <Route path="privacy" element={<Privacy />} />
         <Route path="*" element={<NotFound />} />

--- a/portal/web/src/components/AdCard.tsx
+++ b/portal/web/src/components/AdCard.tsx
@@ -1,52 +1,82 @@
 import { Link } from "react-router-dom";
 import type { Ad } from "../lib/api/client";
-import { formatPrice, normalizeCondition, normalizePlatform, CONDITION_LABELS } from "../lib/normalize";
+import { thumbnailUrl } from "../lib/api/client";
+import { CONDITION_LABELS, formatPrice, normalizeCondition, normalizePlatform, normalizeZone } from "../lib/normalize";
+import { PLATFORMS } from "../lib/platforms";
 import { LazyImage } from "./LazyImage";
 import { PlatformBadge } from "./PlatformBadge";
 
 /**
- * One marketplace listing card — used by both the Home "newest listings"
- * strip (M8.6) and the Marketplace grid (M8.7), so the two never drift.
+ * One marketplace listing card — used by the Home preview (M8.6), the
+ * Marketplace grid (M8.7) and the "related" strip on a detail page, so the
+ * three never drift.
  *
- * `ad.state` is overloaded in the schema (docs/00-overview.md "Data
- * reality": it means *condition*, not platform) — this card runs it through
- * BOTH `normalizeCondition` and `normalizePlatform`. Neither is guaranteed
- * to match; each renders only if it does. That is a display nicety, not a
- * bug: a handful of ads have platform-shaped text in a condition-shaped
- * column ("Data reality": someone answered the wrong question).
+ * `ad.state` is overloaded in the schema (docs/00-overview.md "Data reality":
+ * it means *condition*, not platform) — this card runs it through BOTH
+ * `normalizeCondition` and `normalizePlatform`. Neither is guaranteed to
+ * match; each renders only if it does. That is a display nicety, not a bug: a
+ * handful of ads have platform-shaped text in a condition-shaped column.
+ *
+ * M11: the platform's accent became the card's top rule, which is what makes
+ * a grid of listings scannable by platform at a glance rather than needing
+ * every badge read. `other`/unknown gets a neutral rule — the four accents
+ * mean something specific (src/lib/platforms.ts) and a fifth invented colour
+ * would dilute that.
  */
 export function AdCard({ ad }: { ad: Ad }) {
   const condition = normalizeCondition(ad.state);
-  const platform = normalizePlatform(ad.state);
+  // `state` is a single overloaded column (docs/00-overview.md "Data
+  // reality"). If it parsed as a *condition*, it is definitionally not also a
+  // platform — reading it as both is how a "Novo/Selado" ad ended up wearing
+  // an "Outra" platform badge, asserting a platform nobody recorded. And an
+  // unrecognised value carries no information worth a badge either way.
+  const platform = condition === null ? normalizePlatform(ad.state) : null;
+  const knownPlatform = platform && platform !== "other" ? platform : null;
+  const zone = normalizeZone(ad.zone);
+  const accent = knownPlatform ? PLATFORMS[knownPlatform].colorVar : "var(--color-surface-border)";
 
   return (
     <Link
       to={`/marketplace/${ad.id}`}
-      className="chamfer group block border border-surface-border bg-surface transition-colors hover:border-white/30"
+      className="focus-glow group relative flex h-full flex-col overflow-hidden rounded-xl border border-surface-border bg-surface transition-all duration-200 hover:-translate-y-1.5 hover:border-white/25"
     >
-      <LazyImage
-        src={ad.images[0] ?? null}
-        alt={ad.name ?? "Anúncio"}
-        className="aspect-video w-full overflow-hidden border-b border-surface-border"
-      />
-      <div className="p-4">
-        <div className="flex items-start justify-between gap-2">
-          <h3 className="font-semibold group-hover:text-accent-yellow">{ad.name ?? "Anúncio sem título"}</h3>
-          {ad.adType === "wanted" && (
-            <span className="chamfer shrink-0 border border-accent-blue px-2 py-0.5 text-[11px] font-semibold text-accent-blue">
-              PROCURA-SE
-            </span>
-          )}
-        </div>
-        <p className="mt-1 text-sm text-white/70">{formatPrice(ad.price_cents, ad.price)}</p>
-        <div className="mt-2 flex flex-wrap items-center gap-1.5">
-          {platform && <PlatformBadge platform={platform} />}
+      <span aria-hidden className="absolute inset-x-0 top-0 z-10 h-[3px]" style={{ backgroundColor: accent }} />
+
+      <div className="relative overflow-hidden">
+        <LazyImage
+          src={thumbnailUrl(ad.images[0] ?? null, 480)}
+          alt={ad.name ?? "Anúncio"}
+          className="aspect-video w-full overflow-hidden border-b border-surface-border transition-transform duration-500 group-hover:scale-[1.06]"
+        />
+        {ad.adType === "wanted" && (
+          <span className="absolute top-3 right-3 rounded-md border border-accent-blue bg-background/85 px-2 py-0.5 font-mono text-[10px] font-semibold tracking-[0.12em] text-accent-blue uppercase backdrop-blur">
+            Procura-se
+          </span>
+        )}
+      </div>
+
+      <div className="flex flex-1 flex-col p-4">
+        <h3 className="line-clamp-2 text-[15px] leading-snug font-semibold transition-colors group-hover:text-accent-yellow">
+          {ad.name ?? "Anúncio sem título"}
+        </h3>
+
+        <div className="mt-3 flex flex-wrap items-center gap-1.5">
+          {knownPlatform && <PlatformBadge platform={knownPlatform} />}
           {condition && (
-            <span className="chamfer inline-flex items-center border border-surface-border px-2 py-0.5 text-xs text-white/70">
+            <span className="rounded-md border border-surface-border px-2 py-0.5 font-mono text-[10px] tracking-wide text-white/60">
               {CONDITION_LABELS[condition]}
             </span>
           )}
+          {zone && (
+            <span className="rounded-md border border-surface-border px-2 py-0.5 font-mono text-[10px] tracking-wide text-white/60">
+              {zone.label}
+            </span>
+          )}
         </div>
+
+        <p className="tabular mt-auto pt-4 font-display text-3xl leading-none font-extrabold">
+          {formatPrice(ad.price_cents, ad.price)}
+        </p>
       </div>
     </Link>
   );

--- a/portal/web/src/components/HoloCard.tsx
+++ b/portal/web/src/components/HoloCard.tsx
@@ -1,0 +1,46 @@
+import { useTilt } from "../lib/useTilt";
+
+/**
+ * The redesign's signature element: a collectible-card surface that leans
+ * toward the pointer while a holographic foil tracks the same position.
+ *
+ * Used sparingly and on purpose — the guild card in the hero and the three
+ * podium hunters. Everything else on the site is a plain card with at most a
+ * `.shine` sweep. One memorable thing, executed properly, beats the effect
+ * being sprayed over every tile until it reads as noise.
+ *
+ * Structure matters for the foil to composite correctly:
+ *   - the outer element owns `perspective`, so the tilt has depth
+ *   - the card owns `.holo-foil`, whose ::before/::after sit at z-index 2-3
+ *   - content is z-index 4, above the foil, so text never gets colour-dodged
+ *     into illegibility
+ *
+ * Degrades in the right direction: with no pointer, no JS or reduced motion
+ * the card keeps a static centred sheen (see `.holo-foil`'s defaults) instead
+ * of losing its identity.
+ */
+export function HoloCard({
+  children,
+  className,
+  ratio = "aspect-[63/88]",
+}: {
+  children: React.ReactNode;
+  className?: string;
+  /** Trading-card proportions by default; podium cards override it. */
+  ratio?: string;
+}) {
+  const tilt = useTilt<HTMLDivElement>();
+
+  return (
+    <div className="[perspective:1100px]">
+      <div
+        ref={tilt.ref}
+        onPointerMove={tilt.onPointerMove}
+        onPointerLeave={tilt.onPointerLeave}
+        className={`holo-foil relative overflow-hidden rounded-2xl border border-white/15 bg-gradient-to-br from-[#1b1410] via-[#080504] to-[#141b1e] shadow-[0_26px_60px_-18px_rgba(0,0,0,0.9)] transition-transform duration-200 ease-out [transform-style:preserve-3d] ${ratio} ${className ?? ""}`}
+      >
+        <div className="relative z-[4] flex h-full flex-col p-5">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/portal/web/src/components/Layout.tsx
+++ b/portal/web/src/components/Layout.tsx
@@ -4,101 +4,153 @@ import { BrandMark } from "./BrandMark";
 const DISCORD_INVITE = "https://discord.gg/mBJKUhwE23";
 
 const NAV_LINKS = [
-  { to: "/marketplace", label: "Marketplace" },
+  { to: "/marketplace", label: "Mercado" },
   { to: "/screenshots", label: "Screenshots" },
-  { to: "/trophies", label: "Troféus" },
+  { to: "/trophies", label: "Hall of Fame" },
   { to: "/como-participar", label: "Como participar" },
 ];
 
-// Mobile-first shell (375px baseline — docs/plans/03-portal.md "Mobile"):
-// a slim sticky header that never competes with content, and a footer with
-// the socials from docs/plans/00-overview.md. Desktop is a max-width
-// container, not a different layout.
-//
-// M8.6-M8.9 nav added here (was just the wordmark + Discord CTA in M8.5's
-// scaffold): a horizontally-scrollable link row so it doesn't wrap/crowd the
-// 375px baseline, rather than a hamburger menu — three links is not enough
-// to justify a drawer, and a drawer is one more thing to test in the
-// Discord in-app browser (plan 03 "Mobile").
+const SOCIALS = [
+  { href: DISCORD_INVITE, label: "Discord" },
+  { href: "https://t.me/gameonportugal", label: "Telegram" },
+  { href: "https://facebook.com/gameonportugalofficial", label: "Facebook" },
+];
+
+/**
+ * Mobile-first shell (375px baseline — docs/plans/03-portal.md "Mobile"): a
+ * slim sticky header that never competes with content, and a footer with the
+ * socials from docs/plans/00-overview.md. Desktop is a max-width container,
+ * not a different layout.
+ *
+ * The nav stays a horizontally-scrollable link row rather than becoming a
+ * hamburger drawer — four links is not enough to justify one, and a drawer is
+ * one more thing to test in the Discord in-app browser this site is mostly
+ * opened from (plan 03 "Mobile").
+ *
+ * M10.1's mark-plus-text lockup is kept exactly as it was: the wordmark stays
+ * real text, because it is the accessible name and it stays crisp at every
+ * zoom level. M11 only changes how that text is set — "GAME ON" in the brush
+ * wordmark face over "PORTUGAL" in mono, echoing the lockup in
+ * brand/logo-lockup-2048.png.
+ */
 export function Layout() {
   return (
     <div className="flex min-h-dvh flex-col">
-      <header className="sticky top-0 z-10 border-b border-surface-border bg-background/90 backdrop-blur">
-        <div className="mx-auto flex max-w-5xl items-center justify-between gap-3 px-4 py-3">
-          {/* M10.1 — the mark alongside the wordmark. The wordmark stays as
-              real text rather than becoming part of an image: it is the
-              accessible name, it stays crisp at every zoom level, and it is
-              what M8.5 already got right. The mark is additive. */}
-          <a href="/" className="focus-glow flex shrink-0 items-center gap-2">
-            <BrandMark className="h-8" />
-            <span className="font-display text-lg tracking-tight">
-              GAME ON <span className="text-accent-yellow">PORTUGAL</span>
+      <a
+        href="#conteudo"
+        className="focus-glow sr-only rounded-lg bg-accent-yellow px-4 py-2 font-semibold text-background focus:not-sr-only focus:absolute focus:top-3 focus:left-3 focus:z-50"
+      >
+        Saltar para o conteúdo
+      </a>
+
+      <header className="sticky top-0 z-40 border-b border-surface-border bg-background/85 backdrop-blur-md">
+        <div className="mx-auto flex max-w-6xl items-center gap-4 px-4 py-3 sm:gap-8">
+          <a href="/" className="focus-glow flex shrink-0 items-center gap-2.5 rounded-lg">
+            <BrandMark className="h-9" />
+            <span className="leading-none">
+              <span className="block font-wordmark text-base tracking-tight">GAME ON</span>
+              <span className="mt-1 block font-mono text-[9px] tracking-[0.3em] text-accent-mint">PORTUGAL</span>
             </span>
           </a>
-          <nav className="flex min-w-0 flex-1 items-center gap-4 overflow-x-auto text-sm text-white/70">
+
+          <nav
+            aria-label="Principal"
+            className="flex min-w-0 flex-1 items-center gap-5 overflow-x-auto text-sm whitespace-nowrap"
+          >
             {NAV_LINKS.map((link) => (
               <NavLink
                 key={link.to}
                 to={link.to}
                 className={({ isActive }) =>
-                  `focus-glow shrink-0 whitespace-nowrap hover:text-white ${isActive ? "text-white" : ""}`
+                  `focus-glow shrink-0 rounded font-medium transition-colors ${
+                    isActive ? "text-white" : "text-white/55 hover:text-white"
+                  }`
                 }
               >
                 {link.label}
               </NavLink>
             ))}
           </nav>
+
           <a
             href={DISCORD_INVITE}
             target="_blank"
             rel="noreferrer"
-            className="focus-glow chamfer shrink-0 bg-accent-blue px-4 py-2 text-sm font-semibold text-background transition-opacity hover:opacity-90"
+            className="focus-glow chamfer hidden shrink-0 bg-accent-yellow px-4 py-2.5 text-sm font-bold text-background transition-transform hover:-translate-y-0.5 sm:block"
           >
             Entrar no Discord
           </a>
         </div>
       </header>
 
-      <main className="flex-1">
+      <main id="conteudo" className="flex-1">
         <Outlet />
       </main>
 
-      <footer className="border-t border-surface-border">
-        <div className="mx-auto flex max-w-5xl flex-col gap-2 px-4 py-8 text-sm text-white/60">
-          <p className="flex items-center gap-2">
-            <BrandMark className="h-6 opacity-70" />
-            Game On Portugal — comunidade de jogadores portuguesa.
+      <footer className="mt-16 border-t border-surface-border">
+        <div className="mx-auto max-w-6xl px-4 py-10">
+          <div className="flex flex-wrap items-start justify-between gap-8">
+            <div>
+              <div className="flex items-center gap-2.5">
+                <BrandMark className="h-8 opacity-70" />
+                <span className="leading-none">
+                  <span className="block font-wordmark text-sm tracking-tight">GAME ON</span>
+                  <span className="mt-1 block font-mono text-[8px] tracking-[0.3em] text-white/40">PORTUGAL</span>
+                </span>
+              </div>
+              <p className="mt-4 max-w-sm text-sm text-white/50">
+                A comunidade de jogadores portuguesa. O mercado, a galeria e o ranking vivem no Discord — isto é a
+                janela para eles.
+              </p>
+            </div>
+
+            <div className="flex gap-12">
+              <nav aria-label="Comunidade">
+                <h2 className="font-mono text-[10px] tracking-[0.18em] text-white/35 uppercase">Comunidade</h2>
+                <ul className="mt-3 space-y-2 text-sm">
+                  {SOCIALS.map((social) => (
+                    <li key={social.label}>
+                      <a
+                        href={social.href}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="focus-glow rounded text-white/60 transition-colors hover:text-white"
+                      >
+                        {social.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </nav>
+
+              <nav aria-label="Site">
+                <h2 className="font-mono text-[10px] tracking-[0.18em] text-white/35 uppercase">Site</h2>
+                <ul className="mt-3 space-y-2 text-sm">
+                  {NAV_LINKS.map((link) => (
+                    <li key={link.to}>
+                      <Link to={link.to} className="focus-glow rounded text-white/60 transition-colors hover:text-white">
+                        {link.label}
+                      </Link>
+                    </li>
+                  ))}
+                  {/* M10.2 — the /admin link was removed from here (Luis,
+                      2026-08-22). The route is gated on Discord OAuth +
+                      ManageMessages (pages/admin/AdminLayout.tsx), so the link
+                      was never what protected it; removing it just stops the
+                      login form being advertised to every crawler. */}
+                  <li>
+                    <Link to="/privacy" className="focus-glow rounded text-white/60 transition-colors hover:text-white">
+                      Privacidade
+                    </Link>
+                  </li>
+                </ul>
+              </nav>
+            </div>
+          </div>
+
+          <p className="mt-10 border-t border-surface-border pt-6 font-mono text-[11px] text-white/30">
+            © {new Date().getFullYear()} Game On Portugal — feito por gente que joga.
           </p>
-          <nav className="flex flex-wrap gap-4">
-            <a href={DISCORD_INVITE} target="_blank" rel="noreferrer" className="hover:text-white">
-              Discord
-            </a>
-            <a href="https://t.me/gameonportugal" target="_blank" rel="noreferrer" className="hover:text-white">
-              Telegram
-            </a>
-            <a
-              href="https://facebook.com/gameonportugalofficial"
-              target="_blank"
-              rel="noreferrer"
-              className="hover:text-white"
-            >
-              Facebook
-            </a>
-            {/* M10.2 — the /admin link was removed from here (Luis,
-                2026-08-22). M8.10's "discreet, not hidden" reasoning still
-                holds on the security question: the route is gated on Discord
-                OAuth + ManageMessages (pages/admin/AdminLayout.tsx), so the
-                link was never what protected it, and removing it protects
-                nothing by itself. What it does buy is that the login form is
-                no longer advertised to every passer-by and every crawler, so
-                the auth logs stop collecting drive-by attempts. Moderators
-                navigate to /admin directly; the route is unchanged. */}
-            {/* M9.7 — the privacy page: what's shown publicly, how to opt
-                out, and the GDPR erasure path. */}
-            <Link to="/privacy" className="hover:text-white">
-              Privacidade
-            </Link>
-          </nav>
         </div>
       </footer>
     </div>

--- a/portal/web/src/components/Lightbox.tsx
+++ b/portal/web/src/components/Lightbox.tsx
@@ -1,23 +1,41 @@
 import { useEffect } from "react";
-import type { Screenshot } from "../lib/api/client";
 import { normalizePlatform } from "../lib/normalize";
 import { PlatformBadge } from "./PlatformBadge";
 
 /**
- * Full-screen viewer for the screenshots gallery (M8.8). Keyboard-navigable
- * (Esc closes, arrow keys move) and closes on backdrop click. No transition
- * animation — plan 03's "motion is functional only" plus the global
- * `prefers-reduced-motion` override in index.css already covers this: a
- * plain instant show/hide needs no extra handling for reduced motion,
- * unlike a slide/fade would.
+ * Full-screen viewer for the screenshots gallery (M8.8) and the marketplace
+ * detail gallery (M11).
+ *
+ * The item shape is structural rather than `Screenshot`, so an ad's image
+ * array can be viewed with the same component instead of a second, nearly
+ * identical overlay. `Screenshot` satisfies it as-is.
+ *
+ * Keyboard-navigable (Esc closes, arrows move) and closes on backdrop click.
+ * No enter/exit transition — plan 03's "motion is functional only" plus the
+ * global `prefers-reduced-motion` override already covers this, and a plain
+ * instant show/hide needs no extra handling for reduced motion the way a
+ * slide or fade would.
+ *
+ * Body scroll is locked while open: without it, arrow keys and the wheel
+ * scroll the page behind the overlay, so closing it drops you somewhere else.
  */
+export interface LightboxItem {
+  id: string;
+  name: string | null;
+  imageUrl: string | null;
+  platform?: string | null;
+  createdAt?: string;
+}
+
+const DATE_FORMAT = new Intl.DateTimeFormat("pt-PT", { day: "numeric", month: "long", year: "numeric" });
+
 export function Lightbox({
   items,
   index,
   onClose,
   onNavigate,
 }: {
-  items: Screenshot[];
+  items: LightboxItem[];
   index: number;
   onClose: () => void;
   onNavigate: (nextIndex: number) => void;
@@ -31,42 +49,59 @@ export function Lightbox({
       if (event.key === "ArrowLeft") onNavigate((index - 1 + items.length) % items.length);
     }
     window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
   }, [index, items.length, onClose, onNavigate]);
 
   if (!current) return null;
-  const platform = normalizePlatform(current.platform);
+
+  const platform = current.platform !== undefined ? normalizePlatform(current.platform) : null;
+  const date = current.createdAt ? new Date(current.createdAt) : null;
 
   return (
     <div
-      className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-background/95 p-4"
+      className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-background/96 p-4 backdrop-blur-sm"
       onClick={onClose}
       role="dialog"
       aria-modal
+      aria-label={current.name ?? "Imagem"}
     >
-      <button
-        type="button"
-        onClick={onClose}
-        className="focus-glow absolute top-4 right-4 chamfer border border-surface-border px-3 py-1.5 text-sm text-white/80 hover:text-white"
-        aria-label="Fechar"
-      >
-        Fechar ✕
-      </button>
+      <div className="absolute top-4 right-4 left-4 flex items-center justify-between">
+        <span className="tabular font-mono text-xs text-white/45">
+          {index + 1} / {items.length}
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          className="focus-glow rounded-lg border border-surface-border bg-surface/80 px-3 py-1.5 font-mono text-xs text-white/75 transition-colors hover:text-white"
+        >
+          Fechar ✕
+        </button>
+      </div>
 
-      <div className="flex max-h-full max-w-4xl flex-col items-center gap-3" onClick={(e) => e.stopPropagation()}>
+      <div className="flex max-h-full max-w-5xl flex-col items-center gap-4" onClick={(event) => event.stopPropagation()}>
         {current.imageUrl ? (
           <img
             src={current.imageUrl}
-            alt={current.name ?? "Screenshot"}
-            className="max-h-[75vh] max-w-full object-contain"
+            alt={current.name ?? "Imagem"}
+            className="max-h-[76vh] max-w-full rounded-lg object-contain"
           />
         ) : (
-          <div className="flex h-64 w-full items-center justify-center bg-surface text-white/40">Sem imagem</div>
+          <div className="flex h-64 w-full items-center justify-center rounded-lg bg-surface text-white/40">
+            Sem imagem
+          </div>
         )}
 
-        <div className="flex flex-wrap items-center justify-center gap-3 text-sm text-white/70">
-          {current.name && <span>{current.name}</span>}
+        <div className="flex flex-wrap items-center justify-center gap-3 text-sm">
+          {current.name && <span className="font-semibold">{current.name}</span>}
           {platform && <PlatformBadge platform={platform} />}
+          {date && <span className="font-mono text-xs text-white/40">{DATE_FORMAT.format(date)}</span>}
         </div>
       </div>
 
@@ -74,22 +109,22 @@ export function Lightbox({
         <>
           <button
             type="button"
-            onClick={(e) => {
-              e.stopPropagation();
+            onClick={(event) => {
+              event.stopPropagation();
               onNavigate((index - 1 + items.length) % items.length);
             }}
-            className="focus-glow absolute left-2 top-1/2 -translate-y-1/2 chamfer border border-surface-border bg-background/60 px-3 py-4 text-lg text-white/80 hover:text-white sm:left-6"
+            className="focus-glow absolute top-1/2 left-2 -translate-y-1/2 rounded-lg border border-surface-border bg-surface/70 px-3 py-4 text-lg text-white/75 transition-colors hover:text-white sm:left-6"
             aria-label="Anterior"
           >
             ‹
           </button>
           <button
             type="button"
-            onClick={(e) => {
-              e.stopPropagation();
+            onClick={(event) => {
+              event.stopPropagation();
               onNavigate((index + 1) % items.length);
             }}
-            className="focus-glow absolute right-2 top-1/2 -translate-y-1/2 chamfer border border-surface-border bg-background/60 px-3 py-4 text-lg text-white/80 hover:text-white sm:right-6"
+            className="focus-glow absolute top-1/2 right-2 -translate-y-1/2 rounded-lg border border-surface-border bg-surface/70 px-3 py-4 text-lg text-white/75 transition-colors hover:text-white sm:right-6"
             aria-label="Seguinte"
           >
             ›

--- a/portal/web/src/components/PageHeader.tsx
+++ b/portal/web/src/components/PageHeader.tsx
@@ -1,0 +1,100 @@
+import { Link } from "react-router-dom";
+
+/**
+ * The masthead every list page shares (M11), so Mercado, Screenshots and Hall
+ * of Fame read as three rooms in one building rather than three pages that
+ * happen to share a header.
+ *
+ * `stats` is the page's own headline numbers — the thing that used to live
+ * only on the Home stats bar, now repeated where it is actually relevant.
+ */
+export function PageHeader({
+  eyebrow,
+  title,
+  description,
+  stats,
+  children,
+}: {
+  eyebrow: string;
+  title: string;
+  description: string;
+  stats?: Array<{ label: string; value: string; accent?: string }>;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="border-b border-surface-border">
+      <div className="mx-auto max-w-6xl px-4 pt-10 pb-8">
+        <p className="flex items-center gap-3 font-mono text-[11px] tracking-[0.22em] text-accent-mint uppercase">
+          <span aria-hidden className="h-px w-8 bg-accent-mint" />
+          {eyebrow}
+        </p>
+
+        <div className="mt-4 flex flex-wrap items-end justify-between gap-6">
+          <div>
+            <h1 className="font-display text-5xl font-extrabold uppercase sm:text-6xl">{title}</h1>
+            <p className="mt-3 max-w-xl text-sm leading-relaxed text-white/55">{description}</p>
+          </div>
+
+          {stats && stats.length > 0 && (
+            <dl className="flex gap-8">
+              {stats.map((stat) => (
+                <div key={stat.label}>
+                  <dd
+                    className="tabular font-display text-3xl leading-none font-extrabold"
+                    style={{ color: stat.accent }}
+                  >
+                    {stat.value}
+                  </dd>
+                  <dt className="mt-2 font-mono text-[10px] tracking-[0.15em] text-white/40 uppercase">
+                    {stat.label}
+                  </dt>
+                </div>
+              ))}
+            </dl>
+          )}
+        </div>
+
+        {children && <div className="mt-6">{children}</div>}
+      </div>
+    </div>
+  );
+}
+
+/** A quiet "here is where this actually happens" link, used under page headers. */
+export function HelpLink({ to, children }: { to: string; children: React.ReactNode }) {
+  return (
+    <Link
+      to={to}
+      className="focus-glow inline-flex items-center gap-1.5 rounded font-mono text-xs text-accent-blue transition-colors hover:text-white"
+    >
+      {children}
+      <span aria-hidden>→</span>
+    </Link>
+  );
+}
+
+/** Section heading for the Home preview sections. */
+export function SectionHeader({
+  title,
+  count,
+  href,
+  linkLabel = "Ver tudo",
+}: {
+  title: string;
+  count?: string;
+  href: string;
+  linkLabel?: string;
+}) {
+  return (
+    <div className="flex items-end gap-4 border-b border-surface-border pb-4">
+      <h2 className="font-display text-3xl font-extrabold uppercase sm:text-4xl">{title}</h2>
+      {count && <span className="pb-1 font-mono text-[11px] text-white/35">{count}</span>}
+      <Link
+        to={href}
+        className="focus-glow ml-auto rounded pb-1 font-mono text-[11px] tracking-[0.14em] text-accent-yellow uppercase transition-colors hover:text-white"
+      >
+        {linkLabel} →
+      </Link>
+    </div>
+  );
+}

--- a/portal/web/src/components/PlatformBadge.tsx
+++ b/portal/web/src/components/PlatformBadge.tsx
@@ -1,10 +1,11 @@
-import { PLATFORMS } from "../lib/platforms";
 import type { PlatformTag } from "../lib/normalize";
+import { PLATFORMS } from "../lib/platforms";
 
 /**
- * The one component every future marketplace/gallery/leaderboard row reuses
- * for a platform tag. Text is always near-black on the accent fill — see
- * src/lib/platforms.ts for the AA contrast table that rules out white text.
+ * The one component every marketplace/gallery/leaderboard row reuses for a
+ * platform tag. Text is always near-black on the accent fill — see
+ * src/lib/platforms.ts for the AA contrast table that rules out white text on
+ * every one of the four accents.
  *
  * Also accepts `normalizePlatform()`'s residual `"other"` bucket (M8.4) —
  * deliberately rendered *without* one of the four brand accents (plan 03:
@@ -12,11 +13,15 @@ import type { PlatformTag } from "../lib/normalize";
  * something specific; a fifth, made-up colour for "everything else" would
  * dilute that). It gets a plain muted outline instead.
  */
-export function PlatformBadge({ platform }: { platform: PlatformTag }) {
+export function PlatformBadge({ platform, size = "sm" }: { platform: PlatformTag; size?: "sm" | "md" }) {
+  const sizing = size === "md" ? "px-2.5 py-1 text-[11px]" : "px-2 py-0.5 text-[10px]";
+
   if (platform === "other") {
     return (
-      <span className="chamfer inline-flex items-center border border-surface-border px-2 py-0.5 text-xs font-semibold text-white/70">
-        Outra plataforma
+      <span
+        className={`inline-flex items-center rounded-md border border-surface-border font-mono tracking-wide text-white/60 ${sizing}`}
+      >
+        Outra
       </span>
     );
   }
@@ -25,7 +30,7 @@ export function PlatformBadge({ platform }: { platform: PlatformTag }) {
 
   return (
     <span
-      className="chamfer inline-flex items-center px-2 py-0.5 text-xs font-semibold text-background"
+      className={`inline-flex items-center rounded-md font-mono font-semibold tracking-wide text-background ${sizing}`}
       style={{ backgroundColor: meta.colorVar }}
     >
       {meta.label}

--- a/portal/web/src/components/PlayerCard.tsx
+++ b/portal/web/src/components/PlayerCard.tsx
@@ -1,0 +1,112 @@
+import { Link } from "react-router-dom";
+import { monogram, monogramColor } from "../lib/psn";
+import { HoloCard } from "./HoloCard";
+
+/**
+ * A trophy hunter, as a collectible card.
+ *
+ * Two forms of the same information, so a leaderboard can lead with a podium
+ * without inventing a second visual language for it:
+ *   - `featured` — the top three, on the full holo surface
+ *   - default — everyone else, a plain card with a shine sweep
+ *
+ * Rank colour is metal, not brand accent (`--color-rank-silver/bronze` plus
+ * the brand yellow for first). Deliberate: `src/lib/platforms.ts` reserves
+ * the four face-button colours to mean *platform*, and since every hunter
+ * here is a PSN profile, colouring podium places with them would both flatten
+ * the palette and imply something untrue.
+ */
+const RANK_COLOR: Record<number, string> = {
+  1: "var(--color-accent-yellow)",
+  2: "var(--color-rank-silver)",
+  3: "var(--color-rank-bronze)",
+};
+
+function Monogram({ name, className }: { name: string; className?: string }) {
+  return (
+    <span
+      aria-hidden
+      className={`grid shrink-0 place-items-center rounded-lg font-display font-extrabold text-background ${className ?? "h-9 w-9 text-lg"}`}
+      style={{ backgroundColor: monogramColor(name) }}
+    >
+      {monogram(name)}
+    </span>
+  );
+}
+
+export function PlayerCard({
+  rank,
+  psnProfile,
+  points,
+  trophyCount,
+  featured = false,
+}: {
+  rank: number;
+  psnProfile: string | null;
+  points: number;
+  trophyCount: number;
+  featured?: boolean;
+}) {
+  // A profile with no name can still hold a rank, but it has nothing to link
+  // to and no monogram to draw — it renders as a plain, unlinked card.
+  const name = psnProfile ?? null;
+  const rankColor = RANK_COLOR[rank];
+
+  const body = (
+    <>
+      <div className="flex items-start justify-between gap-2">
+        <span
+          className="tabular font-display text-5xl leading-none font-extrabold"
+          style={{ color: rankColor ?? "rgb(255 255 255 / 0.25)" }}
+        >
+          {String(rank).padStart(2, "0")}
+        </span>
+        {name && !featured && <Monogram name={name} />}
+      </div>
+
+      {/* On the podium the monogram is the card's art, centred in the space a
+          trading card gives its illustration — without it the tall format
+          leaves a void between the rank and the name. */}
+      {featured && name && (
+        <div className="grid min-h-0 flex-1 place-items-center py-4">
+          <Monogram name={name} className="h-20 w-20 rounded-2xl text-4xl shadow-lg" />
+        </div>
+      )}
+
+      <div className={featured ? "mt-auto" : "mt-4"}>
+        <p className="truncate text-[15px] font-bold" title={name ?? undefined}>
+          {name ?? "Perfil sem nome"}
+        </p>
+        <p className="mt-1 font-mono text-[10px] tracking-[0.13em] text-white/45 uppercase">
+          {trophyCount.toLocaleString("pt-PT")} platinas
+        </p>
+        <p className="tabular mt-4 border-t border-surface-border pt-3 font-display text-3xl font-extrabold">
+          {points.toLocaleString("pt-PT")}
+          <span className="ml-1.5 font-mono text-[10px] font-normal tracking-[0.13em] text-white/45">PTS</span>
+        </p>
+      </div>
+    </>
+  );
+
+  const card = featured ? (
+    <HoloCard ratio="aspect-[63/78]">{body}</HoloCard>
+  ) : (
+    <div className="shine h-full rounded-xl border border-surface-border bg-gradient-to-br from-white/[0.055] to-white/[0.012] p-4 transition-transform duration-200 hover:-translate-y-1.5">
+      {body}
+    </div>
+  );
+
+  if (!name) return card;
+
+  return (
+    <Link
+      to={`/trophies/${encodeURIComponent(name)}`}
+      className="focus-glow block rounded-xl"
+      aria-label={`${name} — rank ${rank}, ${points.toLocaleString("pt-PT")} pontos`}
+    >
+      {card}
+    </Link>
+  );
+}
+
+export { Monogram };

--- a/portal/web/src/components/StateViews.tsx
+++ b/portal/web/src/components/StateViews.tsx
@@ -1,15 +1,26 @@
 /**
  * Shared loading/error/empty presentational bits — pulled out of M8.5's
- * Home.tsx skeleton (where they were originally private to that one page)
- * so M8.7/M8.8/M8.9 reuse the same pattern instead of re-implementing it
- * per page.
+ * Home.tsx so every page reuses the same pattern instead of re-implementing
+ * it. M11 restyled them to the card system and gave the empty state a slot
+ * for an action, since "an empty screen is an invitation to act" and most of
+ * this site's empty states have exactly one useful next step.
  */
 
 export function SkeletonRow({ tiles = 4, className }: { tiles?: number; className?: string }) {
   return (
-    <div className={className ?? "grid grid-cols-2 gap-2 sm:grid-cols-4"} aria-hidden>
+    <div className={className ?? "grid grid-cols-2 gap-3 sm:grid-cols-4"} aria-hidden>
       {Array.from({ length: tiles }, (_, i) => i).map((key) => (
-        <div key={key} className="chamfer aspect-square animate-pulse border border-surface-border bg-surface" />
+        <div key={key} className="aspect-square animate-pulse rounded-xl border border-surface-border bg-surface" />
+      ))}
+    </div>
+  );
+}
+
+export function SkeletonRows({ rows = 8 }: { rows?: number }) {
+  return (
+    <div className="space-y-2" aria-hidden>
+      {Array.from({ length: rows }, (_, i) => i).map((key) => (
+        <div key={key} className="h-14 animate-pulse rounded-xl border border-surface-border bg-surface" />
       ))}
     </div>
   );
@@ -20,12 +31,17 @@ export function ApiError({ what }: { what: string }) {
   // "Accessibility" — #EA3223 is marginal as text). The red carries the
   // "error" meaning via the border, not the letters.
   return (
-    <p className="border-l-2 border-accent-red pl-3 text-sm text-white/80">
+    <p className="rounded-r-lg border-l-2 border-accent-red bg-surface/60 py-4 pl-4 text-sm text-white/80">
       Não foi possível carregar {what} de momento. Tenta novamente mais tarde.
     </p>
   );
 }
 
-export function EmptyState({ children }: { children: React.ReactNode }) {
-  return <p className="border border-dashed border-surface-border px-4 py-6 text-center text-white/50">{children}</p>;
+export function EmptyState({ children, action }: { children: React.ReactNode; action?: React.ReactNode }) {
+  return (
+    <div className="rounded-xl border border-dashed border-surface-border px-6 py-12 text-center">
+      <p className="text-white/55">{children}</p>
+      {action && <div className="mt-5">{action}</div>}
+    </div>
+  );
 }

--- a/portal/web/src/components/ui/Controls.tsx
+++ b/portal/web/src/components/ui/Controls.tsx
@@ -1,0 +1,207 @@
+/**
+ * The filter vocabulary every list page shares (M11).
+ *
+ * Before this, Marketplace and Screenshots each rendered a row of bare
+ * `<select>`s — which meant the two pages looked unrelated, and neither told
+ * you what was currently filtering the results without re-reading every
+ * dropdown. These controls are one set, used by both, and they always show
+ * their own state: a segment is visibly chosen, a select that is not on
+ * "all" is highlighted, and `ActiveFilters` summarises the lot with a way
+ * back out.
+ *
+ * Native `<select>` is kept underneath the styled shell rather than replaced
+ * with a custom listbox: it is keyboard- and screen-reader-correct for free,
+ * and on a phone it opens the platform picker, which is the right control in
+ * the Discord in-app browser this site is mostly opened from.
+ */
+
+export function SegmentedControl<T extends string>({
+  value,
+  onChange,
+  options,
+  label,
+}: {
+  value: T;
+  onChange: (value: T) => void;
+  options: Array<{ value: T; label: string; accent?: string }>;
+  label: string;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label={label}
+      className="inline-flex rounded-lg border border-surface-border bg-surface p-1"
+    >
+      {options.map((option) => {
+        const active = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            aria-pressed={active}
+            className={`focus-glow rounded-md px-3 py-1.5 font-mono text-xs tracking-wider uppercase transition-colors ${
+              active ? "text-background" : "text-white/55 hover:text-white"
+            }`}
+            style={active ? { backgroundColor: option.accent ?? "var(--color-foreground)" } : undefined}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function SelectField<T extends string>({
+  value,
+  onChange,
+  options,
+  label,
+  allLabel,
+}: {
+  value: T | "all";
+  onChange: (value: T | "all") => void;
+  options: Array<{ value: T; label: string; count?: number }>;
+  label: string;
+  allLabel: string;
+}) {
+  const isFiltering = value !== "all";
+
+  return (
+    <label className="relative inline-flex items-center">
+      <span className="sr-only">{label}</span>
+      <select
+        value={value}
+        onChange={(event) => onChange(event.target.value as T | "all")}
+        className={`focus-glow appearance-none rounded-lg border bg-surface py-2 pr-8 pl-3 font-mono text-xs tracking-wide text-white transition-colors ${
+          isFiltering ? "border-accent-mint/60" : "border-surface-border hover:border-white/25"
+        }`}
+      >
+        <option value="all">{allLabel}</option>
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+            {option.count !== undefined ? ` (${option.count})` : ""}
+          </option>
+        ))}
+      </select>
+      <span aria-hidden className="pointer-events-none absolute right-3 text-white/40">
+        ▾
+      </span>
+    </label>
+  );
+}
+
+export function SearchField({
+  value,
+  onChange,
+  placeholder,
+  label,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  label: string;
+}) {
+  return (
+    <label className="relative inline-flex min-w-0 flex-1 items-center sm:max-w-xs">
+      <span className="sr-only">{label}</span>
+      <span aria-hidden className="pointer-events-none absolute left-3 text-white/35">
+        ⌕
+      </span>
+      <input
+        type="search"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        className={`focus-glow w-full rounded-lg border bg-surface py-2 pr-3 pl-8 text-sm text-white placeholder:text-white/30 ${
+          value ? "border-accent-mint/60" : "border-surface-border hover:border-white/25"
+        }`}
+      />
+    </label>
+  );
+}
+
+export function Toggle({
+  checked,
+  onChange,
+  children,
+}: {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className={`focus-glow inline-flex items-center gap-2 rounded-lg border px-3 py-2 font-mono text-xs tracking-wide transition-colors ${
+        checked
+          ? "border-accent-mint/60 text-white"
+          : "border-surface-border text-white/55 hover:border-white/25 hover:text-white"
+      }`}
+    >
+      <span
+        aria-hidden
+        className={`h-2 w-2 rounded-full ${checked ? "bg-accent-mint" : "bg-white/25"}`}
+      />
+      {children}
+    </button>
+  );
+}
+
+/**
+ * The summary line: what is filtering right now, each removable, plus the
+ * result count. Rendered even with no filters active so the count never
+ * jumps around as chips appear — an empty chip row still reports "N de M".
+ */
+export function ActiveFilters({
+  chips,
+  onClearAll,
+  resultCount,
+  totalCount,
+  noun,
+}: {
+  chips: Array<{ key: string; label: string; onRemove: () => void }>;
+  onClearAll: () => void;
+  resultCount: number;
+  totalCount: number;
+  noun: string;
+}) {
+  return (
+    <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-surface-border pt-4">
+      <span className="font-mono text-xs text-white/45">
+        <span className="tabular text-white">{resultCount.toLocaleString("pt-PT")}</span>
+        {resultCount !== totalCount && <> de {totalCount.toLocaleString("pt-PT")}</>} {noun}
+      </span>
+
+      {chips.map((chip) => (
+        <button
+          key={chip.key}
+          type="button"
+          onClick={chip.onRemove}
+          className="focus-glow inline-flex items-center gap-1.5 rounded-full border border-surface-border bg-surface py-1 pr-2 pl-3 font-mono text-xs text-white/75 transition-colors hover:border-white/30 hover:text-white"
+        >
+          {chip.label}
+          <span aria-hidden className="text-white/40">
+            ✕
+          </span>
+          <span className="sr-only">(remover filtro)</span>
+        </button>
+      ))}
+
+      {chips.length > 0 && (
+        <button
+          type="button"
+          onClick={onClearAll}
+          className="focus-glow font-mono text-xs text-accent-mint hover:underline"
+        >
+          limpar tudo
+        </button>
+      )}
+    </div>
+  );
+}

--- a/portal/web/src/index.css
+++ b/portal/web/src/index.css
@@ -1,22 +1,34 @@
 @import "tailwindcss";
 
-/* Self-hosted webfonts (no third-party CDN — see portal/README.md). Archivo
-   Black is the stand-in "heavy display face echoing the wordmark's brush
-   weight" until M8.1 (brand vendoring) traces/sources the real one; Inter is
-   the neutral body sans. Two families total, per docs/plans/03-portal.md. */
+/* Self-hosted webfonts (no third-party CDN — see portal/README.md).
+ *
+ * Three roles, deliberately (M11 "Holo" redesign):
+ *   - display  Big Shoulders Display — a tall, condensed, high-contrast
+ *              grotesk. Chosen over the previous Archivo Black because the
+ *              redesign leans on *large* numerals (ranks, prices, point
+ *              totals) and a condensed face lets a 5-digit score sit in a
+ *              narrow card without shrinking to unreadable. Archivo Black is
+ *              kept below as the wordmark face only.
+ *   - body     Space Grotesk — a neutral geometric sans with enough
+ *              character not to read as a default UI font.
+ *   - mono     JetBrains Mono — every label, eyebrow, count and timestamp.
+ *              Data reads as data.
+ */
+@import "@fontsource-variable/big-shoulders-display";
+@import "@fontsource-variable/space-grotesk";
+@import "@fontsource-variable/jetbrains-mono";
 @import "@fontsource/archivo-black";
-@import "@fontsource-variable/inter";
 
 /*
- * Design tokens — docs/plans/03-portal.md "Brand and design direction" +
- * docs/plans/00-overview.md "Brand assets" (palette sampled from the guild
- * icon). This @theme block is the SINGLE place these values are defined;
- * every component consumes them as Tailwind utilities (bg-background,
- * text-accent-blue, font-display, etc.) rather than hardcoding hex codes.
+ * Design tokens — the SINGLE place these values are defined; every component
+ * consumes them as Tailwind utilities (bg-background, text-accent-blue,
+ * font-display, …) rather than hardcoding hex codes.
  *
- * Dark-first, not dark-mode-as-afterthought: there is no light theme in v1
- * (settled, GLOBAL-PLAN M8 note) — --color-background/--color-foreground are
- * applied directly in the `body` rule below, not behind a `dark:` variant.
+ * Palette is unchanged from M8.1 and still sampled from the guild icon
+ * (brand/README.md) — the redesign changes typography, structure and motion,
+ * not the brand's colours.
+ *
+ * Dark-first, not dark-mode-as-afterthought: there is no light theme.
  */
 @theme {
   --color-background: #060302;
@@ -37,13 +49,23 @@
   --color-surface: #120d0a;
   --color-surface-border: #2a211c;
 
-  --font-display: "Archivo Black", "Arial Black", system-ui, sans-serif;
-  --font-body: "Inter Variable", "Inter", system-ui, sans-serif;
+  /* Podium metals. Rank 1 reuses the brand yellow; 2 and 3 are neutral
+     silver/bronze rather than brand accents, so a podium never implies a
+     platform. */
+  --color-rank-silver: #d8d8d8;
+  --color-rank-bronze: #c98b4b;
 
-  /* Chamfered corners ("restrained gaming cues", plan 03) instead of rounded
-     ones — a single cut-corner radius token used everywhere via `rounded-chamfer`
-     is more consistent than every component picking its own clip-path. */
+  --font-display: "Big Shoulders Display Variable", "Arial Narrow", system-ui, sans-serif;
+  --font-body: "Space Grotesk Variable", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono Variable", ui-monospace, monospace;
+  /* The wordmark only — "GAME ON PORTUGAL" set in the header/footer/hero.
+     It echoes the brush lockup in brand/logo-lockup-2048.png. */
+  --font-wordmark: "Archivo Black", "Arial Black", system-ui, sans-serif;
+
+  /* The cut-corner radius: primary buttons on the public pages, and all of
+     /admin. Cards use --radius-card. See .chamfer below. */
   --radius-chamfer: 0.5rem;
+  --radius-card: 0.75rem;
 }
 
 @layer base {
@@ -53,9 +75,6 @@
 
   body {
     @apply bg-background text-foreground font-body antialiased;
-    /* Hairline scanline texture at very low opacity on hero surfaces only —
-       applied via the .scanlines utility below, not globally: plan 03 warns
-       against loud/animated backgrounds everywhere. */
   }
 
   h1,
@@ -63,25 +82,26 @@
   h3,
   h4 {
     @apply font-display;
+    font-weight: 800;
+    letter-spacing: 0.005em;
+    line-height: 0.95;
+  }
+
+  /* Condensed display faces need explicit tabular figures wherever numbers
+     are compared column-to-column (leaderboard points, prices), or the
+     ranking visibly ripples as digits change width. */
+  .tabular {
+    font-variant-numeric: tabular-nums;
   }
 }
 
 @layer utilities {
-  /* Restrained "gaming cue" #1: a low-opacity scanline texture, hero
-     surfaces only (see plan 03's design principles). Pure CSS, no image
-     asset. */
-  .scanlines {
-    background-image: repeating-linear-gradient(
-      to bottom,
-      rgb(255 255 255 / 0.035) 0px,
-      rgb(255 255 255 / 0.035) 1px,
-      transparent 1px,
-      transparent 3px
-    );
-  }
-
-  /* Restrained "gaming cue" #2: chamfered (cut) corners on hero/card
-     surfaces, applied with clip-path so it composes with a border. */
+  /* The cut-corner shape. Two roles after the M11 redesign: it is the shape
+     of every primary call-to-action on the public pages (the one angular cue
+     in an otherwise rounded card system, so the main action never looks like
+     a card), and it is what /admin still uses throughout — admin keeps its
+     existing look rather than being half-migrated into a second visual
+     language. */
   .chamfer {
     clip-path: polygon(
       var(--radius-chamfer) 0%,
@@ -93,19 +113,123 @@
     );
   }
 
-  /* Focus states glow rather than outline (plan 03) — respects
-     prefers-reduced-motion via the transition being cut to 0 below. */
+  /* Focus states glow rather than outline — switched off by the
+     reduced-motion block below along with everything else. */
   .focus-glow:focus-visible {
     outline: none;
     box-shadow: 0 0 0 3px var(--color-background), 0 0 0 5px var(--color-accent-blue), 0 0 16px 2px
       rgb(65 153 231 / 0.55);
   }
+
+  /* --- The signature: holographic foil ------------------------------------
+   *
+   * A collectible-card foil whose highlight tracks the pointer. `--mx`/`--my`
+   * are written by `useTilt` (src/lib/useTilt.ts); the defaults below mean the
+   * effect degrades to a static centred sheen with no JS, no pointer, or
+   * reduced motion — it never disappears entirely, so the card still reads as
+   * foiled on a touch device.
+   *
+   * `color-dodge` over a near-black card is what makes this look like light
+   * catching a surface rather than a rainbow gradient pasted on top.
+   */
+  .holo-foil::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    pointer-events: none;
+    mix-blend-mode: color-dodge;
+    opacity: var(--foil, 0.3);
+    transition: opacity 0.3s ease;
+    background:
+      radial-gradient(60% 60% at var(--mx, 50%) var(--my, 50%), rgb(255 255 255 / 0.5), transparent 60%),
+      repeating-linear-gradient(
+        115deg,
+        rgb(65 153 231 / 0.55) 0%,
+        rgb(138 251 204 / 0.55) 12%,
+        rgb(255 253 84 / 0.5) 24%,
+        rgb(234 50 35 / 0.5) 36%,
+        rgb(65 153 231 / 0.55) 48%
+      );
+    background-size: auto, 220% 220%;
+    background-position: 0 0, calc(var(--mx, 50%) * -1 + 100%) calc(var(--my, 50%) * -1 + 100%);
+  }
+
+  /* Fine diagonal texture so the foil has a surface to sit on rather than
+     floating over flat colour. */
+  .holo-foil::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    pointer-events: none;
+    opacity: 0.5;
+    background: repeating-linear-gradient(65deg, rgb(255 255 255 / 0.05) 0 1px, transparent 1px 5px);
+  }
+
+  .holo-foil:hover {
+    --foil: 0.55;
+  }
+
+  /* The cheap version, for the many small cards (ads, screenshots, ranked
+     rows) where a full foil would be noise: a single shine that sweeps
+     across once on hover. */
+  .shine {
+    position: relative;
+    overflow: hidden;
+  }
+  .shine::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    pointer-events: none;
+    opacity: 0;
+    transform: translateX(-100%);
+    background: linear-gradient(115deg, transparent 30%, rgb(255 255 255 / 0.16) 48%, transparent 62%);
+  }
+  .shine:hover::before {
+    opacity: 1;
+    animation: shine-sweep 0.8s ease-out;
+  }
+  @keyframes shine-sweep {
+    to {
+      transform: translateX(100%);
+    }
+  }
+
+  /* Entry motion, used once per section rather than per element — an
+     orchestrated reveal, not scattered effects. */
+  .rise {
+    animation: rise 0.5s cubic-bezier(0.2, 0.8, 0.3, 1) both;
+  }
+  @keyframes rise {
+    from {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+  }
+
+  .float {
+    animation: float 6s ease-in-out infinite;
+  }
+  @keyframes float {
+    0%,
+    100% {
+      transform: translateY(0) rotate(0deg);
+    }
+    50% {
+      transform: translateY(-8px) rotate(1.5deg);
+    }
+  }
 }
 
-/* Motion is functional only (page transitions, image loads) — never
-   decorative, and switched off entirely for anyone who asked for less
-   motion. Do this once, globally, rather than trusting every component to
-   remember the media query. */
+/* Motion is functional only (page transitions, image loads, the foil) —
+ * never load-bearing for meaning, and switched off entirely for anyone who
+ * asked for less motion. Done once, globally, rather than trusting every
+ * component to remember the media query. `useTilt` checks the same query in
+ * JS so it never even attaches its listeners.
+ */
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/portal/web/src/lib/api/client.ts
+++ b/portal/web/src/lib/api/client.ts
@@ -47,6 +47,20 @@ export interface LeaderboardEntry {
   trophyCount: number;
 }
 
+export interface HunterTrophy {
+  url: string | null;
+  points: number;
+  completionDate: string | null;
+}
+
+export interface Hunter {
+  psnProfile: string;
+  rank: number;
+  points: number;
+  trophyCount: number;
+  trophies: HunterTrophy[];
+}
+
 export interface PortalStats {
   activeAds: number;
   screenshots: number;
@@ -93,5 +107,7 @@ export const api = {
   listScreenshots: (limit = 8) =>
     get<{ screenshots: Screenshot[]; total: number }>(`/api/screenshots?limit=${limit}`),
   leaderboard: (limit = 10) => get<{ leaderboard: LeaderboardEntry[] }>(`/api/trophies/leaderboard?limit=${limit}`),
+  hunter: (psnProfile: string) =>
+    get<{ hunter: Hunter }>(`/api/trophies/hunters/${encodeURIComponent(psnProfile)}`),
   stats: () => get<PortalStats>("/api/stats"),
 };

--- a/portal/web/src/lib/psn.ts
+++ b/portal/web/src/lib/psn.ts
@@ -1,0 +1,106 @@
+/**
+ * Reading a game out of a stored PSNProfiles trophy URL.
+ *
+ * There is no game column anywhere in the schema — `trophies` holds only
+ * `url`, `points` and `completionDate` (discord-bot/prisma/schema.prisma).
+ * But the URL the bot captured when it claimed the trophy
+ * (`PsnProfilesTrophySource.parseProfileTrophies`) carries the game in its
+ * path:
+ *
+ *     https://psnprofiles.com/trophies/11783-assassins-creed-valhalla/Someone
+ *                                      └── id ──┘└──── slug ────────┘
+ *
+ * so "which games has this hunter platinumed" is answerable from data already
+ * in the database, with no new scraping and no new column. That is the whole
+ * reason the hunter page can show a game list at all.
+ *
+ * Deliberately conservative: anything that does not match the expected shape
+ * returns `null` and the caller shows the trophy without a game name, rather
+ * than this inventing a title from a URL it did not understand. The slug is a
+ * lossy, lower-cased, punctuation-stripped form of the real title — see
+ * `titleFromSlug` for exactly how far it is safe to un-mangle it.
+ */
+
+/** A game as recovered from a trophy URL. `id` is PSNProfiles' own numeric id. */
+export interface TrophyGame {
+  id: string;
+  slug: string;
+  title: string;
+  /** The game's trophy page — the URL minus the profile segment. */
+  url: string;
+}
+
+const TROPHY_PATH = /\/trophies\/(\d+)-([a-z0-9-]+)/i;
+
+/**
+ * Words the slug lower-cases that should not be title-cased back, so
+ * "marvels-spider-man-miles-morales" reads "Marvels Spider Man Miles Morales"
+ * but "grand-theft-auto-iv" keeps its numeral as "IV" rather than "Iv".
+ */
+const ROMAN_NUMERAL = /^(?:i{1,3}|i[vx]|vi{0,3}|ix|xi{0,3}|xiv|xv|xvi{0,3}|xix|xx)$/;
+const LOWERCASE_WORDS = new Set(["a", "an", "and", "of", "the", "to", "in", "on", "at", "for", "vs"]);
+
+function titleFromSlug(slug: string): string {
+  const words = slug.split("-").filter(Boolean);
+
+  return words
+    .map((word, index) => {
+      if (ROMAN_NUMERAL.test(word)) return word.toUpperCase();
+      // Small words stay lower-cased mid-title, but never as the first word.
+      if (index > 0 && LOWERCASE_WORDS.has(word)) return word;
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join(" ");
+}
+
+export function gameFromTrophyUrl(url: string | null | undefined): TrophyGame | null {
+  if (!url) return null;
+
+  const match = TROPHY_PATH.exec(url);
+  if (!match) return null;
+
+  const [, id, slug] = match;
+  if (!id || !slug) return null;
+
+  return {
+    id,
+    slug,
+    title: titleFromSlug(slug),
+    url: `https://psnprofiles.com/trophies/${id}-${slug}`,
+  };
+}
+
+/** A hunter's PSNProfiles page. The column is un-validated free text, hence the encode. */
+export function psnProfileUrl(psnProfile: string): string {
+  return `https://psnprofiles.com/${encodeURIComponent(psnProfile)}`;
+}
+
+/**
+ * Deterministic accent for a hunter's monogram tile.
+ *
+ * **Not** a platform colour, despite drawing from the same four values: every
+ * profile on this leaderboard is a PSN profile, so colouring by platform
+ * would paint the whole page one blue. This is identity-by-hash — the same
+ * name always gets the same tile, which makes a hunter recognisable when
+ * scanning a list, and it is the honest stand-in until a real avatar exists
+ * (`trophyprofiles` stores no avatar; see docs/plans/GLOBAL-PLAN.md).
+ */
+const MONOGRAM_COLORS = [
+  "var(--color-accent-blue)",
+  "var(--color-accent-mint)",
+  "var(--color-accent-yellow)",
+  "var(--color-accent-red)",
+];
+
+export function monogramColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i += 1) {
+    hash = (hash * 31 + name.charCodeAt(i)) >>> 0;
+  }
+  return MONOGRAM_COLORS[hash % MONOGRAM_COLORS.length]!;
+}
+
+export function monogram(name: string): string {
+  const first = name.trim().charAt(0);
+  return first ? first.toUpperCase() : "?";
+}

--- a/portal/web/src/lib/useTilt.ts
+++ b/portal/web/src/lib/useTilt.ts
@@ -1,0 +1,67 @@
+import { useCallback, useRef } from "react";
+
+/**
+ * The pointer-tracking half of the holographic card (the other half is
+ * `.holo-foil` in index.css).
+ *
+ * Writes two custom properties — `--mx`/`--my`, the pointer's position inside
+ * the element as a percentage — and a matching 3D rotation. The foil's
+ * highlight reads off the same two properties, so the sheen and the tilt stay
+ * locked together and the card looks like a physical surface catching light
+ * rather than a gradient that happens to move.
+ *
+ * Two guards, checked per event rather than once at mount so a mid-session
+ * change (plugging in a mouse, toggling the OS motion setting) is respected:
+ *
+ *   - `(hover: hover)` — on a touch screen every "pointer move" is a drag, so
+ *     tilting would fight the scroll. The card keeps `.holo-foil`'s static
+ *     centred sheen instead of losing the effect entirely.
+ *   - `prefers-reduced-motion` — no tilt at all. index.css already flattens
+ *     the CSS transition, but without this the element would still be
+ *     re-transformed on every pointer move, which is exactly the motion the
+ *     user asked not to see.
+ *
+ * Inline styles rather than React state on purpose: this fires on every
+ * pointer move, and re-rendering a card subtree at that rate is how a
+ * scroll-janky page gets built.
+ */
+function canTilt(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return (
+    window.matchMedia("(hover: hover)").matches && !window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+export function useTilt<T extends HTMLElement = HTMLDivElement>(maxDegrees = 14) {
+  const ref = useRef<T | null>(null);
+
+  const onPointerMove = useCallback(
+    (event: React.PointerEvent<T>) => {
+      const element = ref.current;
+      if (!element || !canTilt()) return;
+
+      const rect = element.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return;
+
+      const x = (event.clientX - rect.left) / rect.width;
+      const y = (event.clientY - rect.top) / rect.height;
+
+      element.style.setProperty("--mx", `${(x * 100).toFixed(1)}%`);
+      element.style.setProperty("--my", `${(y * 100).toFixed(1)}%`);
+      element.style.transform =
+        `rotateY(${((x - 0.5) * maxDegrees).toFixed(2)}deg) ` +
+        `rotateX(${((0.5 - y) * maxDegrees).toFixed(2)}deg) translateZ(12px)`;
+    },
+    [maxDegrees],
+  );
+
+  const reset = useCallback(() => {
+    const element = ref.current;
+    if (!element) return;
+    element.style.transform = "";
+    element.style.removeProperty("--mx");
+    element.style.removeProperty("--my");
+  }, []);
+
+  return { ref, onPointerMove, onPointerLeave: reset, onBlur: reset };
+}

--- a/portal/web/src/pages/HallOfFame.tsx
+++ b/portal/web/src/pages/HallOfFame.tsx
@@ -36,28 +36,27 @@ export function HallOfFame() {
     description: "As screenshots vencedoras da semana na comunidade Game On Portugal.",
     path: "/screenshots/hall-of-fame",
   });
-
   return (
-    <div className="mx-auto max-w-2xl px-4 py-16 text-center">
-      <p className="text-xs font-semibold tracking-[0.3em] text-white/50 uppercase">Hall of Fame</p>
-      <h1 className="mt-4 font-display text-3xl">Ainda a construir o histórico</h1>
-      <p className="mt-4 text-white/70">
+    <div className="mx-auto max-w-2xl px-4 py-24 text-center">
+      <p className="font-mono text-[11px] tracking-[0.22em] text-accent-mint uppercase">Hall of Fame · Screenshots</p>
+      <h1 className="mt-5 font-display text-5xl font-extrabold uppercase">Ainda a construir o histórico</h1>
+      <p className="mt-5 leading-relaxed text-white/65">
         Todas as semanas, a screenshot com mais reações 🏆 no canal do Discord é anunciada como vencedora — mas essa
         escolha ainda não fica gravada em lado nenhum, por isso esta página ainda não tem um histórico para mostrar.
       </p>
-      <p className="mt-2 text-white/70">
+      <p className="mt-3 leading-relaxed text-white/65">
         Para veres a vencedora mais recente (e participares na próxima), entra no Discord.
       </p>
       <a
         href={DISCORD_INVITE}
         target="_blank"
         rel="noreferrer"
-        className="focus-glow chamfer mt-8 inline-block bg-accent-blue px-6 py-3 font-semibold text-background transition-opacity hover:opacity-90"
+        className="focus-glow chamfer mt-9 inline-block bg-accent-yellow px-6 py-3.5 font-bold text-background transition-transform hover:-translate-y-0.5"
       >
         Entrar no Discord
       </a>
       <div className="mt-6">
-        <Link to="/screenshots" className="focus-glow text-sm text-white/60 hover:text-white">
+        <Link to="/screenshots" className="focus-glow rounded font-mono text-xs text-white/50 hover:text-white">
           ← Ver a galeria de screenshots
         </Link>
       </div>

--- a/portal/web/src/pages/Home.tsx
+++ b/portal/web/src/pages/Home.tsx
@@ -1,31 +1,33 @@
 import { Link } from "react-router-dom";
 import { AdCard } from "../components/AdCard";
 import { BrandMark } from "../components/BrandMark";
+import { HoloCard } from "../components/HoloCard";
 import { LazyImage } from "../components/LazyImage";
+import { PlayerCard } from "../components/PlayerCard";
+import { SectionHeader } from "../components/PageHeader";
 import { ApiError, EmptyState, SkeletonRow } from "../components/StateViews";
-import { api } from "../lib/api/client";
+import { api, thumbnailUrl } from "../lib/api/client";
 import { useDocumentHead } from "../lib/seo";
 import { useApi } from "../lib/useApi";
 
 const DISCORD_INVITE = "https://discord.gg/mBJKUhwE23";
 
 /**
- * M8.6 — Home. Builds on M8.5's skeleton (hero + three data strips) with:
- * live stats (new `/api/stats`, M8.6's own addition — see
- * portal/api/src/repositories/stats.ts for why there's no member count),
- * real navigation into the M8.7/M8.8/M8.9 pages instead of dead-end strips,
- * and the AdCard/LazyImage components those pages also use.
+ * Home. The hero is the thesis: the community's own mark on a foiled
+ * collectible card numbered Nº 001, carrying the three live totals. That card
+ * is the site's signature (see components/HoloCard.tsx) and it is the reason
+ * the rest of the site can be quiet — every other surface is a plain card.
  *
- * The "latest screenshots" section has to look right when the newest
- * content is months old (task brief: newest screenshot is 2026-06-01, 90
- * days stale) — it does not pretend otherwise; see `ScreenshotsStrip`'s
- * `EmptyState` copy and the honest date-relative note below the stats bar.
+ * Below it, three previews, each linking to a page that now does far more
+ * than the preview can (filters, search, detail views) —
+ * rather than the old layout, where Home showed roughly what the sub-pages
+ * showed and the sub-pages had little reason to exist.
+ *
+ * Every strip still has to look right when the newest content is months old
+ * (the screenshot set has been static since 2026-06-01) — the empty and error
+ * states below say so plainly instead of rendering an empty grid.
  */
 export function Home() {
-  // M8.13 — reasserts the site-level title/description/og:url index.html
-  // already ships (see lib/seo.ts's header for why this is additive, not a
-  // replacement) so navigating *back* to "/" after another page overrode
-  // them restores the real defaults instead of leaving the last page's.
   useDocumentHead({
     title: "Game On Portugal",
     description:
@@ -36,164 +38,240 @@ export function Home() {
   return (
     <div>
       <Hero />
-      <StatsBar />
-      <Section title="Últimos anúncios" viewAllHref="/marketplace">
-        <AdsStrip />
-      </Section>
-      <Section title="Últimas screenshots" viewAllHref="/screenshots">
-        <ScreenshotsStrip />
-      </Section>
-      <Section title="Hall of Fame — Trophy leaderboard" viewAllHref="/trophies">
-        <LeaderboardPreview />
-      </Section>
+      <div className="mx-auto max-w-6xl space-y-16 px-4 py-16">
+        <section>
+          <SectionHeader title="Hall of Fame" href="/trophies" linkLabel="Ver ranking" />
+          <div className="mt-6">
+            <PodiumPreview />
+          </div>
+        </section>
+
+        <section>
+          <SectionHeader title="Mercado" href="/marketplace" />
+          <div className="mt-6">
+            <AdsPreview />
+          </div>
+        </section>
+
+        <section>
+          <SectionHeader title="Screenshots" href="/screenshots" />
+          <div className="mt-6">
+            <ScreenshotsPreview />
+          </div>
+        </section>
+      </div>
     </div>
   );
 }
 
 function Hero() {
-  return (
-    <section className="scanlines relative overflow-hidden border-b border-surface-border px-4 py-16 text-center sm:py-24">
-      {/* M10.1 — the mark leads the hero. Decorative: the H1 immediately
-          below says the same thing as text, so announcing it twice would
-          only add noise for a screen reader. */}
-      <BrandMark variant="lg" className="mx-auto h-24 sm:h-32" />
-      <p className="mt-6 text-xs font-semibold tracking-[0.3em] text-white/50 uppercase">Discord community</p>
-      <h1 className="mx-auto mt-4 max-w-2xl font-display text-4xl leading-tight sm:text-6xl">
-        GAME ON <span className="text-accent-yellow">PORTUGAL</span>
-      </h1>
-      <p className="mx-auto mt-4 max-w-md text-white/70">
-        Marketplace, screenshots e leaderboard de troféus da maior comunidade de jogadores portuguesa.
-      </p>
-      <a
-        href={DISCORD_INVITE}
-        target="_blank"
-        rel="noreferrer"
-        className="focus-glow chamfer mt-8 inline-block bg-accent-blue px-6 py-3 font-semibold text-background transition-opacity hover:opacity-90"
-      >
-        Entrar no Discord
-      </a>
-    </section>
-  );
-}
-
-function StatsBar() {
   const { state, data } = useApi(() => api.stats(), [], () => false);
 
-  const tiles: Array<{ label: string; value: number | null }> = [
-    { label: "Anúncios ativos", value: data?.activeAds ?? null },
-    { label: "Screenshots", value: data?.screenshots ?? null },
-    { label: "Troféus", value: data?.trophies ?? null },
-    { label: "Trophy hunters", value: data?.hunters ?? null },
-  ];
+  const value = (n: number | undefined) => (state === "error" ? "—" : (n?.toLocaleString("pt-PT") ?? "···"));
 
   return (
-    <section className="border-b border-surface-border">
-      <div className="mx-auto grid max-w-5xl grid-cols-2 divide-x divide-surface-border border-x border-surface-border sm:grid-cols-4">
-        {tiles.map((tile) => (
-          <div key={tile.label} className="px-4 py-5 text-center">
-            <div className="font-display text-2xl text-accent-mint sm:text-3xl">
-              {state === "error" ? "—" : (tile.value?.toLocaleString("pt-PT") ?? "···")}
-            </div>
-            <div className="mt-1 text-xs text-white/60">{tile.label}</div>
+    <section className="relative overflow-hidden border-b border-surface-border">
+      {/* Ambient only: a soft brand-coloured wash behind the card, masked so
+          it never reaches the text column and reduces contrast there. */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-25 blur-[120px]"
+        style={{
+          background:
+            "radial-gradient(40% 50% at 78% 30%, var(--color-accent-blue), transparent 70%)," +
+            "radial-gradient(35% 45% at 88% 75%, var(--color-accent-mint), transparent 70%)",
+        }}
+      />
+
+      <div className="relative mx-auto grid max-w-6xl items-center gap-12 px-4 py-16 lg:grid-cols-[1fr_380px] lg:py-24">
+        <div className="rise">
+          <p className="flex items-center gap-3 font-mono text-[11px] tracking-[0.22em] text-accent-mint uppercase">
+            <span aria-hidden className="h-px w-8 bg-accent-mint" />
+            Comunidade portuguesa · desde 2021
+          </p>
+
+          <h1 className="mt-6 font-display text-6xl leading-[0.86] font-extrabold uppercase sm:text-8xl">
+            Joga.
+            <span className="mt-1 block text-transparent [-webkit-text-stroke:1.5px_var(--color-accent-yellow)]">
+              Colecciona.
+            </span>
+          </h1>
+
+          <p className="mt-6 max-w-md leading-relaxed text-white/60">
+            Cada caçador de troféus tem a sua carta. Cada anúncio, cada screenshot e cada platina da comunidade fica
+            registada aqui — puxada em direto do Discord.
+          </p>
+
+          <div className="mt-8 flex flex-wrap items-center gap-5">
+            <a
+              href={DISCORD_INVITE}
+              target="_blank"
+              rel="noreferrer"
+              className="focus-glow chamfer bg-accent-yellow px-6 py-3.5 font-bold text-background transition-transform hover:-translate-y-0.5"
+            >
+              Entrar no Discord
+            </a>
+            <Link
+              to="/trophies"
+              className="focus-glow rounded border-b border-white/25 pb-1 text-sm font-semibold text-white/70 transition-colors hover:border-white hover:text-white"
+            >
+              Ver o Hall of Fame
+            </Link>
           </div>
-        ))}
+        </div>
+
+        <div className="rise mx-auto w-full max-w-[340px] lg:max-w-none">
+          <HoloCard>
+            <div className="flex items-start justify-between">
+              <span className="rounded border border-accent-yellow/40 px-2 py-1 font-mono text-[9px] tracking-[0.2em] text-accent-yellow">
+                GUILD · LENDÁRIA
+              </span>
+              <span className="text-right font-mono text-[9px] leading-relaxed text-white/40">
+                Nº 001
+                <br />
+                2021 — ∞
+              </span>
+            </div>
+
+            <div className="grid min-h-0 flex-1 place-items-center py-4">
+              <BrandMark
+                variant="lg"
+                className="float max-h-full w-auto max-w-[60%] drop-shadow-[0_0_26px_rgba(255,255,255,0.34)]"
+              />
+            </div>
+
+            <h2 className="font-display text-4xl leading-[0.86] font-extrabold uppercase">
+              Game <span className="text-accent-yellow">On</span>
+              <br />
+              Portugal
+            </h2>
+            <p className="mt-2 font-mono text-[9px] tracking-[0.19em] text-white/50">
+              PC · PLAYSTATION · XBOX · NINTENDO
+            </p>
+
+            <dl className="mt-4 grid grid-cols-3 gap-2 border-t border-white/15 pt-3.5 text-center">
+              <div>
+                <dd className="tabular font-display text-2xl leading-none font-extrabold text-accent-yellow">
+                  {value(data?.trophies)}
+                </dd>
+                <dt className="mt-1.5 font-mono text-[8px] tracking-[0.12em] text-white/45">TROFÉUS</dt>
+              </div>
+              <div>
+                <dd className="tabular font-display text-2xl leading-none font-extrabold text-accent-mint">
+                  {value(data?.screenshots)}
+                </dd>
+                <dt className="mt-1.5 font-mono text-[8px] tracking-[0.12em] text-white/45">SHOTS</dt>
+              </div>
+              <div>
+                <dd className="tabular font-display text-2xl leading-none font-extrabold text-accent-blue">
+                  {value(data?.hunters)}
+                </dd>
+                <dt className="mt-1.5 font-mono text-[8px] tracking-[0.12em] text-white/45">CAÇADORES</dt>
+              </div>
+            </dl>
+          </HoloCard>
+
+          <p className="mt-4 text-center font-mono text-[10px] tracking-[0.16em] text-white/25 uppercase">
+            Move o rato sobre a carta
+          </p>
+        </div>
       </div>
     </section>
   );
 }
 
-function Section({
-  title,
-  viewAllHref,
-  children,
-}: {
-  title: string;
-  viewAllHref: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <section className="mx-auto max-w-5xl px-4 py-10">
-      <div className="flex items-baseline justify-between">
-        <h2 className="font-display text-xl">{title}</h2>
-        <Link to={viewAllHref} className="focus-glow text-sm text-accent-blue hover:underline">
-          Ver tudo →
-        </Link>
-      </div>
-      <div className="mt-4">{children}</div>
-    </section>
-  );
-}
-
-function AdsStrip() {
+function PodiumPreview() {
   const { state, data } = useApi(
-    () => api.listAds(6),
+    () => api.leaderboard(3),
+    [],
+    (value) => value.leaderboard.length === 0,
+  );
+
+  if (state === "loading") return <SkeletonRow tiles={3} className="grid grid-cols-1 gap-4 sm:grid-cols-3" />;
+  if (state === "error") return <ApiError what="o ranking" />;
+  if (state === "empty") return <EmptyState>Sem troféus registados ainda.</EmptyState>;
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      {data!.leaderboard.map((entry) => (
+        <PlayerCard
+          key={entry.rank}
+          rank={entry.rank}
+          psnProfile={entry.psnProfile}
+          points={entry.points}
+          trophyCount={entry.trophyCount}
+          featured
+        />
+      ))}
+    </div>
+  );
+}
+
+function AdsPreview() {
+  const { state, data } = useApi(
+    () => api.listAds(8),
     [],
     (value) => value.ads.length === 0,
   );
 
-  if (state === "loading") return <SkeletonRow className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3" tiles={3} />;
+  if (state === "loading")
+    return <SkeletonRow tiles={4} className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4" />;
   if (state === "error") return <ApiError what="os anúncios" />;
-  if (state === "empty") return <EmptyState>Sem anúncios ativos neste momento — o marketplace está sossegado.</EmptyState>;
+  if (state === "empty")
+    return (
+      <EmptyState
+        action={
+          <Link to="/como-participar#marketplace" className="focus-glow chamfer bg-accent-blue px-5 py-2.5 text-sm font-bold text-background">
+            Como publicar um anúncio
+          </Link>
+        }
+      >
+        Sem anúncios ativos neste momento — o mercado está sossegado.
+      </EmptyState>
+    );
 
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3">
-      {data!.ads.map((ad) => (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {data!.ads.slice(0, 4).map((ad) => (
         <AdCard key={ad.id} ad={ad} />
       ))}
     </div>
   );
 }
 
-function ScreenshotsStrip() {
+function ScreenshotsPreview() {
   const { state, data } = useApi(
-    () => api.listScreenshots(8),
+    () => api.listScreenshots(10),
     [],
     (value) => value.screenshots.length === 0,
   );
 
-  if (state === "loading") return <SkeletonRow />;
+  if (state === "loading")
+    return <SkeletonRow tiles={5} className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5" />;
   if (state === "error") return <ApiError what="as screenshots" />;
-  if (state === "empty") return <EmptyState>Ainda sem screenshots publicadas. Sê o primeiro a partilhar uma!</EmptyState>;
+  if (state === "empty")
+    return <EmptyState>Ainda sem screenshots publicadas. Sê o primeiro a partilhar uma!</EmptyState>;
 
   return (
-    <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-      {data!.screenshots.map((shot) => (
-        <Link key={shot.id} to="/screenshots" className="block">
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+      {data!.screenshots.slice(0, 5).map((shot) => (
+        <Link
+          key={shot.id}
+          to="/screenshots"
+          className="focus-glow group relative block overflow-hidden rounded-xl border border-surface-border"
+        >
           <LazyImage
-            src={shot.imageUrl}
+            src={thumbnailUrl(shot.imageUrl, 320)}
             alt={shot.name ?? "Screenshot"}
-            className="chamfer aspect-square overflow-hidden border border-surface-border bg-surface"
+            className="aspect-[4/3] w-full overflow-hidden bg-surface transition-transform duration-500 group-hover:scale-[1.07]"
           />
+          {shot.name && (
+            <span className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background/95 to-transparent px-3 pt-8 pb-2.5 text-xs font-medium">
+              <span className="line-clamp-1">{shot.name}</span>
+            </span>
+          )}
         </Link>
       ))}
     </div>
-  );
-}
-
-function LeaderboardPreview() {
-  const { state, data } = useApi(
-    () => api.leaderboard(10),
-    [],
-    (value) => value.leaderboard.length === 0,
-  );
-
-  if (state === "loading") return <SkeletonRow />;
-  if (state === "error") return <ApiError what="o leaderboard" />;
-  if (state === "empty") return <EmptyState>Sem troféus registados.</EmptyState>;
-
-  return (
-    <ol className="divide-y divide-surface-border border border-surface-border">
-      {data!.leaderboard.map((entry) => (
-        <li key={entry.rank} className="flex items-center justify-between px-4 py-2">
-          <span className="flex items-center gap-3">
-            <span className="w-6 text-right font-display text-accent-mint">{entry.rank}</span>
-            <span>{entry.psnProfile ?? "Perfil sem nome"}</span>
-          </span>
-          <span className="text-sm text-white/60">
-            {entry.points.toLocaleString("pt-PT")} pts · {entry.trophyCount}
-          </span>
-        </li>
-      ))}
-    </ol>
   );
 }

--- a/portal/web/src/pages/HunterDetail.tsx
+++ b/portal/web/src/pages/HunterDetail.tsx
@@ -1,0 +1,306 @@
+import { useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { HoloCard } from "../components/HoloCard";
+import { Monogram } from "../components/PlayerCard";
+import { EmptyState, SkeletonRows } from "../components/StateViews";
+import { SearchField, SegmentedControl } from "../components/ui/Controls";
+import { api, type HunterTrophy } from "../lib/api/client";
+import { gameFromTrophyUrl, psnProfileUrl } from "../lib/psn";
+import { useDocumentHead } from "../lib/seo";
+import { useApi } from "../lib/useApi";
+
+type Sort = "recent" | "points" | "name";
+
+const DATE_FORMAT = new Intl.DateTimeFormat("pt-PT", { day: "numeric", month: "long", year: "numeric" });
+const MONTH_FORMAT = new Intl.DateTimeFormat("pt-PT", { month: "short", year: "numeric" });
+
+/**
+ * M11 — one hunter's platinum collection.
+ *
+ * The whole page rests on one fact: **the game is recoverable from the stored
+ * trophy URL**. `trophies` has no game column — only `url`, `points` and
+ * `completionDate` — but the URL the bot captured
+ * (`PsnProfilesTrophySource.parseProfileTrophies`) is of the form
+ * `/trophies/<id>-<game-slug>/<profile>`, so the slug is the game. See
+ * src/lib/psn.ts. No new scraping, no schema change, no third-party call at
+ * request time.
+ *
+ * What this page deliberately does NOT show, and why:
+ *
+ *   - **A PSN avatar.** `trophyprofiles` stores `userId` and `psnProfile` and
+ *     nothing else; the scraper never parses an avatar. Fetching one would
+ *     mean scraping psnprofiles.com per page view, from the web tier, against
+ *     a site the bot deliberately throttles to one request per second. The
+ *     monogram tile is the honest stand-in until the bot persists an avatar.
+ *   - **A Discord name or avatar.** That needs the raw Discord id, which
+ *     portal-api never exposes by design (privacy decision 5 — see
+ *     portal/api/src/repositories/visibility.ts), and a bot token portal-api
+ *     does not hold. Both are decisions to take deliberately, not to slip in
+ *     behind an avatar.
+ *
+ * A profile that is excluded or has opted out 404s from the API, so this page
+ * cannot be used to look up someone who chose not to be listed.
+ */
+export function HunterDetail() {
+  const { psnProfile = "" } = useParams<{ psnProfile: string }>();
+  const { state, data } = useApi(() => api.hunter(psnProfile), [psnProfile], () => false);
+
+  const hunter = data?.hunter;
+
+  useDocumentHead({
+    title: hunter ? `${hunter.psnProfile} — Hall of Fame` : "Caçador",
+    description: hunter
+      ? `${hunter.psnProfile} tem ${hunter.trophyCount} platinas e ${hunter.points.toLocaleString("pt-PT")} pontos no ranking da Game On Portugal.`
+      : undefined,
+    path: `/trophies/${encodeURIComponent(psnProfile)}`,
+  });
+
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<Sort>("recent");
+
+  const games = useMemo(() => {
+    const list = (hunter?.trophies ?? []).map((trophy) => ({
+      trophy,
+      game: gameFromTrophyUrl(trophy.url),
+      date: trophy.completionDate ? new Date(trophy.completionDate) : null,
+    }));
+
+    const term = query.trim().toLowerCase();
+    const matched = term
+      ? list.filter((item) => (item.game?.title ?? "").toLowerCase().includes(term))
+      : list;
+
+    const sorted = [...matched];
+    if (sort === "points") {
+      sorted.sort((a, b) => b.trophy.points - a.trophy.points);
+    } else if (sort === "name") {
+      sorted.sort((a, b) => (a.game?.title ?? "").localeCompare(b.game?.title ?? "", "pt-PT"));
+    } else {
+      // Newest first; a trophy with no completion date sinks to the bottom
+      // rather than being dropped — it still counts toward the totals.
+      sorted.sort((a, b) => (b.date?.getTime() ?? -Infinity) - (a.date?.getTime() ?? -Infinity));
+    }
+    return sorted;
+  }, [hunter, query, sort]);
+
+  if (state === "loading") {
+    return (
+      <div className="mx-auto max-w-6xl px-4 py-12">
+        <SkeletonRows rows={10} />
+      </div>
+    );
+  }
+
+  if (state === "error" || !hunter) {
+    return (
+      <div className="mx-auto max-w-2xl px-4 py-24 text-center">
+        <h1 className="font-display text-4xl font-extrabold uppercase">Caçador não encontrado</h1>
+        <p className="mt-3 text-white/60">
+          Este perfil não está no ranking público — pode não ter platinas registadas, ter saído da comunidade, ou ter
+          pedido para não aparecer publicamente.
+        </p>
+        <Link
+          to="/trophies"
+          className="focus-glow chamfer mt-8 inline-block bg-accent-yellow px-6 py-3 font-bold text-background"
+        >
+          Voltar ao Hall of Fame
+        </Link>
+      </div>
+    );
+  }
+
+  const dates = hunter.trophies
+    .map((trophy) => (trophy.completionDate ? new Date(trophy.completionDate) : null))
+    .filter((date): date is Date => date !== null)
+    .sort((a, b) => a.getTime() - b.getTime());
+  const firstPlatinum = dates[0];
+  const lastPlatinum = dates[dates.length - 1];
+  const averagePoints = Math.round(hunter.points / Math.max(1, hunter.trophyCount));
+
+  return (
+    <div>
+      <div className="border-b border-surface-border">
+        <div className="mx-auto grid max-w-6xl items-center gap-10 px-4 pt-8 pb-10 lg:grid-cols-[1fr_300px]">
+          <div>
+            <Link
+              to="/trophies"
+              className="focus-glow rounded font-mono text-xs text-white/45 transition-colors hover:text-white"
+            >
+              ← Hall of Fame
+            </Link>
+
+            <div className="mt-5 flex items-center gap-4">
+              <Monogram name={hunter.psnProfile} className="h-14 w-14 rounded-xl text-2xl" />
+              <div className="min-w-0">
+                <h1 className="truncate font-display text-5xl leading-none font-extrabold uppercase">
+                  {hunter.psnProfile}
+                </h1>
+                <p className="mt-2 font-mono text-[11px] tracking-[0.16em] text-white/45 uppercase">
+                  Rank #{hunter.rank} · caçador de platinas
+                </p>
+              </div>
+            </div>
+
+            <dl className="mt-8 grid max-w-lg grid-cols-2 gap-x-8 gap-y-5 sm:grid-cols-4">
+              <Stat label="Pontos" value={hunter.points.toLocaleString("pt-PT")} accent="var(--color-accent-yellow)" />
+              <Stat
+                label="Platinas"
+                value={hunter.trophyCount.toLocaleString("pt-PT")}
+                accent="var(--color-accent-mint)"
+              />
+              <Stat label="Média" value={averagePoints.toLocaleString("pt-PT")} />
+              <Stat label="Última" value={lastPlatinum ? MONTH_FORMAT.format(lastPlatinum) : "—"} />
+            </dl>
+
+            <a
+              href={psnProfileUrl(hunter.psnProfile)}
+              target="_blank"
+              rel="noreferrer"
+              className="focus-glow mt-8 inline-flex items-center gap-2 rounded-lg border border-surface-border px-4 py-2.5 text-sm font-semibold transition-colors hover:border-white/30"
+            >
+              Ver perfil no PSNProfiles
+              <span aria-hidden className="text-white/40">
+                ↗
+              </span>
+            </a>
+          </div>
+
+          <div className="mx-auto w-full max-w-[280px] lg:max-w-none">
+            <HoloCard ratio="aspect-[63/78]">
+              <div className="flex items-start justify-between">
+                <span className="rounded border border-white/25 px-2 py-1 font-mono text-[9px] tracking-[0.2em] text-white/70">
+                  CAÇADOR
+                </span>
+                <span className="tabular font-display text-3xl leading-none font-extrabold text-accent-yellow">
+                  #{hunter.rank}
+                </span>
+              </div>
+
+              <div className="grid min-h-0 flex-1 place-items-center py-4">
+                <Monogram name={hunter.psnProfile} className="h-20 w-20 rounded-2xl text-4xl" />
+              </div>
+
+              <p className="truncate font-display text-3xl leading-none font-extrabold uppercase">
+                {hunter.psnProfile}
+              </p>
+              <dl className="mt-4 grid grid-cols-2 gap-2 border-t border-white/15 pt-3.5 text-center">
+                <div>
+                  <dd className="tabular font-display text-2xl leading-none font-extrabold text-accent-yellow">
+                    {hunter.points.toLocaleString("pt-PT")}
+                  </dd>
+                  <dt className="mt-1.5 font-mono text-[8px] tracking-[0.12em] text-white/45">PONTOS</dt>
+                </div>
+                <div>
+                  <dd className="tabular font-display text-2xl leading-none font-extrabold text-accent-mint">
+                    {hunter.trophyCount}
+                  </dd>
+                  <dt className="mt-1.5 font-mono text-[8px] tracking-[0.12em] text-white/45">PLATINAS</dt>
+                </div>
+              </dl>
+            </HoloCard>
+          </div>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-6xl px-4 py-10">
+        <div className="flex flex-wrap items-end justify-between gap-4 border-b border-surface-border pb-4">
+          <h2 className="font-display text-3xl font-extrabold uppercase">
+            As platinas
+            {firstPlatinum && (
+              <span className="ml-3 font-mono text-[11px] font-normal tracking-normal text-white/35 normal-case">
+                desde {MONTH_FORMAT.format(firstPlatinum)}
+              </span>
+            )}
+          </h2>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <SearchField value={query} onChange={setQuery} label="Procurar jogo" placeholder="Procurar jogo…" />
+            <SegmentedControl<Sort>
+              label="Ordenar"
+              value={sort}
+              onChange={setSort}
+              options={[
+                { value: "recent", label: "Recentes", accent: "var(--color-accent-mint)" },
+                { value: "points", label: "Pontos", accent: "var(--color-accent-yellow)" },
+                { value: "name", label: "A-Z", accent: "var(--color-accent-blue)" },
+              ]}
+            />
+          </div>
+        </div>
+
+        <p className="mt-4 font-mono text-xs text-white/40">
+          <span className="tabular text-white">{games.length.toLocaleString("pt-PT")}</span>
+          {query.trim() !== "" && <> de {hunter.trophyCount.toLocaleString("pt-PT")}</>} platinas
+        </p>
+
+        {games.length === 0 ? (
+          <div className="mt-6">
+            <EmptyState>Nenhum jogo corresponde a “{query.trim()}”.</EmptyState>
+          </div>
+        ) : (
+          <ul className="mt-5 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {games.map((item, index) => (
+              <li key={item.trophy.url ?? index}>
+                <GameCard trophy={item.trophy} title={item.game?.title ?? null} href={item.game?.url ?? item.trophy.url} date={item.date} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value, accent }: { label: string; value: string; accent?: string }) {
+  return (
+    <div>
+      <dd className="tabular font-display text-2xl leading-none font-extrabold" style={{ color: accent }}>
+        {value}
+      </dd>
+      <dt className="mt-2 font-mono text-[10px] tracking-[0.14em] text-white/40 uppercase">{label}</dt>
+    </div>
+  );
+}
+
+function GameCard({
+  trophy,
+  title,
+  href,
+  date,
+}: {
+  trophy: HunterTrophy;
+  title: string | null;
+  href: string | null;
+  date: Date | null;
+}) {
+  const body = (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-[15px] leading-snug font-semibold">
+          {/* A URL this parser did not recognise still shows as a trophy —
+              it just cannot be named. Better an honest unnamed platinum than
+              a title invented from a slug we did not understand. */}
+          {title ?? "Platina"}
+        </h3>
+        <span className="tabular shrink-0 font-display text-2xl leading-none font-extrabold text-accent-yellow">
+          {trophy.points}
+        </span>
+      </div>
+      <p className="mt-3 flex items-center gap-2 font-mono text-[10px] tracking-wide text-white/40">
+        <span aria-hidden>🏆</span>
+        {date ? DATE_FORMAT.format(date) : "Data desconhecida"}
+      </p>
+    </>
+  );
+
+  const className =
+    "shine block h-full rounded-xl border border-surface-border bg-gradient-to-br from-white/[0.05] to-white/[0.01] p-4 transition-all duration-200 hover:-translate-y-1 hover:border-white/25";
+
+  if (!href) return <div className={className}>{body}</div>;
+
+  return (
+    <a href={href} target="_blank" rel="noreferrer" className={`focus-glow ${className}`}>
+      {body}
+    </a>
+  );
+}

--- a/portal/web/src/pages/Marketplace.tsx
+++ b/portal/web/src/pages/Marketplace.tsx
@@ -1,41 +1,54 @@
-import { Link } from "react-router-dom";
 import { useMemo, useState } from "react";
 import { AdCard } from "../components/AdCard";
+import { HelpLink, PageHeader } from "../components/PageHeader";
 import { ApiError, EmptyState, SkeletonRow } from "../components/StateViews";
+import { ActiveFilters, SearchField, SegmentedControl, SelectField, Toggle } from "../components/ui/Controls";
 import { api } from "../lib/api/client";
 import {
-  CONDITION_LABELS,
   type AdCondition,
+  CONDITION_LABELS,
   normalizeCondition,
   normalizePlatform,
   normalizeZone,
   type PlatformTag,
 } from "../lib/normalize";
-import { PLATFORM_ORDER } from "../lib/platforms";
+import { PLATFORM_ORDER, PLATFORMS } from "../lib/platforms";
 import { useDocumentHead } from "../lib/seo";
 import { useApi } from "../lib/useApi";
 
 type AdTypeFilter = "all" | "sell" | "wanted";
 type SortOrder = "recent" | "price_asc" | "price_desc";
-// "all" (no filter) or a normalized zone label ("Lisboa", "Online", "Outra",
-// ...) — built from whatever districts/buckets actually appear in the
-// currently-loaded ad set, not a hardcoded list, so it never offers an empty
-// filter option.
 type ZoneFilter = "all" | string;
 
+const PAGE_SIZE = 24;
+
+const PLATFORM_LABEL: Record<PlatformTag, string> = {
+  playstation: PLATFORMS.playstation.label,
+  xbox: PLATFORMS.xbox.label,
+  nintendo: PLATFORMS.nintendo.label,
+  pc: PLATFORMS.pc.label,
+  other: "Outra",
+};
+
 /**
- * M8.7 — Marketplace grid + filters. All filtering happens client-side over
- * one fetch of the active set (currently ~40 rows post-expiry per the task
- * brief's "28 were just expired" note — small enough that a single `?limit=`
- * call and in-memory filtering is simpler and more consistent than teaching
- * `portal/api` to filter by *normalised* platform/condition/zone, which
- * would mean duplicating M8.4's mapping server-side). If the active count
- * grows by an order of magnitude this should move server-side — noted as a
- * scaling follow-up, not a correctness gap today.
+ * M8.7 + M11 — the marketplace.
+ *
+ * All filtering happens client-side over one fetch of the active set (~40
+ * rows today). That is deliberate: the platform/condition/zone filters run on
+ * *normalised* values, and M8.4's mapping lives in `portal/web` only — so
+ * filtering server-side would mean duplicating it in the API, and filtering a
+ * server-paginated page would show fewer results than the count promises. If
+ * the active set grows by an order of magnitude this moves server-side; noted
+ * as a scaling follow-up, not a correctness gap today.
+ *
+ * M11 adds free-text search, per-option result counts, a photo-only toggle, a
+ * removable summary of what is currently filtering, and paging — so a visitor
+ * can actually find "a PS5 game under 40€ near Porto" instead of scrolling
+ * every listing.
  */
 export function Marketplace() {
   useDocumentHead({
-    title: "Marketplace",
+    title: "Mercado",
     description: "Anúncios de compra e venda entre membros da comunidade Game On Portugal.",
     path: "/marketplace",
   });
@@ -46,171 +59,274 @@ export function Marketplace() {
     (value) => value.ads.length === 0,
   );
 
+  const [query, setQuery] = useState("");
   const [adType, setAdType] = useState<AdTypeFilter>("all");
   const [platform, setPlatform] = useState<PlatformTag | "all">("all");
   const [condition, setCondition] = useState<AdCondition | "all">("all");
   const [zone, setZone] = useState<ZoneFilter>("all");
+  const [withPhoto, setWithPhoto] = useState(false);
   const [sort, setSort] = useState<SortOrder>("recent");
+  const [visible, setVisible] = useState(PAGE_SIZE);
 
-  const zoneOptions = useMemo(() => {
-    const labels = new Set<string>();
-    for (const ad of data?.ads ?? []) {
-      const normalized = normalizeZone(ad.zone);
-      if (normalized) labels.add(normalized.label);
+  const ads = useMemo(() => data?.ads ?? [], [data]);
+
+  // Option counts come from the whole loaded set, not the filtered one, so a
+  // dropdown never offers "PC (0)" or silently hides a platform that exists.
+  const counts = useMemo(() => {
+    const platforms = new Map<PlatformTag, number>();
+    const conditions = new Map<AdCondition, number>();
+    const zones = new Map<string, number>();
+
+    for (const ad of ads) {
+      const c = normalizeCondition(ad.state);
+      if (c) conditions.set(c, (conditions.get(c) ?? 0) + 1);
+      // Counted exactly the way AdCard reads it, or the dropdown would promise
+      // "PC (3)" and the grid would show three cards with no PC badge.
+      const p = c === null ? normalizePlatform(ad.state) : null;
+      if (p) platforms.set(p, (platforms.get(p) ?? 0) + 1);
+      const z = normalizeZone(ad.zone);
+      if (z) zones.set(z.label, (zones.get(z.label) ?? 0) + 1);
     }
-    return Array.from(labels).sort((a, b) => a.localeCompare(b, "pt-PT"));
-  }, [data]);
+    return { platforms, conditions, zones };
+  }, [ads]);
+
+  const zoneOptions = useMemo(
+    () =>
+      Array.from(counts.zones.entries())
+        .sort((a, b) => a[0].localeCompare(b[0], "pt-PT"))
+        .map(([label, count]) => ({ value: label, label, count })),
+    [counts],
+  );
 
   const filtered = useMemo(() => {
-    if (!data) return [];
-    let ads = data.ads;
-    if (adType !== "all") ads = ads.filter((ad) => ad.adType === adType);
-    if (platform !== "all") ads = ads.filter((ad) => normalizePlatform(ad.state) === platform);
-    if (condition !== "all") ads = ads.filter((ad) => normalizeCondition(ad.state) === condition);
-    if (zone !== "all") ads = ads.filter((ad) => normalizeZone(ad.zone)?.label === zone);
+    const term = query.trim().toLowerCase();
+    let result = ads;
+
+    if (term) {
+      result = result.filter(
+        (ad) =>
+          (ad.name ?? "").toLowerCase().includes(term) || (ad.description ?? "").toLowerCase().includes(term),
+      );
+    }
+    if (adType !== "all") result = result.filter((ad) => ad.adType === adType);
+    if (platform !== "all")
+      result = result.filter((ad) => normalizeCondition(ad.state) === null && normalizePlatform(ad.state) === platform);
+    if (condition !== "all") result = result.filter((ad) => normalizeCondition(ad.state) === condition);
+    if (zone !== "all") result = result.filter((ad) => normalizeZone(ad.zone)?.label === zone);
+    if (withPhoto) result = result.filter((ad) => ad.images.length > 0);
 
     if (sort === "price_asc" || sort === "price_desc") {
-      const withPrice = ads.filter((ad) => ad.price_cents != null);
-      const withoutPrice = ads.filter((ad) => ad.price_cents == null);
-      withPrice.sort((a, b) =>
+      // Ads with no parseable price are not "free" (schema note on
+      // `price_cents`) — they sort to the end either way rather than being
+      // treated as 0€ and hijacking the cheapest slot.
+      const priced = result.filter((ad) => ad.price_cents != null);
+      const unpriced = result.filter((ad) => ad.price_cents == null);
+      priced.sort((a, b) =>
         sort === "price_asc" ? a.price_cents! - b.price_cents! : b.price_cents! - a.price_cents!,
       );
-      ads = [...withPrice, ...withoutPrice];
+      result = [...priced, ...unpriced];
     }
-    return ads;
-  }, [data, adType, platform, condition, sort]);
+
+    return result;
+    // `zone` and `withPhoto` were missing from this list before M11, so
+    // changing the zone dropdown filtered nothing until some other filter
+    // happened to invalidate the memo.
+  }, [ads, query, adType, platform, condition, zone, withPhoto, sort]);
+
+  const chips = [
+    query.trim() && { key: "q", label: `“${query.trim()}”`, onRemove: () => setQuery("") },
+    adType !== "all" && {
+      key: "type",
+      label: adType === "sell" ? "À venda" : "Procura-se",
+      onRemove: () => setAdType("all"),
+    },
+    platform !== "all" && {
+      key: "platform",
+      label: PLATFORM_LABEL[platform],
+      onRemove: () => setPlatform("all"),
+    },
+    condition !== "all" && {
+      key: "condition",
+      label: CONDITION_LABELS[condition],
+      onRemove: () => setCondition("all"),
+    },
+    zone !== "all" && { key: "zone", label: zone, onRemove: () => setZone("all") },
+    withPhoto && { key: "photo", label: "Com foto", onRemove: () => setWithPhoto(false) },
+  ].filter(Boolean) as Array<{ key: string; label: string; onRemove: () => void }>;
+
+  function clearAll() {
+    setQuery("");
+    setAdType("all");
+    setPlatform("all");
+    setCondition("all");
+    setZone("all");
+    setWithPhoto(false);
+    setVisible(PAGE_SIZE);
+  }
+
+  const forSale = ads.filter((ad) => ad.adType !== "wanted").length;
+  const wanted = ads.filter((ad) => ad.adType === "wanted").length;
 
   return (
-    <div className="mx-auto max-w-5xl px-4 py-8">
-      <h1 className="font-display text-2xl">Marketplace</h1>
-      <p className="mt-1 text-sm text-white/60">Anúncios de compra e venda entre membros da comunidade.</p>
-      {/* M10.10 — how to actually post one; the portal is read-only, the ad
-          is created in Discord. */}
-      <p className="mt-3 text-sm">
-        <Link to="/como-participar#marketplace" className="focus-glow text-accent-blue hover:underline">
-          Como publicar um anúncio →
-        </Link>
-      </p>
-
-      <Filters
-        adType={adType}
-        onAdType={setAdType}
-        platform={platform}
-        onPlatform={setPlatform}
-        condition={condition}
-        onCondition={setCondition}
-        zone={zone}
-        onZone={setZone}
-        zoneOptions={zoneOptions}
-        sort={sort}
-        onSort={setSort}
-      />
-
-      {state === "loading" && (
-        <SkeletonRow className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3" tiles={6} />
-      )}
-      {state === "error" && (
-        <div className="mt-6">
-          <ApiError what="os anúncios" />
-        </div>
-      )}
-      {state !== "loading" && state !== "error" && filtered.length === 0 && (
-        <div className="mt-6">
-          <EmptyState>
-            {data && data.ads.length > 0
-              ? "Nenhum anúncio corresponde a estes filtros."
-              : "Sem anúncios ativos neste momento — volta mais tarde ou publica o teu no Discord."}
-          </EmptyState>
-        </div>
-      )}
-      {state !== "loading" && state !== "error" && filtered.length > 0 && (
-        <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3">
-          {filtered.map((ad) => (
-            <AdCard key={ad.id} ad={ad} />
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function Filters({
-  adType,
-  onAdType,
-  platform,
-  onPlatform,
-  condition,
-  onCondition,
-  zone,
-  onZone,
-  zoneOptions,
-  sort,
-  onSort,
-}: {
-  adType: AdTypeFilter;
-  onAdType: (v: AdTypeFilter) => void;
-  platform: PlatformTag | "all";
-  onPlatform: (v: PlatformTag | "all") => void;
-  condition: AdCondition | "all";
-  onCondition: (v: AdCondition | "all") => void;
-  zone: ZoneFilter;
-  onZone: (v: ZoneFilter) => void;
-  zoneOptions: string[];
-  sort: SortOrder;
-  onSort: (v: SortOrder) => void;
-}) {
-  const selectClass =
-    "focus-glow chamfer border border-surface-border bg-surface px-3 py-2 text-sm text-white";
-
-  return (
-    <div className="mt-4 flex flex-wrap gap-2">
-      <select className={selectClass} value={adType} onChange={(e) => onAdType(e.target.value as AdTypeFilter)}>
-        <option value="all">Tipo: todos</option>
-        <option value="sell">À venda</option>
-        <option value="wanted">Procura-se</option>
-      </select>
-
-      <select
-        className={selectClass}
-        value={platform}
-        onChange={(e) => onPlatform(e.target.value as PlatformTag | "all")}
+    <div>
+      <PageHeader
+        eyebrow="Compra, vende, troca"
+        title="Mercado"
+        description="Anúncios entre membros da comunidade. Os negócios fazem-se no Discord — isto é a montra."
+        stats={[
+          { label: "À venda", value: forSale.toLocaleString("pt-PT"), accent: "var(--color-accent-mint)" },
+          { label: "Procura-se", value: wanted.toLocaleString("pt-PT"), accent: "var(--color-accent-blue)" },
+        ]}
       >
-        <option value="all">Plataforma: todas</option>
-        {PLATFORM_ORDER.map((p) => (
-          <option key={p} value={p}>
-            {p === "playstation" ? "PlayStation" : p === "xbox" ? "Xbox" : p === "nintendo" ? "Nintendo" : "PC"}
-          </option>
-        ))}
-        <option value="other">Outra</option>
-      </select>
+        <HelpLink to="/como-participar#marketplace">Como publicar um anúncio</HelpLink>
+      </PageHeader>
 
-      <select
-        className={selectClass}
-        value={condition}
-        onChange={(e) => onCondition(e.target.value as AdCondition | "all")}
-      >
-        <option value="all">Estado: todos</option>
-        {Object.entries(CONDITION_LABELS).map(([value, label]) => (
-          <option key={value} value={value}>
-            {label}
-          </option>
-        ))}
-      </select>
+      <div className="mx-auto max-w-6xl px-4 py-8">
+        <div className="flex flex-wrap items-center gap-3">
+          <SearchField
+            value={query}
+            onChange={(next) => {
+              setQuery(next);
+              setVisible(PAGE_SIZE);
+            }}
+            label="Procurar anúncios"
+            placeholder="Procurar por título ou descrição…"
+          />
 
-      <select className={selectClass} value={zone} onChange={(e) => onZone(e.target.value)}>
-        <option value="all">Zona: todas</option>
-        {zoneOptions.map((label) => (
-          <option key={label} value={label}>
-            {label}
-          </option>
-        ))}
-      </select>
+          <SegmentedControl<AdTypeFilter>
+            label="Tipo de anúncio"
+            value={adType}
+            onChange={(next) => {
+              setAdType(next);
+              setVisible(PAGE_SIZE);
+            }}
+            options={[
+              { value: "all", label: "Todos" },
+              { value: "sell", label: "À venda", accent: "var(--color-accent-mint)" },
+              { value: "wanted", label: "Procura-se", accent: "var(--color-accent-blue)" },
+            ]}
+          />
 
-      <select className={selectClass} value={sort} onChange={(e) => onSort(e.target.value as SortOrder)}>
-        <option value="recent">Mais recentes</option>
-        <option value="price_asc">Preço: mais baixo</option>
-        <option value="price_desc">Preço: mais alto</option>
-      </select>
+          <SelectField<PlatformTag>
+            label="Plataforma"
+            allLabel="Plataforma: todas"
+            value={platform}
+            onChange={(next) => {
+              setPlatform(next);
+              setVisible(PAGE_SIZE);
+            }}
+            options={[...PLATFORM_ORDER, "other" as const]
+              .filter((p) => counts.platforms.has(p))
+              .map((p) => ({ value: p, label: PLATFORM_LABEL[p], count: counts.platforms.get(p) }))}
+          />
+
+          <SelectField<AdCondition>
+            label="Estado"
+            allLabel="Estado: todos"
+            value={condition}
+            onChange={(next) => {
+              setCondition(next);
+              setVisible(PAGE_SIZE);
+            }}
+            options={(Object.keys(CONDITION_LABELS) as AdCondition[])
+              .filter((c) => counts.conditions.has(c))
+              .map((c) => ({ value: c, label: CONDITION_LABELS[c], count: counts.conditions.get(c) }))}
+          />
+
+          <SelectField
+            label="Zona"
+            allLabel="Zona: todas"
+            value={zone}
+            onChange={(next) => {
+              setZone(next);
+              setVisible(PAGE_SIZE);
+            }}
+            options={zoneOptions}
+          />
+
+          <SelectField<SortOrder>
+            label="Ordenar"
+            allLabel="Mais recentes"
+            value={sort === "recent" ? "all" : sort}
+            onChange={(next) => setSort(next === "all" ? "recent" : (next as SortOrder))}
+            options={[
+              { value: "price_asc", label: "Preço: mais baixo" },
+              { value: "price_desc", label: "Preço: mais alto" },
+            ]}
+          />
+
+          <Toggle
+            checked={withPhoto}
+            onChange={(next) => {
+              setWithPhoto(next);
+              setVisible(PAGE_SIZE);
+            }}
+          >
+            Só com foto
+          </Toggle>
+        </div>
+
+        <ActiveFilters
+          chips={chips}
+          onClearAll={clearAll}
+          resultCount={filtered.length}
+          totalCount={ads.length}
+          noun="anúncios"
+        />
+
+        {state === "loading" && (
+          <SkeletonRow tiles={6} className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3" />
+        )}
+        {state === "error" && (
+          <div className="mt-8">
+            <ApiError what="os anúncios" />
+          </div>
+        )}
+
+        {state !== "loading" && state !== "error" && filtered.length === 0 && (
+          <div className="mt-8">
+            <EmptyState
+              action={
+                chips.length > 0 ? (
+                  <button
+                    type="button"
+                    onClick={clearAll}
+                    className="focus-glow rounded-lg border border-surface-border px-5 py-2.5 font-mono text-xs text-white/70 hover:border-white/30 hover:text-white"
+                  >
+                    Limpar filtros
+                  </button>
+                ) : undefined
+              }
+            >
+              {ads.length > 0
+                ? "Nenhum anúncio corresponde a estes filtros."
+                : "Sem anúncios ativos neste momento — volta mais tarde, ou publica o teu no Discord."}
+            </EmptyState>
+          </div>
+        )}
+
+        {filtered.length > 0 && (
+          <>
+            <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {filtered.slice(0, visible).map((ad) => (
+                <AdCard key={ad.id} ad={ad} />
+              ))}
+            </div>
+
+            {visible < filtered.length && (
+              <div className="mt-8 text-center">
+                <button
+                  type="button"
+                  onClick={() => setVisible((count) => count + PAGE_SIZE)}
+                  className="focus-glow rounded-lg border border-surface-border px-6 py-2.5 font-mono text-xs tracking-wide text-white/70 transition-colors hover:border-white/30 hover:text-white"
+                >
+                  Mostrar mais ({filtered.length - visible} restantes)
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/portal/web/src/pages/MarketplaceDetail.tsx
+++ b/portal/web/src/pages/MarketplaceDetail.tsx
@@ -1,9 +1,11 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
+import { AdCard } from "../components/AdCard";
 import { LazyImage } from "../components/LazyImage";
+import { Lightbox } from "../components/Lightbox";
 import { PlatformBadge } from "../components/PlatformBadge";
 import { SkeletonRow } from "../components/StateViews";
-import { api } from "../lib/api/client";
+import { api, thumbnailUrl } from "../lib/api/client";
 import {
   CONDITION_LABELS,
   formatPrice,
@@ -11,6 +13,7 @@ import {
   normalizePlatform,
   normalizeZone,
 } from "../lib/normalize";
+import { PLATFORMS } from "../lib/platforms";
 import { useDocumentHead } from "../lib/seo";
 import { useApi } from "../lib/useApi";
 
@@ -22,133 +25,217 @@ const DISPATCH_LABELS: Record<string, string> = {
   face_to_face: "Entrega em mão",
 };
 
+const DATE_FORMAT = new Intl.DateTimeFormat("pt-PT", { day: "numeric", month: "long", year: "numeric" });
+
 /**
- * M8.7 — ad detail view. `getAdById` 404s for a soft-deleted/inactive row
- * (portal/api/src/repositories/ads.ts's `publicAdsWhere`). A 404 and a
- * network/5xx failure both surface here as one honest "not available"
- * state rather than a blank page — the two aren't disambiguated because
- * neither is actionable differently by a visitor (both times, the ad
- * cannot currently be shown).
+ * M8.7 + M11 — ad detail.
  *
- * "Contact on Discord" (plan 03's pages table) is a plain invite link, not a
- * deep link to the ad's own message: `portal/api`'s ads repository
- * deliberately never returns `channel_id`/`message_id` (privacy decision 5
- * groups them with raw user IDs — see that file's header comment), so this
- * page has no message reference to link to even if it wanted to. Recorded
- * as a scope decision in the M8.7 row, not an oversight.
+ * `getAdById` 404s for a soft-deleted/inactive row (`publicAdsWhere`). A 404
+ * and a network/5xx both surface as one honest "not available" state: neither
+ * is actionable differently by a visitor, since both times the ad cannot be
+ * shown.
+ *
+ * "Contact on Discord" is a plain invite link, not a deep link to the ad's
+ * own message: portal-api deliberately never returns `channel_id`/
+ * `message_id` (privacy decision 5 groups them with raw user IDs), so this
+ * page has no message reference to link to even if it wanted one.
+ *
+ * M11 adds the full spec table — the ad's `zone`, `dispatch`, `warranty` and
+ * dates were all being fetched and then thrown away, so a listing showed a
+ * photo and a price and left every practical question ("does it ship?", "how
+ * old is this?") unanswered.
  */
 export function MarketplaceDetail() {
   const { id } = useParams<{ id: string }>();
-  const { state, data } = useApi(
-    () => api.getAd(id!),
-    [id],
-    () => false,
-  );
+  const { state, data } = useApi(() => api.getAd(id!), [id], () => false);
   const [activeImage, setActiveImage] = useState(0);
+  const [lightboxOpen, setLightboxOpen] = useState(false);
 
-  // Called unconditionally (Rules of Hooks) — before the loading/error early
-  // returns below, so it runs on every render regardless of fetch state.
-  // Falls back to the site defaults (index.html) while data isn't loaded
-  // yet, then swaps in the ad's own name/first image once it is.
+  const ad = data?.ad;
+
   useDocumentHead({
-    title: data?.ad?.name ?? "Anúncio",
-    description: data?.ad?.description ?? undefined,
-    image: data?.ad?.images[0],
+    title: ad?.name ?? "Anúncio",
+    description: ad?.description ?? undefined,
+    image: ad?.images[0],
     path: id ? `/marketplace/${id}` : undefined,
   });
 
+  const lightboxItems = useMemo(
+    () => (ad?.images ?? []).map((image, index) => ({ id: `${index}`, name: ad?.name ?? null, imageUrl: image })),
+    [ad],
+  );
+
   if (state === "loading") {
     return (
-      <div className="mx-auto max-w-3xl px-4 py-8">
+      <div className="mx-auto max-w-5xl px-4 py-10">
         <SkeletonRow tiles={1} className="aspect-video w-full" />
       </div>
     );
   }
 
-  const ad = data?.ad;
-
   if (state === "error" || !ad) {
     return (
-      <div className="mx-auto max-w-3xl px-4 py-16 text-center">
-        <h1 className="font-display text-2xl">Anúncio não disponível</h1>
-        <p className="mt-2 text-white/60">Pode ter sido vendido, removido, ou o link estar incorreto.</p>
-        <Link to="/marketplace" className="focus-glow mt-6 inline-block text-accent-blue hover:underline">
-          ← Voltar ao marketplace
+      <div className="mx-auto max-w-2xl px-4 py-24 text-center">
+        <h1 className="font-display text-4xl font-extrabold uppercase">Anúncio não disponível</h1>
+        <p className="mt-3 text-white/60">Pode ter sido vendido, removido, ou o link estar incorreto.</p>
+        <Link
+          to="/marketplace"
+          className="focus-glow chamfer mt-8 inline-block bg-accent-yellow px-6 py-3 font-bold text-background"
+        >
+          Voltar ao mercado
         </Link>
       </div>
     );
   }
 
   const condition = normalizeCondition(ad.state);
-  const platform = normalizePlatform(ad.state);
+  // Same one-column rule as AdCard: a value that parsed as a condition is not
+  // also a platform, and "other" asserts nothing worth showing.
+  const platform = condition === null ? normalizePlatform(ad.state) : null;
+  const knownPlatform = platform && platform !== "other" ? platform : null;
   const zone = normalizeZone(ad.zone);
   const dispatch = ad.dispatch ? (DISPATCH_LABELS[ad.dispatch] ?? ad.dispatch) : null;
+  const accent = knownPlatform ? PLATFORMS[knownPlatform].colorVar : "var(--color-surface-border)";
   const images = ad.images.length > 0 ? ad.images : [null];
 
+  const specs: Array<{ label: string; value: string }> = [
+    { label: "Tipo", value: ad.adType === "wanted" ? "Procura-se" : "À venda" },
+    ...(condition ? [{ label: "Estado", value: CONDITION_LABELS[condition] }] : []),
+    ...(zone ? [{ label: "Zona", value: zone.label }] : []),
+    ...(dispatch ? [{ label: "Envio", value: dispatch }] : []),
+    ...(ad.warranty ? [{ label: "Garantia", value: ad.warranty }] : []),
+    { label: "Publicado", value: DATE_FORMAT.format(new Date(ad.createdAt)) },
+    ...(ad.bumped_at ? [{ label: "Renovado", value: DATE_FORMAT.format(new Date(ad.bumped_at)) }] : []),
+    ...(ad.expires_at ? [{ label: "Expira", value: DATE_FORMAT.format(new Date(ad.expires_at)) }] : []),
+  ];
+
   return (
-    <div className="mx-auto max-w-3xl px-4 py-8">
-      <Link to="/marketplace" className="focus-glow text-sm text-white/60 hover:text-white">
-        ← Marketplace
+    <div className="mx-auto max-w-5xl px-4 py-8">
+      <Link
+        to="/marketplace"
+        className="focus-glow rounded font-mono text-xs text-white/45 transition-colors hover:text-white"
+      >
+        ← Mercado
       </Link>
 
-      <div className="mt-4 chamfer overflow-hidden border border-surface-border bg-surface">
-        <LazyImage src={images[activeImage] ?? null} alt={ad.name ?? "Anúncio"} className="aspect-video w-full" />
+      <div className="mt-5 grid gap-8 lg:grid-cols-[1.15fr_1fr]">
+        <div>
+          <div className="relative overflow-hidden rounded-xl border border-surface-border bg-surface">
+            <span aria-hidden className="absolute inset-x-0 top-0 z-10 h-[3px]" style={{ backgroundColor: accent }} />
+            <LazyImage
+              src={images[activeImage] ?? null}
+              alt={ad.name ?? "Anúncio"}
+              className="aspect-video w-full"
+              onClick={ad.images.length > 0 ? () => setLightboxOpen(true) : undefined}
+            />
+          </div>
+
+          {images.length > 1 && (
+            <div className="mt-3 flex gap-2 overflow-x-auto pb-1">
+              {images.map((image, index) => (
+                <button
+                  key={image ?? index}
+                  type="button"
+                  onClick={() => setActiveImage(index)}
+                  aria-label={`Imagem ${index + 1}`}
+                  aria-current={index === activeImage}
+                  className={`focus-glow h-16 w-24 shrink-0 overflow-hidden rounded-lg border transition-colors ${
+                    index === activeImage ? "border-accent-yellow" : "border-surface-border hover:border-white/30"
+                  }`}
+                >
+                  <LazyImage src={thumbnailUrl(image, 160)} alt="" className="h-full w-full" />
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            {knownPlatform && <PlatformBadge platform={knownPlatform} size="md" />}
+            {ad.adType === "wanted" && (
+              <span className="rounded-md border border-accent-blue px-2.5 py-1 font-mono text-[11px] font-semibold tracking-[0.12em] text-accent-blue uppercase">
+                Procura-se
+              </span>
+            )}
+          </div>
+
+          <h1 className="mt-4 font-display text-4xl leading-none font-extrabold uppercase">
+            {ad.name ?? "Anúncio sem título"}
+          </h1>
+
+          <p className="tabular mt-4 font-display text-5xl leading-none font-extrabold text-accent-yellow">
+            {formatPrice(ad.price_cents, ad.price)}
+          </p>
+
+          <dl className="mt-8 divide-y divide-surface-border border-y border-surface-border">
+            {specs.map((spec) => (
+              <div key={spec.label} className="flex items-baseline justify-between gap-4 py-2.5">
+                <dt className="font-mono text-[10px] tracking-[0.15em] text-white/40 uppercase">{spec.label}</dt>
+                <dd className="text-right text-sm">{spec.value}</dd>
+              </div>
+            ))}
+          </dl>
+
+          <a
+            href={DISCORD_INVITE}
+            target="_blank"
+            rel="noreferrer"
+            className="focus-glow chamfer mt-8 block bg-accent-yellow px-6 py-3.5 text-center font-bold text-background transition-transform hover:-translate-y-0.5"
+          >
+            Contactar no Discord
+          </a>
+          <p className="mt-3 text-center font-mono text-[11px] text-white/35">
+            O negócio faz-se no servidor — este site não trata pagamentos.
+          </p>
+        </div>
       </div>
 
-      {images.length > 1 && (
-        <div className="mt-2 flex gap-2 overflow-x-auto">
-          {images.map((img, i) => (
-            <button
-              key={img ?? i}
-              type="button"
-              onClick={() => setActiveImage(i)}
-              className={`focus-glow chamfer h-14 w-20 shrink-0 overflow-hidden border ${
-                i === activeImage ? "border-accent-yellow" : "border-surface-border"
-              }`}
-            >
-              <LazyImage src={img} alt="" className="h-full w-full" />
-            </button>
-          ))}
-        </div>
+      {ad.description && (
+        <section className="mt-12">
+          <h2 className="font-display text-2xl font-extrabold uppercase">Descrição</h2>
+          <p className="mt-4 max-w-3xl leading-relaxed whitespace-pre-wrap text-white/75">{ad.description}</p>
+        </section>
       )}
 
-      <div className="mt-6 flex items-start justify-between gap-3">
-        <h1 className="font-display text-2xl">{ad.name ?? "Anúncio sem título"}</h1>
-        {ad.adType === "wanted" && (
-          <span className="chamfer shrink-0 border border-accent-blue px-2 py-1 text-xs font-semibold text-accent-blue">
-            PROCURA-SE
-          </span>
-        )}
-      </div>
-      <p className="mt-1 text-xl text-accent-yellow">{formatPrice(ad.price_cents, ad.price)}</p>
+      <RelatedAds currentId={ad.id} adType={ad.adType} />
 
-      <div className="mt-3 flex flex-wrap gap-1.5">
-        {platform && <PlatformBadge platform={platform} />}
-        {condition && (
-          <span className="chamfer border border-surface-border px-2 py-0.5 text-xs text-white/70">
-            {CONDITION_LABELS[condition]}
-          </span>
-        )}
-        {zone && (
-          <span className="chamfer border border-surface-border px-2 py-0.5 text-xs text-white/70">
-            {zone.label}
-          </span>
-        )}
-        {dispatch && (
-          <span className="chamfer border border-surface-border px-2 py-0.5 text-xs text-white/70">{dispatch}</span>
-        )}
-      </div>
-
-      {ad.description && <p className="mt-4 whitespace-pre-wrap text-white/80">{ad.description}</p>}
-
-      <a
-        href={DISCORD_INVITE}
-        target="_blank"
-        rel="noreferrer"
-        className="focus-glow chamfer mt-8 inline-block bg-accent-blue px-6 py-3 font-semibold text-background transition-opacity hover:opacity-90"
-      >
-        Contactar no Discord
-      </a>
+      {lightboxOpen && (
+        <Lightbox
+          items={lightboxItems}
+          index={activeImage}
+          onClose={() => setLightboxOpen(false)}
+          onNavigate={setActiveImage}
+        />
+      )}
     </div>
+  );
+}
+
+/**
+ * "Other listings like this one" — same ad type, newest first, the current ad
+ * excluded. Not a similarity model: there is no category on an `Ad` to match
+ * on, so pretending to recommend would be dressing up "here are some others"
+ * as something cleverer than it is. The heading says exactly what it is.
+ */
+function RelatedAds({ currentId, adType }: { currentId: string; adType: string | null }) {
+  const { state, data } = useApi(() => api.listAds(24), [], () => false);
+
+  if (state !== "ready" || !data) return null;
+
+  const related = data.ads.filter((ad) => ad.id !== currentId && ad.adType === adType).slice(0, 3);
+  if (related.length === 0) return null;
+
+  return (
+    <section className="mt-16">
+      <h2 className="border-b border-surface-border pb-4 font-display text-2xl font-extrabold uppercase">
+        Outros anúncios
+      </h2>
+      <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {related.map((ad) => (
+          <AdCard key={ad.id} ad={ad} />
+        ))}
+      </div>
+    </section>
   );
 }

--- a/portal/web/src/pages/MarketplaceDetail.tsx
+++ b/portal/web/src/pages/MarketplaceDetail.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { AdCard } from "../components/AdCard";
 import { LazyImage } from "../components/LazyImage";
@@ -50,6 +50,14 @@ export function MarketplaceDetail() {
   const { state, data } = useApi(() => api.getAd(id!), [id], () => false);
   const [activeImage, setActiveImage] = useState(0);
   const [lightboxOpen, setLightboxOpen] = useState(false);
+
+  // React Router reuses this component instance across `:id` changes (e.g.
+  // clicking a related ad below), so image/lightbox state from the previous
+  // ad would otherwise leak into the new one.
+  useEffect(() => {
+    setActiveImage(0);
+    setLightboxOpen(false);
+  }, [id]);
 
   const ad = data?.ad;
 

--- a/portal/web/src/pages/Screenshots.tsx
+++ b/portal/web/src/pages/Screenshots.tsx
@@ -1,32 +1,49 @@
 import { useMemo, useState } from "react";
-import { Link } from "react-router-dom";
 import { LazyImage } from "../components/LazyImage";
 import { Lightbox } from "../components/Lightbox";
+import { HelpLink, PageHeader } from "../components/PageHeader";
+import { PlatformBadge } from "../components/PlatformBadge";
 import { ApiError, EmptyState, SkeletonRow } from "../components/StateViews";
+import { ActiveFilters, SearchField, SegmentedControl, SelectField } from "../components/ui/Controls";
 import { api, thumbnailUrl } from "../lib/api/client";
 import { normalizePlatform, type PlatformTag } from "../lib/normalize";
-import { PLATFORM_ORDER } from "../lib/platforms";
+import { PLATFORM_ORDER, PLATFORMS } from "../lib/platforms";
 import { useDocumentHead } from "../lib/seo";
 import { useApi } from "../lib/useApi";
 
-const PAGE_SIZE = 60;
+const PAGE_SIZE = 48;
+
+type Sort = "recent" | "oldest";
+
+const PLATFORM_LABEL: Record<PlatformTag, string> = {
+  playstation: PLATFORMS.playstation.label,
+  xbox: PLATFORMS.xbox.label,
+  nintendo: PLATFORMS.nintendo.label,
+  pc: PLATFORMS.pc.label,
+  other: "Outra",
+};
 
 /**
- * M8.8 — screenshots gallery. Fetches the full public set in one call
- * (`/api/screenshots` with the raised `MAX_LIMIT`, see
- * portal/api/src/routes/pagination.ts) rather than server-side-paginating,
- * because the platform filter is normalised client-side (M8.4 lives in
- * `portal/web` only) — filtering a server page would show fewer results
- * than expected whenever a filter is active. At 624 rows of small JSON
- * metadata this is cheap; the images themselves are what's guarded, via
- * `LazyImage`'s viewport gating (see that file's header for what "on the
- * fly thumbnails" could and couldn't be built here) and the "carregar mais"
- * button below capping how many grid tiles exist in the DOM at once.
+ * M8.8 + M11 — the screenshots gallery.
  *
- * Handles the two known-dead 2022 Discord CDN links (and any other missing
- * `imageUrl`) via `LazyImage`'s broken-image fallback — a row with no
- * working image still counts and still appears, it just shows a
- * placeholder instead of silently vanishing from the grid.
+ * Fetches the full public set in one call (`/api/screenshots` with the raised
+ * MAX_LIMIT) rather than server-paginating, because the platform filter is
+ * normalised client-side (M8.4 lives in `portal/web` only) — filtering a
+ * server page would show fewer results than the count promises. At ~624 rows
+ * of small JSON metadata this is cheap; the *images* are what's guarded, via
+ * `LazyImage`'s viewport gating, `thumbnailUrl()`'s resized WebP, and the
+ * paging below capping how many tiles exist in the DOM at once.
+ *
+ * M11 adds a year filter and a title search — the gallery spans years and
+ * "show me 2023" was previously only reachable by scrolling. Platform is now
+ * a set of counted chips rather than a bare dropdown, since there are only
+ * five buckets and a visible count is the useful part.
+ *
+ * What is deliberately absent: **who posted each screenshot.** `screenshots`
+ * stores `author_id`, a raw Discord id, and portal-api never exposes it
+ * (privacy decision 5 — portal/api/src/repositories/visibility.ts). Showing
+ * an uploader name or Discord avatar needs both that decision reversed and a
+ * Discord token the portal does not hold. See the note in HunterDetail.tsx.
  */
 export function Screenshots() {
   useDocumentHead({
@@ -42,96 +59,220 @@ export function Screenshots() {
   );
 
   const [platform, setPlatform] = useState<PlatformTag | "all">("all");
-  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const [year, setYear] = useState<string>("all");
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<Sort>("recent");
+  const [visible, setVisible] = useState(PAGE_SIZE);
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
-  const filtered = useMemo(() => {
-    const items = data?.screenshots ?? [];
-    if (platform === "all") return items;
-    return items.filter((shot) => normalizePlatform(shot.platform) === platform);
-  }, [data, platform]);
+  const shots = useMemo(() => data?.screenshots ?? [], [data]);
 
-  const visible = filtered.slice(0, visibleCount);
+  const counts = useMemo(() => {
+    const platforms = new Map<PlatformTag, number>();
+    const years = new Map<string, number>();
+    for (const shot of shots) {
+      const p = normalizePlatform(shot.platform);
+      if (p) platforms.set(p, (platforms.get(p) ?? 0) + 1);
+      const y = String(new Date(shot.createdAt).getFullYear());
+      if (y !== "NaN") years.set(y, (years.get(y) ?? 0) + 1);
+    }
+    return { platforms, years };
+  }, [shots]);
+
+  const yearOptions = useMemo(
+    () =>
+      Array.from(counts.years.entries())
+        .sort((a, b) => b[0].localeCompare(a[0]))
+        .map(([value, count]) => ({ value, label: value, count })),
+    [counts],
+  );
+
+  const filtered = useMemo(() => {
+    const term = query.trim().toLowerCase();
+    let result = shots;
+
+    if (platform !== "all") result = result.filter((shot) => normalizePlatform(shot.platform) === platform);
+    if (year !== "all") result = result.filter((shot) => String(new Date(shot.createdAt).getFullYear()) === year);
+    if (term) result = result.filter((shot) => (shot.name ?? "").toLowerCase().includes(term));
+
+    if (sort === "oldest") {
+      result = [...result].reverse();
+    }
+    return result;
+  }, [shots, platform, year, query, sort]);
+
+  const visibleShots = filtered.slice(0, visible);
+
+  const chips = [
+    query.trim() && { key: "q", label: `“${query.trim()}”`, onRemove: () => setQuery("") },
+    platform !== "all" && {
+      key: "platform",
+      label: PLATFORM_LABEL[platform],
+      onRemove: () => setPlatform("all"),
+    },
+    year !== "all" && { key: "year", label: year, onRemove: () => setYear("all") },
+  ].filter(Boolean) as Array<{ key: string; label: string; onRemove: () => void }>;
+
+  function clearAll() {
+    setQuery("");
+    setPlatform("all");
+    setYear("all");
+    setVisible(PAGE_SIZE);
+  }
 
   return (
-    <div className="mx-auto max-w-6xl px-4 py-8">
-      <div className="flex flex-wrap items-baseline justify-between gap-2">
-        <div>
-          <h1 className="font-display text-2xl">Screenshots</h1>
-          <p className="mt-1 text-sm text-white/60">A galeria da comunidade — {data?.total ?? "…"} publicadas.</p>
-        </div>
-        <Link to="/screenshots/hall-of-fame" className="focus-glow text-sm text-accent-blue hover:underline">
-          Hall of Fame →
-        </Link>
-      </div>
+    <div>
+      <PageHeader
+        eyebrow="A parede da comunidade"
+        title="Screenshots"
+        description="As melhores capturas partilhadas no Discord. Todas as semanas há uma vencedora — a que juntar mais reações."
+        stats={[
+          {
+            label: "Publicadas",
+            value: data?.total?.toLocaleString("pt-PT") ?? "···",
+            accent: "var(--color-accent-mint)",
+          },
+          { label: "Anos", value: String(yearOptions.length || "·"), accent: "var(--color-accent-yellow)" },
+        ]}
+      >
+        <HelpLink to="/como-participar#screenshots">Como partilhar a tua</HelpLink>
+      </PageHeader>
 
-      <div className="mt-4 flex flex-wrap gap-2">
-        <select
-          className="focus-glow chamfer border border-surface-border bg-surface px-3 py-2 text-sm text-white"
-          value={platform}
-          onChange={(e) => {
-            setPlatform(e.target.value as PlatformTag | "all");
-            setVisibleCount(PAGE_SIZE);
-          }}
-        >
-          <option value="all">Plataforma: todas</option>
-          {PLATFORM_ORDER.map((p) => (
-            <option key={p} value={p}>
-              {p === "playstation" ? "PlayStation" : p === "xbox" ? "Xbox" : p === "nintendo" ? "Nintendo" : "PC"}
-            </option>
-          ))}
-          <option value="other">Outra</option>
-        </select>
-      </div>
+      <div className="mx-auto max-w-6xl px-4 py-8">
+        <div className="flex flex-wrap items-center gap-3">
+          <SearchField
+            value={query}
+            onChange={(next) => {
+              setQuery(next);
+              setVisible(PAGE_SIZE);
+            }}
+            label="Procurar screenshots"
+            placeholder="Procurar por jogo…"
+          />
 
-      {state === "loading" && (
-        <SkeletonRow tiles={12} className="mt-6 grid grid-cols-2 gap-2 sm:grid-cols-4 md:grid-cols-6" />
-      )}
-      {state === "error" && (
-        <div className="mt-6">
-          <ApiError what="as screenshots" />
-        </div>
-      )}
-      {state !== "loading" && state !== "error" && filtered.length === 0 && (
-        <div className="mt-6">
-          <EmptyState>Ainda sem screenshots publicadas. Sê o primeiro a partilhar uma no Discord!</EmptyState>
-        </div>
-      )}
+          <SelectField<PlatformTag>
+            label="Plataforma"
+            allLabel="Plataforma: todas"
+            value={platform}
+            onChange={(next) => {
+              setPlatform(next);
+              setVisible(PAGE_SIZE);
+            }}
+            options={[...PLATFORM_ORDER, "other" as const]
+              .filter((p) => counts.platforms.has(p))
+              .map((p) => ({ value: p, label: PLATFORM_LABEL[p], count: counts.platforms.get(p) }))}
+          />
 
-      {state !== "loading" && state !== "error" && visible.length > 0 && (
-        <>
-          <div className="mt-6 grid grid-cols-2 gap-2 sm:grid-cols-4 md:grid-cols-6">
-            {visible.map((shot, i) => (
-              <LazyImage
-                key={shot.id}
-                // M8.8: grid tiles request the resized/cached thumbnail, not
-                // the full-size origin image (LazyImage's viewport gating is
-                // complementary, not a replacement — see that file's
-                // header). The Lightbox below still opens the full image.
-                src={thumbnailUrl(shot.imageUrl, 320)}
-                alt={shot.name ?? "Screenshot"}
-                className="chamfer aspect-square overflow-hidden border border-surface-border bg-surface"
-                onClick={() => setLightboxIndex(i)}
-              />
-            ))}
+          <SelectField
+            label="Ano"
+            allLabel="Ano: todos"
+            value={year}
+            onChange={(next) => {
+              setYear(next);
+              setVisible(PAGE_SIZE);
+            }}
+            options={yearOptions}
+          />
+
+          <SegmentedControl<Sort>
+            label="Ordenar"
+            value={sort}
+            onChange={setSort}
+            options={[
+              { value: "recent", label: "Recentes", accent: "var(--color-accent-mint)" },
+              { value: "oldest", label: "Antigas", accent: "var(--color-accent-yellow)" },
+            ]}
+          />
+        </div>
+
+        <ActiveFilters
+          chips={chips}
+          onClearAll={clearAll}
+          resultCount={filtered.length}
+          totalCount={shots.length}
+          noun="screenshots"
+        />
+
+        {state === "loading" && (
+          <SkeletonRow tiles={12} className="mt-8 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4" />
+        )}
+        {state === "error" && (
+          <div className="mt-8">
+            <ApiError what="as screenshots" />
           </div>
+        )}
 
-          {visibleCount < filtered.length && (
-            <div className="mt-6 text-center">
-              <button
-                type="button"
-                onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
-                className="focus-glow chamfer border border-surface-border px-6 py-2 text-sm text-white/80 hover:text-white"
-              >
-                Carregar mais ({filtered.length - visibleCount} restantes)
-              </button>
-            </div>
-          )}
-        </>
-      )}
+        {state !== "loading" && state !== "error" && filtered.length === 0 && (
+          <div className="mt-8">
+            <EmptyState
+              action={
+                chips.length > 0 ? (
+                  <button
+                    type="button"
+                    onClick={clearAll}
+                    className="focus-glow rounded-lg border border-surface-border px-5 py-2.5 font-mono text-xs text-white/70 hover:border-white/30 hover:text-white"
+                  >
+                    Limpar filtros
+                  </button>
+                ) : undefined
+              }
+            >
+              {shots.length > 0
+                ? "Nenhuma screenshot corresponde a estes filtros."
+                : "Ainda sem screenshots publicadas. Sê o primeiro a partilhar uma no Discord!"}
+            </EmptyState>
+          </div>
+        )}
+
+        {visibleShots.length > 0 && (
+          <>
+            <ul className="mt-8 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+              {visibleShots.map((shot, index) => {
+                const tag = normalizePlatform(shot.platform);
+                return (
+                  <li key={shot.id} className="group relative overflow-hidden rounded-xl border border-surface-border">
+                    <LazyImage
+                      src={thumbnailUrl(shot.imageUrl, 480)}
+                      alt={shot.name ?? "Screenshot"}
+                      className="aspect-[4/3] w-full overflow-hidden bg-surface transition-transform duration-500 group-hover:scale-[1.06]"
+                      onClick={() => setLightboxIndex(index)}
+                    />
+                    <div className="pointer-events-none absolute inset-x-0 bottom-0 translate-y-1 bg-gradient-to-t from-background/95 via-background/70 to-transparent px-3 pt-10 pb-3 opacity-0 transition-all duration-200 group-hover:translate-y-0 group-hover:opacity-100">
+                      <p className="line-clamp-1 text-xs font-semibold">{shot.name ?? "Sem título"}</p>
+                      <p className="mt-1.5 flex items-center gap-2">
+                        {tag && <PlatformBadge platform={tag} />}
+                        <span className="font-mono text-[10px] text-white/45">
+                          {new Date(shot.createdAt).getFullYear()}
+                        </span>
+                      </p>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+
+            {visible < filtered.length && (
+              <div className="mt-8 text-center">
+                <button
+                  type="button"
+                  onClick={() => setVisible((count) => count + PAGE_SIZE)}
+                  className="focus-glow rounded-lg border border-surface-border px-6 py-2.5 font-mono text-xs tracking-wide text-white/70 transition-colors hover:border-white/30 hover:text-white"
+                >
+                  Mostrar mais ({filtered.length - visible} restantes)
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
 
       {lightboxIndex !== null && (
-        <Lightbox items={visible} index={lightboxIndex} onClose={() => setLightboxIndex(null)} onNavigate={setLightboxIndex} />
+        <Lightbox
+          items={visibleShots}
+          index={lightboxIndex}
+          onClose={() => setLightboxIndex(null)}
+          onNavigate={setLightboxIndex}
+        />
       )}
     </div>
   );

--- a/portal/web/src/pages/Trophies.tsx
+++ b/portal/web/src/pages/Trophies.tsx
@@ -1,144 +1,248 @@
+import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { ApiError, EmptyState } from "../components/StateViews";
+import { HelpLink, PageHeader } from "../components/PageHeader";
+import { Monogram, PlayerCard } from "../components/PlayerCard";
+import { ApiError, EmptyState, SkeletonRow, SkeletonRows } from "../components/StateViews";
+import { SearchField } from "../components/ui/Controls";
 import { api } from "../lib/api/client";
 import { useDocumentHead } from "../lib/seo";
 import { useApi } from "../lib/useApi";
 
-// Top-3 highlight via a left border, not text colour — src/lib/platforms.ts's
-// contrast table is why: yellow (rank 1) is AAA-safe as text (19.02:1) so it
-// gets both, but red (rank 3, 4.87:1 — "technically AA-passing but
-// marginal") stays out of text entirely here, matching the stricter line
-// M8.5 already drew for this exact colour ("even the one place that seemed
-// safe, error-copy, uses a red left border with white text instead" — see
-// GLOBAL-PLAN.md's M8.5 row). Accents are for fills/borders/icons.
-const RANK_BORDER: Record<number, string> = {
-  1: "border-accent-yellow",
-  2: "border-white/40",
-  3: "border-accent-red",
-};
-const RANK_TEXT: Record<number, string> = {
-  1: "text-accent-yellow",
-};
+const PAGE_SIZE = 25;
+
+// The route clamps `limit` to 100 (portal/api/src/routes/trophies.ts), so this
+// board is the top 100 and says so — rather than implying it is everyone.
+const BOARD_SIZE = 100;
 
 /**
- * M10.9 — link a ranked hunter to the profile the numbers came from.
- *
- * Same base URL the bot already scrapes
- * (`discord-bot/src/Infrastructure/Trophy/PsnProfilesTrophySource.ts`'s
- * `BASE_URL`), and `psnProfile` is exactly the path segment
- * `extractPsnProfileFromUrl` parsed out of the URL the member submitted to
- * `/trophy create` — so any profile that appears on this leaderboard at all
- * is one PSNProfiles served a page for. `encodeURIComponent` because the
- * column is un-validated free text at the database level.
- */
-function psnProfileUrl(psnProfile: string): string {
-  return `https://psnprofiles.com/${encodeURIComponent(psnProfile)}`;
-}
-
-/**
- * M8.9 — trophy leaderboard. The plan-03 pages table and the M8.9 row in
- * GLOBAL-PLAN both originally called for an honest "data frozen at
- * 2024-12-02" notice — that was true when this task was scoped, but the
- * task brief for THIS agent is explicit that M7 (the trophy sync port)
- * landed the same night (commit history: M7.1-M7.7, "feat(trophies): ...").
- * Adding a stale-data banner here would be actively wrong, not just
- * outdated, so it is deliberately absent — see the M8.9 row in
- * docs/plans/GLOBAL-PLAN.md for this call spelled out.
+ * M8.9 + M11 — the trophy leaderboard, rebuilt as the Hall of Fame.
  *
  * Numbers match `/trophy rank` for the same query by construction:
  * `portal/api`'s `getLeaderboard` (src/repositories/trophies.ts) mirrors
- * `OrmTrophyRepository.queryRankedHunters`'s SQL shape exactly (same
- * `isExcluded` filter, same tie-break order) — see that file's header.
+ * `OrmTrophyRepository.queryRankedHunters`'s SQL shape exactly — same
+ * `isExcluded` filter, same tie-break order.
+ *
+ * M11 adds the podium, a name search over the loaded board, a points bar so
+ * the gap between hunters is legible at a glance, and a route into each
+ * hunter's own platinum list (`/trophies/:psnProfile`) — which is the thing
+ * this page was missing: it showed a ranking and gave you nowhere to go.
+ *
+ * No stale-data banner: M7's sync port landed, so the numbers are live. The
+ * header says "sincronizado periodicamente" rather than claiming real-time,
+ * which is the honest description of a cron-driven scrape.
  */
 export function Trophies() {
   useDocumentHead({
-    title: "Troféus",
-    description: "Leaderboard de troféus da comunidade Game On Portugal.",
+    title: "Hall of Fame",
+    description: "Ranking de troféus da comunidade Game On Portugal — os caçadores de platinas da comunidade.",
     path: "/trophies",
   });
 
-  const { state, data } = useApi(
-    () => api.leaderboard(100),
+  const board = useApi(
+    () => api.leaderboard(BOARD_SIZE),
     [],
     (value) => value.leaderboard.length === 0,
   );
+  const stats = useApi(() => api.stats(), [], () => false);
+
+  const [query, setQuery] = useState("");
+  const [visible, setVisible] = useState(PAGE_SIZE);
+
+  const entries = board.data?.leaderboard ?? [];
+  const podium = entries.slice(0, 3);
+  const rest = entries.slice(3);
+
+  const filtered = useMemo(() => {
+    const term = query.trim().toLowerCase();
+    if (!term) return rest;
+    return rest.filter((entry) => (entry.psnProfile ?? "").toLowerCase().includes(term));
+  }, [rest, query]);
+
+  // The bar is scaled to the leader, not to the visible slice — otherwise the
+  // bars would rescale as you search or page, making the same hunter look
+  // different depending on how you got there.
+  const topPoints = entries[0]?.points ?? 0;
 
   return (
-    <div className="mx-auto max-w-3xl px-4 py-8">
-      <h1 className="font-display text-2xl">Trophy leaderboard</h1>
-      <p className="mt-1 text-sm text-white/60">
-        Ranking por pontos de troféus somados por perfil. Sincronizado periodicamente com a PSN — pode estar alguns
-        minutos atrás do que vês no Discord.
-      </p>
-      {/* M10.10 — the leaderboard showed the result and never said how to get
-          into it. Both links go to the same page; they are separate because
-          "how do I join" and "why am I missing" are different questions asked
-          by different people, and burying the second inside the first is how
-          the excluded-but-fixable case goes unanswered. */}
-      <p className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-sm">
-        <Link to="/como-participar#ranking" className="focus-glow text-accent-blue hover:underline">
-          Como entrar no ranking →
-        </Link>
-        <Link to="/como-participar#fora-do-ranking" className="focus-glow text-white/60 hover:text-white">
-          Não apareço aqui, porquê?
-        </Link>
-      </p>
+    <div>
+      <PageHeader
+        eyebrow="Caçadores de platinas"
+        title="Hall of Fame"
+        description="Ranking por pontos de platinas somados por perfil, sincronizado periodicamente com o PSNProfiles. Pode estar alguns minutos atrás do que vês no Discord."
+        stats={[
+          {
+            label: "Caçadores",
+            value: stats.data?.hunters?.toLocaleString("pt-PT") ?? "···",
+            accent: "var(--color-accent-blue)",
+          },
+          {
+            label: "Platinas",
+            value: stats.data?.trophies?.toLocaleString("pt-PT") ?? "···",
+            accent: "var(--color-accent-yellow)",
+          },
+        ]}
+      >
+        <div className="flex flex-wrap gap-x-6 gap-y-2">
+          <HelpLink to="/como-participar#ranking">Como entrar no ranking</HelpLink>
+          {/* Kept separate from the link above on purpose: "how do I join" and
+              "why am I missing" are different questions asked by different
+              people, and burying the second inside the first is how the
+              excluded-but-fixable case goes unanswered (M10.11). */}
+          <Link
+            to="/como-participar#fora-do-ranking"
+            className="focus-glow rounded font-mono text-xs text-white/50 transition-colors hover:text-white"
+          >
+            Não apareço aqui, porquê?
+          </Link>
+        </div>
+      </PageHeader>
 
-      {state === "loading" && (
-        <div className="mt-6 space-y-2" aria-hidden>
-          {Array.from({ length: 8 }, (_, i) => i).map((key) => (
-            <div key={key} className="chamfer h-12 animate-pulse border border-surface-border bg-surface" />
-          ))}
-        </div>
-      )}
-      {state === "error" && (
-        <div className="mt-6">
-          <ApiError what="o leaderboard" />
-        </div>
-      )}
-      {state === "empty" && (
-        <div className="mt-6">
-          <EmptyState>Sem troféus registados ainda.</EmptyState>
-        </div>
-      )}
+      <div className="mx-auto max-w-6xl px-4 py-10">
+        {board.state === "loading" && (
+          <>
+            <SkeletonRow tiles={3} className="grid grid-cols-1 gap-4 sm:grid-cols-3" />
+            <div className="mt-10">
+              <SkeletonRows rows={8} />
+            </div>
+          </>
+        )}
 
-      {state === "ready" && data && (
-        <ol className="mt-6 divide-y divide-surface-border border border-surface-border">
-          {data.leaderboard.map((entry) => (
-            <li
-              key={entry.rank}
-              className={`flex items-center justify-between border-l-2 px-4 py-3 ${
-                RANK_BORDER[entry.rank] ?? "border-transparent"
-              }`}
-            >
-              <span className="flex items-center gap-4">
-                <span className={`w-8 text-right font-display text-lg ${RANK_TEXT[entry.rank] ?? "text-white/50"}`}>
-                  {entry.rank}
-                </span>
-                {entry.psnProfile ? (
-                  <a
-                    href={psnProfileUrl(entry.psnProfile)}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="focus-glow hover:underline"
+        {board.state === "error" && <ApiError what="o ranking" />}
+
+        {board.state === "empty" && <EmptyState>Sem troféus registados ainda.</EmptyState>}
+
+        {board.state === "ready" && (
+          <>
+            <section aria-labelledby="podio">
+              <h2 id="podio" className="sr-only">
+                Pódio
+              </h2>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                {podium.map((entry) => (
+                  <PlayerCard
+                    key={entry.rank}
+                    rank={entry.rank}
+                    psnProfile={entry.psnProfile}
+                    points={entry.points}
+                    trophyCount={entry.trophyCount}
+                    featured
+                  />
+                ))}
+              </div>
+            </section>
+
+            <section aria-labelledby="tabela" className="mt-14">
+              <div className="flex flex-wrap items-end justify-between gap-4 border-b border-surface-border pb-4">
+                <h2 id="tabela" className="font-display text-3xl font-extrabold uppercase">
+                  A tabela
+                </h2>
+                <SearchField
+                  value={query}
+                  onChange={(next) => {
+                    setQuery(next);
+                    setVisible(PAGE_SIZE);
+                  }}
+                  label="Procurar caçador"
+                  placeholder="Procurar caçador…"
+                />
+              </div>
+
+              <p className="mt-4 font-mono text-xs text-white/40">
+                <span className="tabular text-white">{filtered.length.toLocaleString("pt-PT")}</span>
+                {query.trim() !== "" && <> de {rest.length.toLocaleString("pt-PT")}</>} caçadores · top {BOARD_SIZE}
+              </p>
+
+              {filtered.length === 0 ? (
+                <div className="mt-6">
+                  <EmptyState>Nenhum caçador corresponde a “{query.trim()}”.</EmptyState>
+                </div>
+              ) : (
+                <ol className="mt-4 space-y-1.5">
+                  {filtered.slice(0, visible).map((entry) => (
+                    <li key={entry.rank}>
+                      <HunterRow
+                        rank={entry.rank}
+                        psnProfile={entry.psnProfile}
+                        points={entry.points}
+                        trophyCount={entry.trophyCount}
+                        topPoints={topPoints}
+                      />
+                    </li>
+                  ))}
+                </ol>
+              )}
+
+              {visible < filtered.length && (
+                <div className="mt-6 text-center">
+                  <button
+                    type="button"
+                    onClick={() => setVisible((count) => count + PAGE_SIZE)}
+                    className="focus-glow rounded-lg border border-surface-border px-6 py-2.5 font-mono text-xs tracking-wide text-white/70 transition-colors hover:border-white/30 hover:text-white"
                   >
-                    {entry.psnProfile}
-                    <span aria-hidden className="ml-1 text-white/40">
-                      ↗
-                    </span>
-                    <span className="sr-only"> (abre o perfil no PSNProfiles)</span>
-                  </a>
-                ) : (
-                  <span>Perfil sem nome</span>
-                )}
-              </span>
-              <span className="text-sm text-white/60">
-                {entry.points.toLocaleString("pt-PT")} pts · {entry.trophyCount} troféus
-              </span>
-            </li>
-          ))}
-        </ol>
-      )}
+                    Mostrar mais ({filtered.length - visible} restantes)
+                  </button>
+                </div>
+              )}
+            </section>
+          </>
+        )}
+      </div>
     </div>
+  );
+}
+
+function HunterRow({
+  rank,
+  psnProfile,
+  points,
+  trophyCount,
+  topPoints,
+}: {
+  rank: number;
+  psnProfile: string | null;
+  points: number;
+  trophyCount: number;
+  topPoints: number;
+}) {
+  const width = topPoints > 0 ? Math.max(2, Math.round((points / topPoints) * 100)) : 0;
+
+  const inner = (
+    <>
+      <span className="tabular w-10 shrink-0 text-right font-display text-2xl leading-none font-extrabold text-white/25">
+        {rank}
+      </span>
+
+      {psnProfile ? <Monogram name={psnProfile} /> : <span aria-hidden className="h-9 w-9 shrink-0 rounded-lg bg-white/10" />}
+
+      <span className="min-w-0 flex-1">
+        <span className="block truncate font-semibold">{psnProfile ?? "Perfil sem nome"}</span>
+        <span className="mt-1.5 block h-1 overflow-hidden rounded-full bg-white/8">
+          <span
+            className="block h-full rounded-full bg-gradient-to-r from-accent-mint to-accent-blue"
+            style={{ width: `${width}%` }}
+          />
+        </span>
+      </span>
+
+      <span className="shrink-0 text-right">
+        <span className="tabular block font-display text-xl leading-none font-extrabold">
+          {points.toLocaleString("pt-PT")}
+        </span>
+        <span className="mt-1 block font-mono text-[10px] text-white/40">
+          {trophyCount.toLocaleString("pt-PT")} platinas
+        </span>
+      </span>
+    </>
+  );
+
+  const className =
+    "shine flex items-center gap-3 rounded-xl border border-surface-border bg-surface px-4 py-3 transition-colors hover:border-white/25 sm:gap-4";
+
+  if (!psnProfile) return <div className={className}>{inner}</div>;
+
+  return (
+    <Link to={`/trophies/${encodeURIComponent(psnProfile)}`} className={`focus-glow ${className}`}>
+      {inner}
+    </Link>
   );
 }

--- a/portal/web/tests/psn.test.ts
+++ b/portal/web/tests/psn.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { gameFromTrophyUrl, monogram, monogramColor, psnProfileUrl } from "../src/lib/psn";
+
+/**
+ * The hunter page's whole game list is derived from these functions — there
+ * is no game column in the schema, only `trophies.url` — so a regression here
+ * silently turns every platinum into an unnamed "Platina" rather than
+ * throwing. Hence tests against the real URL shapes the bot stores.
+ */
+describe("gameFromTrophyUrl", () => {
+  test("recovers id, slug and a readable title from a stored trophy URL", () => {
+    const game = gameFromTrophyUrl("https://psnprofiles.com/trophies/11783-assassins-creed-valhalla/Josh_Lopes");
+
+    expect(game).not.toBeNull();
+    expect(game?.id).toBe("11783");
+    expect(game?.slug).toBe("assassins-creed-valhalla");
+    expect(game?.title).toBe("Assassins Creed Valhalla");
+    // The game's own page — the profile segment is dropped.
+    expect(game?.url).toBe("https://psnprofiles.com/trophies/11783-assassins-creed-valhalla");
+  });
+
+  test("upper-cases roman numerals instead of title-casing them", () => {
+    expect(gameFromTrophyUrl("https://psnprofiles.com/trophies/12-grand-theft-auto-iv/Zephyr-pt")?.title).toBe(
+      "Grand Theft Auto IV",
+    );
+  });
+
+  test("keeps small words lower-case mid-title but not at the start", () => {
+    expect(gameFromTrophyUrl("https://psnprofiles.com/trophies/1-the-last-of-us/Someone")?.title).toBe(
+      "The Last of Us",
+    );
+  });
+
+  test("handles a URL with no trailing profile segment", () => {
+    expect(gameFromTrophyUrl("https://psnprofiles.com/trophies/11783-assassins-creed-valhalla")?.title).toBe(
+      "Assassins Creed Valhalla",
+    );
+  });
+
+  test("returns null rather than inventing a title for anything unrecognised", () => {
+    expect(gameFromTrophyUrl(null)).toBeNull();
+    expect(gameFromTrophyUrl("")).toBeNull();
+    expect(gameFromTrophyUrl("https://psnprofiles.com/Josh_Lopes")).toBeNull();
+    expect(gameFromTrophyUrl("not a url at all")).toBeNull();
+    // No numeric id in the path segment — not the shape we know how to read.
+    expect(gameFromTrophyUrl("https://psnprofiles.com/trophies/assassins-creed/Josh")).toBeNull();
+  });
+});
+
+describe("psnProfileUrl", () => {
+  test("encodes the profile, which is un-validated free text in the database", () => {
+    expect(psnProfileUrl("Josh_Lopes")).toBe("https://psnprofiles.com/Josh_Lopes");
+    expect(psnProfileUrl("a b/c")).toBe("https://psnprofiles.com/a%20b%2Fc");
+  });
+});
+
+describe("monogram", () => {
+  test("takes the first character, upper-cased", () => {
+    expect(monogram("rui_pt")).toBe("R");
+    expect(monogram("  spaced")).toBe("S");
+  });
+
+  test("falls back to ? for an empty name rather than rendering blank", () => {
+    expect(monogram("")).toBe("?");
+    expect(monogram("   ")).toBe("?");
+  });
+
+  test("is stable: the same name always gets the same colour", () => {
+    expect(monogramColor("rui_pt")).toBe(monogramColor("rui_pt"));
+    // And it is always one of the four brand accents, never an invented fifth.
+    expect(monogramColor("anything")).toMatch(/^var\(--color-accent-(blue|mint|yellow|red)\)$/);
+  });
+});


### PR DESCRIPTION
## Summary

Redesigns the portal web interface around collectible cards as a core interaction model, adds hunter/player detail pages with real data filters, and enhances the visual presentation with holographic card effects and improved layouts.

- Portal card-based redesign with hunter detail pages
- Real trophy and ad filtering capabilities
- Enhanced visual design with brand integration
- PSN API utilities for player data

## Test plan

- [ ] Portal loads and renders collectible cards
- [ ] Hunter detail pages display correctly
- [ ] Marketplace and trophy filters work
- [ ] Screenshots and ad cards render properly
- [ ] Layout responsive on mobile
- [ ] API client integrates correctly
- [ ] No regressions in existing pages