### PR TITLE
fix(infra): make the trophy crawl survive a deploy, and stop it starving profiles

### DIFF
--- a/discord-bot/src/Infrastructure/Job/Jobs/TrophiesSyncJob.ts
+++ b/discord-bot/src/Infrastructure/Job/Jobs/TrophiesSyncJob.ts
@@ -281,12 +281,22 @@ interface NewTrophyAnnouncement {
 @injectable()
 export class TrophiesSyncJob implements Job {
     public readonly name = 'trophies:sync';
-    // Matches the old bot's `@every 10m` cadence (scheduler/config.ini,
-    // commented out there — this is the first time it actually runs).
-    // Whether this schedule is actually registered with the JobRunner is
-    // gated by TROPHIES_SYNC_ENABLED in inversify.config.ts, not here — see
-    // this class's doc comment.
-    public readonly schedule = '*/10 * * * *';
+    // Hourly, not the old bot's `@every 10m`.
+    //
+    // A full pass over the community takes ~16 minutes: every profile costs
+    // at least two PSNProfiles fetches, and the crawler spaces requests 6s
+    // apart because sustained volume is exactly what makes Cloudflare start
+    // issuing challenges that never clear. On a 10-minute schedule a run
+    // would therefore still be in flight when the next one came due, and the
+    // job would crawl a site with no public API continuously, around the
+    // clock — roughly 14,000 requests a day to re-learn facts that change a
+    // few times a week. Overlap protection would prevent damage, but
+    // "permanently running" is not a cadence anyone chose.
+    //
+    // Trophy standings do not need ten-minute latency; hourly leaves the
+    // crawler idle most of the time, which is both politer and less likely
+    // to trip the bot protection this whole feature depends on.
+    public readonly schedule = '0 * * * *';
 
     constructor(
         @inject(TYPES.TrophyProfileRepository)

--- a/discord-bot/tests/Integration/Infrastructure/Job/Jobs/TrophiesSyncJob.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Job/Jobs/TrophiesSyncJob.test.ts
@@ -72,9 +72,12 @@ describe('TrophiesSyncJob', () => {
         await ormClient.$disconnect();
     });
 
-    test('exposes a stable name and the every-10-minutes schedule', () => {
+    test('exposes a stable name and the hourly schedule', () => {
         expect(job.name).toBe('trophies:sync');
-        expect(job.schedule).toBe('*/10 * * * *');
+        // Hourly, not every 10 minutes: a full pass takes ~16 minutes at the
+        // crawler's 6s spacing, so a 10-minute schedule meant the job was
+        // effectively always running. See TrophiesSyncJob's comment.
+        expect(job.schedule).toBe('0 * * * *');
     });
 
     test('catch-up mode: creates newer trophies and stops at the first already-claimed one', async () => {

--- a/infrastructure/game-on-portugal.yaml
+++ b/infrastructure/game-on-portugal.yaml
@@ -31,6 +31,27 @@ services:
       S3_BUCKET: ${S3_BUCKET:-gop-media}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:-gameonportugal}
       S3_SECRET_KEY: ${S3_SECRET_KEY:?set S3_SECRET_KEY in the Portainer stack env (min 8 chars)}
+      # --- Trophy crawl (M7.3) — full detail in docs/psn-crawl.md -----------
+      # PSNProfiles is behind a Cloudflare challenge that cannot be cleared
+      # from a datacenter IP at all, so fetches go through the psn-fetch
+      # sidecar on a residential connection. Unset, the bot falls back to
+      # fetching directly, which fails on every request in production.
+      PSN_FETCH_URL: ${PSN_FETCH_URL:-}
+      PSN_FETCH_TOKEN: ${PSN_FETCH_TOKEN:-}
+      # The sidecar's worst case is a failed challenge (60s) plus a cooldown
+      # (120s) plus a retry, which overruns the client's 120s default and
+      # surfaces as "The operation timed out" mid-walk.
+      PSN_FETCH_TIMEOUT_MS: ${PSN_FETCH_TIMEOUT_MS:-300000}
+      # Both default to OFF on purpose. Merging to `main` deploys, so neither
+      # a job that writes to ~118 real members' profiles nor a feature that
+      # posts publicly may switch itself on as a side effect of a deploy —
+      # they are set in the Portainer stack env by an operator who watched a
+      # dry run first.
+      TROPHIES_SYNC_ENABLED: ${TROPHIES_SYNC_ENABLED:-false}
+      TROPHIES_ANNOUNCE_ENABLED: ${TROPHIES_ANNOUNCE_ENABLED:-false}
+      # #ps-trophy-hall. No default in DiscordChannels.ts — announcements
+      # throw (caught and logged) until this is set.
+      DISCORD_CHANNEL_TROPHIES: ${DISCORD_CHANNEL_TROPHIES:-}
       # Optional Grafana Loki shipping. Leave unset to log to stdout only.
       LOKI_HOST: ${LOKI_HOST:-}
       LOKI_AUTH: ${LOKI_AUTH:-}

--- a/infrastructure/game-on-portugal.yaml
+++ b/infrastructure/game-on-portugal.yaml
@@ -42,6 +42,13 @@ services:
       # (120s) plus a retry, which overruns the client's 120s default and
       # surfaces as "The operation timed out" mid-walk.
       PSN_FETCH_TIMEOUT_MS: ${PSN_FETCH_TIMEOUT_MS:-300000}
+      # One pass over the community costs ~4 budget units per profile (rank
+      # fetch, guild check, trophy-list page, first already-claimed check).
+      # At 54 active profiles that is ~216, so JobRunner's default of 200
+      # starves whichever profiles sort last — they are skipped on every run,
+      # forever. Sized with headroom for new trophies rather than to the
+      # exact current count.
+      JOB_WORK_LIMIT: ${JOB_WORK_LIMIT:-600}
       # Both default to OFF on purpose. Merging to `main` deploys, so neither
       # a job that writes to ~118 real members' profiles nor a feature that
       # posts publicly may switch itself on as a side effect of a deploy —

--- a/infrastructure/psn-fetch/docker-compose.yml
+++ b/infrastructure/psn-fetch/docker-compose.yml
@@ -9,7 +9,9 @@ services:
     restart: unless-stopped
     environment:
       PSN_FETCH_TOKEN: ${PSN_FETCH_TOKEN:?PSN_FETCH_TOKEN is required}
-      MIN_REQUEST_INTERVAL_MS: 1500
+      # See server.js: 1.5s survived a burst but not a real backfill —
+      # Cloudflare escalated after ~40 pages. Sustained volume is the limit.
+      MIN_REQUEST_INTERVAL_MS: 6000
     volumes:
       - psn-fetch-profile:/data
     # Bound to loopback on purpose. The bot reaches this through the reverse

--- a/infrastructure/psn-fetch/server.js
+++ b/infrastructure/psn-fetch/server.js
@@ -26,14 +26,26 @@
 
 const http = require('http');
 const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
 const { chromium } = require('patchright');
 
 const PORT = Number(process.env.PORT || 8791);
 const TOKEN = process.env.PSN_FETCH_TOKEN || '';
 const ALLOWED_ORIGIN = 'https://psnprofiles.com';
-const MIN_REQUEST_INTERVAL_MS = Number(process.env.MIN_REQUEST_INTERVAL_MS || 1500);
+// 1.5s survives a short burst but not a real backfill: in the first
+// production run Cloudflare served ~40 pages happily and then began issuing
+// challenges that never cleared, on URLs it had answered minutes earlier.
+// The limit is sustained volume, not any single request, so the throttle is
+// the thing that has to give. 6s puts a ~1000-page catch-up at roughly 100
+// minutes, which is a fine price for a job that runs unattended.
+const MIN_REQUEST_INTERVAL_MS = Number(process.env.MIN_REQUEST_INTERVAL_MS || 6000);
 const NAV_TIMEOUT_MS = Number(process.env.NAV_TIMEOUT_MS || 60000);
-const CHALLENGE_TIMEOUT_MS = Number(process.env.CHALLENGE_TIMEOUT_MS || 45000);
+const CHALLENGE_TIMEOUT_MS = Number(process.env.CHALLENGE_TIMEOUT_MS || 60000);
+/** After a challenge fails, sit out this long before retrying on a fresh browser. */
+const COOLDOWN_MS = Number(process.env.COOLDOWN_MS || 120000);
+/** Attempts per request, including the first. Each retry gets a new browser context. */
+const MAX_ATTEMPTS = Number(process.env.MAX_ATTEMPTS || 2);
 const PROFILE_DIR = process.env.PROFILE_DIR || '/data/profile';
 
 if (!TOKEN) {
@@ -53,15 +65,54 @@ function tokenMatches(presented) {
 }
 
 let browserContext = null;
+/** Guards against two concurrent relaunches racing for the same profile lock. */
+let launching = null;
 let lastRequestAt = 0;
 /** Serialises navigations: each request chains onto the previous one. */
 let queue = Promise.resolve();
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+/**
+ * Chromium leaves `SingletonLock`/`SingletonCookie`/`SingletonSocket` in the
+ * profile directory and refuses to start if they name a process that is gone.
+ * Because the profile lives on a volume that outlives the container, any
+ * ungraceful stop (`docker compose up` recreating this service, an OOM kill)
+ * strands them and every subsequent launch fails with "Target page, context
+ * or browser has been closed" — which reads like a bug in this code rather
+ * than leftover state. They are only ever valid for a live browser we own, so
+ * clearing them before each launch is safe.
+ */
+function clearStaleProfileLocks() {
+  for (const name of ['SingletonLock', 'SingletonCookie', 'SingletonSocket']) {
+    try {
+      fs.rmSync(path.join(PROFILE_DIR, name), { force: true });
+    } catch (error) {
+      log('profile.lock-cleanup-failed', { name, error: error.message });
+    }
+  }
+}
+
 async function getContext() {
   if (browserContext) return browserContext;
+  // Serialise launches: the queue makes concurrent requests impossible today,
+  // but a relaunch racing itself would corrupt the profile in a way that is
+  // very hard to diagnose.
+  if (launching) return launching;
 
+  launching = (async () => {
+    clearStaleProfileLocks();
+    return launchContext();
+  })();
+
+  try {
+    return await launching;
+  } finally {
+    launching = null;
+  }
+}
+
+async function launchContext() {
   // Headed (under xvfb) and persistent, both load-bearing: headless is
   // detected outright, and a persistent profile keeps the clearance cookie
   // so most requests skip the challenge entirely.
@@ -82,7 +133,49 @@ async function getContext() {
   return browserContext;
 }
 
+/**
+ * Drops the browser so the next request starts a fresh one. Cloudflare's
+ * clearance lives in the browser profile, so once it has decided this
+ * session is suspicious, reusing the same context just replays the failure —
+ * a relaunch is what actually re-earns clearance.
+ */
+async function recycleContext(reason) {
+  log('browser.recycling', { reason });
+  const ctx = browserContext;
+  browserContext = null;
+  if (ctx) {
+    await ctx.close().catch(() => {});
+  }
+  // Chromium releases the profile lock asynchronously after close() resolves;
+  // relaunching immediately hits the very stale-lock failure above.
+  await sleep(3000);
+  clearStaleProfileLocks();
+}
+
 async function fetchPage(url) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      return await attemptFetch(url);
+    } catch (error) {
+      lastError = error;
+      if (attempt >= MAX_ATTEMPTS) break;
+
+      // Only a challenge failure is worth the expensive recovery; a genuine
+      // 404 or a navigation error would just fail again more slowly.
+      if (!/challenge did not clear/i.test(error.message)) break;
+
+      log('fetch.retrying', { url, attempt, cooldownMs: COOLDOWN_MS });
+      await recycleContext('challenge did not clear');
+      await sleep(COOLDOWN_MS);
+    }
+  }
+
+  throw lastError;
+}
+
+async function attemptFetch(url) {
   const elapsed = Date.now() - lastRequestAt;
   if (elapsed < MIN_REQUEST_INTERVAL_MS) {
     await sleep(MIN_REQUEST_INTERVAL_MS - elapsed);


### PR DESCRIPTION
**The trophy crawl switched itself back off in production, and two more faults only appeared once it ran unattended.** All three are here.

## 1. It didn't survive a deploy

I enabled the crawl by setting six variables in the Portainer stack env. It ran, wrote trophies, announced them — and a few deploys later (#86/#87/#89) it was dead again, logging *"TROPHIES_SYNC_ENABLED is not true"* while all six values sat in Portainer untouched.

The values were never the problem. `game-on-portugal.yaml` never **declared** them, so compose had nothing to pass into the container. Each deploy overwrites Portainer's copy of the stack file with this repo's version, wiping the declarations and leaving the values inert a layer above.

**Anything set only in the stack env is one deploy away from being dropped.**

Worth noting how it hid: `docker exec gop-bot env` showed the variables perfectly, because that reads the container config the exec inherits. Only `/proc/1/environ` — what the bot process actually booted with — and the boot log told the truth.

## 2. Five members would never have synced again

The first unattended run reported `considered: 49, skipped: 5`. It would have reported that forever.

A caught-up profile costs four budget units (rank fetch, guild check, trophy-list page, first already-claimed check). 54 active profiles need ~216 against JobRunner's default of **200**. Budget is spent walking the list in order, so the same tail is skipped every run. Nothing errors; those members just quietly stop existing as far as the crawl is concerned.

`JOB_WORK_LIMIT` now declared at 600 — headroom, not sized to today's exact count.

## 3. It was crawling PSNProfiles around the clock

A full pass takes **~16 minutes** (two fetches minimum per profile, spaced 6s because sustained volume is what makes Cloudflare start issuing challenges that never clear). On the inherited `*/10` schedule the next run came due before the previous finished — continuous crawling of a site with no public API, ~14,000 requests/day, to re-learn facts that change a few times a week.

Overlap protection meant nothing would break, which is exactly why it would have gone unnoticed. **Now hourly.** Standings don't need ten-minute latency, and an idle crawler is both politer and less likely to trip the protection this feature depends on.

## Defaults stay off

```
TROPHIES_SYNC_ENABLED      false
TROPHIES_ANNOUNCE_ENABLED  false
PSN_FETCH_URL / _TOKEN     empty
DISCORD_CHANNEL_TROPHIES   empty
```

Merging to `main` deploys. Neither a job that writes to real members' profiles (including `isBanned`/`isExcluded`, which has no automatic un-flagging) nor a feature that posts publicly may switch itself on as a side effect of a PR landing.

`PSN_FETCH_TIMEOUT_MS` defaults to 300000, not the client's 120000: the sidecar's worst case is a failed challenge (60s) + cooldown (120s) + retry, which overruns two minutes and surfaces mid-walk as `"The operation timed out"`.

## Plus psn-fetch hardening the first backfill forced

- **Throttle 1.5s → 6s** — Cloudflare served ~40 pages happily, then began challenging URLs it had answered minutes earlier
- **Browser recycling + cooldown-retry** — clearance lives in the profile, so reusing a burned session just replays the failure
- **Stale profile-lock cleanup** — the profile volume outlives the container, so an ungraceful stop stranded `SingletonLock` and every later launch failed with *"Target page, context or browser has been closed"*

## Verification

`bun run typecheck` clean, **587 tests pass**, Prettier clean.

Live in production now (applied directly to Portainer), **but that copy is overwritten by the next deploy of `main` unless this merges.**

- **+447 trophies**, 4,971 → 5,418 (Dec 2024 → Aug 2026)
- **27 members** announced the catch-up, 429 trophies / 42,850 TP, 0 failed
- **Scheduled run confirmed working unattended**: `changed: 6, failed: 0, newlyFlagged: []`, 6 announcements posted with no manual step
- **18 profiles auto-excluded** — all verified by hand, since one-profile-per-invocation meant the >10 mass-flag safety valve never engaged. 13 confirmed by Discord's API as having left; 5 have no PSNProfiles rank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)