### PR TITLE
feat(bot): track trophy profile sync progress with lastSyncedAt

### DIFF
--- a/discord-bot/prisma/migrations/20260823000000_add_trophy_profile_last_synced_at/migration.sql
+++ b/discord-bot/prisma/migrations/20260823000000_add_trophy_profile_last_synced_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `trophyprofiles` ADD COLUMN `lastSyncedAt` DATETIME(3) NULL;

--- a/discord-bot/prisma/schema.prisma
+++ b/discord-bot/prisma/schema.prisma
@@ -100,15 +100,21 @@ model Screenshot {
 }
 
 model TrophyProfile {
-  id         String     @id @default(uuid())
-  userId     String?
-  psnProfile String?
-  isBanned   Boolean?   @default(false)
-  hasLeft    Boolean?   @default(false)
-  isExcluded Boolean?   @default(false)
-  createdAt  DateTime   @default(now())
-  updatedAt  DateTime   @updatedAt
-  trophies   Trophies[]
+  id           String     @id @default(uuid())
+  userId       String?
+  psnProfile   String?
+  isBanned     Boolean?   @default(false)
+  hasLeft      Boolean?   @default(false)
+  isExcluded   Boolean?   @default(false)
+  createdAt    DateTime   @default(now())
+  updatedAt    DateTime   @updatedAt
+  // When `trophies:sync` last finished walking this profile on PSNProfiles.
+  // Distinct from `updatedAt`, which only moves when the row itself changes
+  // (creation, or auto-moderation flagging) and so sat frozen in 2022 for
+  // every member the job had never had to flag. Nullable because every
+  // pre-existing row predates the job.
+  lastSyncedAt DateTime?
+  trophies     Trophies[]
 
   @@map("trophyprofiles")
 }

--- a/discord-bot/src/Domain/Trophy/TrophyProfile.ts
+++ b/discord-bot/src/Domain/Trophy/TrophyProfile.ts
@@ -9,6 +9,7 @@ export interface TrophyProfileArray {
     isExcluded: boolean | null;
     createdAt: Date;
     updatedAt: Date;
+    lastSyncedAt?: Date | null;
 }
 
 export class TrophyProfile {
@@ -21,6 +22,16 @@ export class TrophyProfile {
         public readonly isExcluded: boolean | null,
         public readonly createdAt: Date,
         public readonly updatedAt: Date,
+        /**
+         * When `trophies:sync` last finished walking this profile on
+         * PSNProfiles — stamped by `TrophyProfileRepository.markSynced`, not
+         * by any of the write paths that build this entity. `null` means
+         * "never walked by the job", which is the honest state for every row
+         * that predates it. Last and defaulted so the existing positional
+         * call sites (all of which are creating a profile, and so have
+         * nothing to say about syncing) keep compiling unchanged.
+         */
+        public readonly lastSyncedAt: Date | null = null,
     ) {}
 
     public static fromArray(array: TrophyProfileArray): TrophyProfile {
@@ -33,6 +44,7 @@ export class TrophyProfile {
             array.isExcluded,
             array.createdAt,
             array.updatedAt,
+            array.lastSyncedAt ?? null,
         );
     }
 }

--- a/discord-bot/src/Domain/Trophy/TrophyProfileRepository.ts
+++ b/discord-bot/src/Domain/Trophy/TrophyProfileRepository.ts
@@ -11,6 +11,17 @@ export interface TrophyProfileRepository {
 
     delete(id: TrophyProfileId): Promise<void>;
 
+    /**
+     * Stamps `lastSyncedAt` and nothing else — the one write `trophies:sync`
+     * makes for a profile it merely walked without having to moderate it.
+     *
+     * Deliberately not `save()`: this runs once per profile per run, and a
+     * whole-row upsert would make the hourly crawl rewrite every flag it
+     * happens to be holding a stale copy of, turning a bookkeeping stamp
+     * into a chance to clobber a moderation decision made in between.
+     */
+    markSynced(id: TrophyProfileId, syncedAt: Date): Promise<void>;
+
     findByUserId(userId: string): Promise<TrophyProfile | null>;
 
     findByPsnProfile(psnProfile: string): Promise<TrophyProfile | null>;

--- a/discord-bot/src/Domain/Trophy/TrophyProfileRepository.ts
+++ b/discord-bot/src/Domain/Trophy/TrophyProfileRepository.ts
@@ -33,6 +33,12 @@ export interface TrophyProfileRepository {
      * excluded (auto-moderation flag, or manual) simply stops appearing
      * here on the next run, which is also why the sync job never needs to
      * "un-consider" a profile explicitly.
+     *
+     * Ordered by `lastSyncedAt` ascending (never-synced first, then
+     * longest-stale) so a run whose work-limit budget runs out before a
+     * full pass spends it on the profiles most overdue, rather than always
+     * re-considering the same prefix in whatever order the table returns
+     * them.
      */
     findAllNonExcluded(): Promise<TrophyProfile[]>;
 }

--- a/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.ts
+++ b/discord-bot/src/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.ts
@@ -58,7 +58,7 @@ export class CheckTrophyProfileSubcommand {
                         name: '📅 Datas',
                         value: [
                             `🆕 Registado: ${profile.createdAt.toLocaleDateString('pt-PT')}`,
-                            `🔄 Última atualização: ${profile.updatedAt.toLocaleDateString('pt-PT')}`,
+                            `🔄 Última sincronização: ${formatLastSynced(profile.lastSyncedAt)}`,
                         ].join('\n'),
                         inline: true,
                     },
@@ -141,4 +141,26 @@ export class CheckTrophyProfileSubcommand {
             return '⚠️ Não foi possível obter o rank em tempo real neste momento.';
         }
     }
+}
+
+/**
+ * This line used to render `profile.updatedAt`, which sounds like "when we
+ * last checked your trophies" but is really "when this row was last
+ * written" — and the row is only written on creation or auto-moderation.
+ * A member who had never been flagged therefore saw a date from whenever the
+ * legacy bot last touched them (2022, for most of the community), which read
+ * as the bot having quietly stopped tracking them. `lastSyncedAt` is stamped
+ * by `TrophiesSyncJob` on every completed walk, so it answers the question
+ * the label implies.
+ *
+ * `null` is not an error state: it is every profile the job has not yet
+ * walked — all of them before this shipped, and any new profile until the
+ * next hourly run — so it gets a plain "not yet" rather than a warning.
+ */
+function formatLastSynced(lastSyncedAt: Date | null): string {
+    if (lastSyncedAt === null) {
+        return 'ainda não sincronizado';
+    }
+
+    return lastSyncedAt.toLocaleDateString('pt-PT');
 }

--- a/discord-bot/src/Infrastructure/Job/Jobs/TrophiesSyncJob.ts
+++ b/discord-bot/src/Infrastructure/Job/Jobs/TrophiesSyncJob.ts
@@ -566,6 +566,21 @@ export class TrophiesSyncJob implements Job {
             announcementBudget,
         );
 
+        // Reached only by a profile whose walk ran to completion: the two
+        // moderation paths above return early (a flagged profile was
+        // moderated, not synced), and a throw anywhere in between propagates
+        // to run()'s catch, which counts it `failed`. So `lastSyncedAt`
+        // means "the job last got all the way through this profile", which
+        // is the question `/trophy check` is really asking. Note a walk cut
+        // short by an exhausted `budget` still counts: the job did look at
+        // the profile, and catch-up mode re-walks from the newest trophy
+        // next run regardless.
+        //
+        // Skipped under --dry-run, like every other write in this job.
+        if (!context.dryRun) {
+            await this.trophyProfileRepository.markSynced(profile.id, new Date());
+        }
+
         return { changed, skipped, failed };
     }
 
@@ -700,6 +715,10 @@ export class TrophiesSyncJob implements Job {
             flags.isExcluded ?? profile.isExcluded,
             profile.createdAt,
             new Date(),
+            // Carried through explicitly: `save()` writes this column, and
+            // the constructor defaults it to null, so omitting it here would
+            // silently clear the sync stamp every time a profile is flagged.
+            profile.lastSyncedAt,
         );
 
         await this.trophyProfileRepository.save(updated);

--- a/discord-bot/src/Infrastructure/Orm/OrmTrophyProfileRepository.ts
+++ b/discord-bot/src/Infrastructure/Orm/OrmTrophyProfileRepository.ts
@@ -13,13 +13,18 @@ export class OrmTrophyProfileRepository implements TrophyProfileRepository {
     async save(trophyProfile: TrophyProfile): Promise<void> {
         await this.prismaClient.trophyProfile.upsert({
             where: { id: trophyProfile.id.toString() },
+            // `updatedAt` is deliberately absent here: Prisma's `@updatedAt`
+            // only auto-stamps a field the payload does not mention, so
+            // passing the entity's own (just-loaded, therefore stale) value
+            // back would pin the column forever — which is exactly how it
+            // came to read 2022 on profiles that had been written since.
             update: {
                 userId: trophyProfile.userId,
                 psnProfile: trophyProfile.psnProfile,
                 isBanned: trophyProfile.isBanned,
                 hasLeft: trophyProfile.hasLeft,
                 isExcluded: trophyProfile.isExcluded,
-                updatedAt: trophyProfile.updatedAt,
+                lastSyncedAt: trophyProfile.lastSyncedAt,
             },
             create: {
                 id: trophyProfile.id.toString(),
@@ -30,6 +35,7 @@ export class OrmTrophyProfileRepository implements TrophyProfileRepository {
                 isExcluded: trophyProfile.isExcluded,
                 createdAt: trophyProfile.createdAt,
                 updatedAt: trophyProfile.updatedAt,
+                lastSyncedAt: trophyProfile.lastSyncedAt,
             },
         });
     }
@@ -49,6 +55,13 @@ export class OrmTrophyProfileRepository implements TrophyProfileRepository {
     async delete(id: TrophyProfileId): Promise<void> {
         await this.prismaClient.trophyProfile.delete({
             where: { id: id.toString() },
+        });
+    }
+
+    async markSynced(id: TrophyProfileId, syncedAt: Date): Promise<void> {
+        await this.prismaClient.trophyProfile.update({
+            where: { id: id.toString() },
+            data: { lastSyncedAt: syncedAt },
         });
     }
 

--- a/discord-bot/src/Infrastructure/Orm/OrmTrophyProfileRepository.ts
+++ b/discord-bot/src/Infrastructure/Orm/OrmTrophyProfileRepository.ts
@@ -95,8 +95,16 @@ export class OrmTrophyProfileRepository implements TrophyProfileRepository {
         // (OrmTrophyRepository's ranking queries) — a NULL isExcluded row is
         // treated as excluded by both, so the two never disagree about which
         // profiles are "live".
+        //
+        // `orderBy: lastSyncedAt asc` is what makes that column actually
+        // steer the crawl rather than merely record it: MySQL sorts NULL
+        // first in ascending order, so never-synced profiles lead, then the
+        // longest-stale ones — exactly the set `TrophiesSyncJob.run()`'s
+        // work-limit budget should spend on first when a pass can't cover
+        // every profile in one run.
         const trophyProfiles = await this.prismaClient.trophyProfile.findMany({
             where: { isExcluded: false },
+            orderBy: { lastSyncedAt: 'asc' },
         });
 
         return trophyProfiles.map((trophyProfile) =>

--- a/discord-bot/tests/Helper/StaticFixtures.ts
+++ b/discord-bot/tests/Helper/StaticFixtures.ts
@@ -54,6 +54,7 @@ export const createTrophyProfile = async (
     isBanned?: boolean,
     hasLeft?: boolean,
     isExcluded?: boolean,
+    lastSyncedAt?: Date | null,
 ): Promise<TrophyProfile> => {
     const trophyProfile = new TrophyProfile(
         id ?? TrophyProfileId.generate(),
@@ -64,6 +65,9 @@ export const createTrophyProfile = async (
         isExcluded ?? false,
         new Date(),
         new Date(),
+        // Defaults to null, matching a profile `trophies:sync` has never
+        // walked — which is what a freshly created profile actually is.
+        lastSyncedAt ?? null,
     );
 
     await myContainer

--- a/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.test.ts
@@ -77,7 +77,7 @@ describe('CheckTrophyProfileSubcommand Integration Test', () => {
         expect(rankField.value).toContain('12');
     });
 
-    it('shows the sync stamp, not the row\'s updatedAt, in the dates field', async () => {
+    it("shows the sync stamp, not the row's updatedAt, in the dates field", async () => {
         const userId = '444444444444444444';
         const lastSyncedAt = new Date('2026-08-22T09:30:00.000Z');
         await createTrophyProfile(

--- a/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Bot/Discord/SlashCommand/Trophy/CheckTrophyProfileSubcommand.test.ts
@@ -77,6 +77,51 @@ describe('CheckTrophyProfileSubcommand Integration Test', () => {
         expect(rankField.value).toContain('12');
     });
 
+    it('shows the sync stamp, not the row\'s updatedAt, in the dates field', async () => {
+        const userId = '444444444444444444';
+        const lastSyncedAt = new Date('2026-08-22T09:30:00.000Z');
+        await createTrophyProfile(
+            undefined,
+            userId,
+            'SyncedPsnUser',
+            false,
+            false,
+            false,
+            lastSyncedAt,
+        );
+        fakeTrophySource.setRank('SyncedPsnUser', { worldRank: 10, countryRank: 2 });
+
+        const interaction = new FakeInteraction({}, userId);
+
+        await checkTrophyProfileSubcommand.handle(buildContext(interaction));
+
+        const embedJson = interaction.editReplyCalls[0].embeds[0].toJSON();
+        const datesField = embedJson.fields.find(
+            (field: { name: string }) => field.name === '📅 Datas',
+        );
+        expect(datesField.value).toContain('Última sincronização');
+        expect(datesField.value).toContain(lastSyncedAt.toLocaleDateString('pt-PT'));
+    });
+
+    it('says a profile is not yet synced rather than showing a misleading date', async () => {
+        const userId = '555555555555555555';
+        // No lastSyncedAt: exactly the state of every profile that predates
+        // TrophiesSyncJob, which is what used to render a 2022 date under a
+        // "última atualização" label.
+        await createTrophyProfile(undefined, userId, 'NeverSyncedPsnUser');
+        fakeTrophySource.setRank('NeverSyncedPsnUser', { worldRank: 10, countryRank: 2 });
+
+        const interaction = new FakeInteraction({}, userId);
+
+        await checkTrophyProfileSubcommand.handle(buildContext(interaction));
+
+        const embedJson = interaction.editReplyCalls[0].embeds[0].toJSON();
+        const datesField = embedJson.fields.find(
+            (field: { name: string }) => field.name === '📅 Datas',
+        );
+        expect(datesField.value).toContain('ainda não sincronizado');
+    });
+
     it('does not call the live TrophySource for a banned profile, and shows a banned message', async () => {
         const userId = '111111111111111111';
         await createTrophyProfile(undefined, userId, 'BannedPsnUser', true, false, false);

--- a/discord-bot/tests/Integration/Infrastructure/Job/Jobs/TrophiesSyncJob.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Job/Jobs/TrophiesSyncJob.test.ts
@@ -115,6 +115,7 @@ describe('TrophiesSyncJob', () => {
         const stored = await trophyProfileRepository.get(profile.id);
         expect(stored.isBanned).toBe(false);
         expect(stored.isExcluded).toBe(false);
+        expect(stored.lastSyncedAt).toBeNull();
     });
 
     test('a --dry-run flag change is also not written', async () => {
@@ -126,6 +127,66 @@ describe('TrophiesSyncJob', () => {
         const stored = await trophyProfileRepository.get(profile.id);
         expect(stored.isBanned).toBe(false);
         expect(stored.isExcluded).toBe(false);
+    });
+
+    test('stamps lastSyncedAt on a profile it walked to completion', async () => {
+        const profile = await createTrophyProfile(undefined, 'user-sync-1', 'StampedUser');
+        trophySource.setTrophyPages('StampedUser', [['url-s']]);
+        trophySource.setTrophyData('url-s', { percentage: 5, completionDate: new Date() });
+        const before = Date.now();
+
+        await job.run(context());
+
+        const stored = await trophyProfileRepository.get(profile.id);
+        expect(stored.lastSyncedAt).not.toBeNull();
+        expect(stored.lastSyncedAt!.getTime()).toBeGreaterThanOrEqual(before - 1000);
+    });
+
+    test('stamps lastSyncedAt even when the walk found nothing new', async () => {
+        // The steady state, and the whole point of the column: a member with
+        // no new platinum still wants to see the bot checked on them today,
+        // not a date from whenever their row was last written.
+        const profile = await createTrophyProfile(undefined, 'user-sync-2', 'QuietUser');
+        trophySource.setTrophyPages('QuietUser', [[]]);
+
+        const result = await job.run(context());
+
+        expect(result.changed).toBe(0);
+        const stored = await trophyProfileRepository.get(profile.id);
+        expect(stored.lastSyncedAt).not.toBeNull();
+    });
+
+    test('does not stamp lastSyncedAt on a profile it flagged instead of walking', async () => {
+        const profile = await createTrophyProfile(undefined, 'user-sync-3', 'NoRankUser');
+        trophySource.setNoRank('NoRankUser');
+
+        await job.run(context());
+
+        const stored = await trophyProfileRepository.get(profile.id);
+        expect(stored.isBanned).toBe(true);
+        expect(stored.lastSyncedAt).toBeNull();
+    });
+
+    test('flagging a profile preserves a lastSyncedAt stamped by an earlier run', async () => {
+        const syncedAt = new Date('2026-08-20T08:00:00.000Z');
+        const profile = await createTrophyProfile(
+            undefined,
+            'user-sync-4',
+            'LaterBannedUser',
+            false,
+            false,
+            false,
+            syncedAt,
+        );
+        trophySource.setNoRank('LaterBannedUser');
+
+        await job.run(context());
+
+        const stored = await trophyProfileRepository.get(profile.id);
+        expect(stored.isBanned).toBe(true);
+        // writeFlags goes through save(), which writes this column — the
+        // stamp must survive being moderated.
+        expect(stored.lastSyncedAt?.toISOString()).toBe(syncedAt.toISOString());
     });
 
     test('respects the work limit: later profiles are skipped, not silently dropped', async () => {

--- a/discord-bot/tests/Integration/Infrastructure/Orm/OrmTrophyProfileRepository.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Orm/OrmTrophyProfileRepository.test.ts
@@ -5,6 +5,7 @@ import { TYPES } from '../../../../src/Infrastructure/DependencyInjection/types'
 import type { TrophyProfileRepository } from '../../../../src/Domain/Trophy/TrophyProfileRepository';
 import DatabaseUtil from '../../../Helper/DatabaseUtil';
 import { createTrophyProfile } from '../../../Helper/StaticFixtures';
+import { TrophyProfile } from '../../../../src/Domain/Trophy/TrophyProfile';
 
 /**
  * M7.3: `findAllNonExcluded` is the candidate set `TrophiesSyncJob` walks
@@ -54,5 +55,79 @@ describe('OrmTrophyProfileRepository — findAllNonExcluded', () => {
         const result = await trophyProfileRepository.findAllNonExcluded();
 
         expect(result).toEqual([]);
+    });
+
+    test('markSynced stamps lastSyncedAt and touches nothing else', async () => {
+        const profile = await createTrophyProfile(undefined, 'user-5', 'ToSync', false, true, false);
+        expect(profile.lastSyncedAt).toBeNull();
+
+        const syncedAt = new Date('2026-08-23T10:00:00.000Z');
+        await trophyProfileRepository.markSynced(profile.id, syncedAt);
+
+        const reloaded = await trophyProfileRepository.get(profile.id);
+        expect(reloaded.lastSyncedAt?.toISOString()).toBe(syncedAt.toISOString());
+        // The flags this run was not asked to change must survive untouched
+        // — the reason markSynced is a narrow update and not a save().
+        expect(reloaded.hasLeft).toBe(true);
+        expect(reloaded.isBanned).toBe(false);
+        expect(reloaded.psnProfile).toBe('ToSync');
+    });
+
+    test('save() lets updatedAt advance instead of pinning it to a stale value', async () => {
+        const profile = await createTrophyProfile(undefined, 'user-6', 'ToUpdate');
+        const originalUpdatedAt = (await trophyProfileRepository.get(profile.id)).updatedAt;
+
+        // A round-trip: load, change one flag, save. The entity carries the
+        // updatedAt it was loaded with, and the repository used to write it
+        // straight back, freezing the column forever.
+        const loaded = await trophyProfileRepository.get(profile.id);
+        await trophyProfileRepository.save(
+            new TrophyProfile(
+                loaded.id,
+                loaded.userId,
+                loaded.psnProfile,
+                true,
+                loaded.hasLeft,
+                loaded.isExcluded,
+                loaded.createdAt,
+                loaded.updatedAt,
+                loaded.lastSyncedAt,
+            ),
+        );
+
+        const reloaded = await trophyProfileRepository.get(profile.id);
+        expect(reloaded.isBanned).toBe(true);
+        expect(reloaded.updatedAt.getTime()).toBeGreaterThan(originalUpdatedAt.getTime());
+    });
+
+    test('save() preserves an existing lastSyncedAt it was handed', async () => {
+        const syncedAt = new Date('2026-08-23T11:00:00.000Z');
+        const profile = await createTrophyProfile(
+            undefined,
+            'user-7',
+            'Flagged',
+            false,
+            false,
+            false,
+            syncedAt,
+        );
+
+        const loaded = await trophyProfileRepository.get(profile.id);
+        await trophyProfileRepository.save(
+            new TrophyProfile(
+                loaded.id,
+                loaded.userId,
+                loaded.psnProfile,
+                true,
+                loaded.hasLeft,
+                loaded.isExcluded,
+                loaded.createdAt,
+                loaded.updatedAt,
+                loaded.lastSyncedAt,
+            ),
+        );
+
+        const reloaded = await trophyProfileRepository.get(profile.id);
+        expect(reloaded.lastSyncedAt?.toISOString()).toBe(syncedAt.toISOString());
     });
 });

--- a/discord-bot/tests/Integration/Infrastructure/Orm/OrmTrophyProfileRepository.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Orm/OrmTrophyProfileRepository.test.ts
@@ -48,6 +48,44 @@ describe('OrmTrophyProfileRepository — findAllNonExcluded', () => {
         expect(ids).toHaveLength(1);
     });
 
+    test('orders never-synced profiles first, then oldest-synced, so a budget-limited run makes progress', async () => {
+        const recentlySynced = await createTrophyProfile(
+            undefined,
+            'user-8',
+            'RecentlySynced',
+            false,
+            false,
+            false,
+            new Date('2026-08-23T09:00:00.000Z'),
+        );
+        const neverSynced = await createTrophyProfile(
+            undefined,
+            'user-9',
+            'NeverSynced',
+            false,
+            false,
+            false,
+            null,
+        );
+        const staleSynced = await createTrophyProfile(
+            undefined,
+            'user-10',
+            'StaleSynced',
+            false,
+            false,
+            false,
+            new Date('2026-08-20T09:00:00.000Z'),
+        );
+
+        const result = await trophyProfileRepository.findAllNonExcluded();
+
+        expect(result.map((profile) => profile.id.toString())).toEqual([
+            neverSynced.id.toString(),
+            staleSynced.id.toString(),
+            recentlySynced.id.toString(),
+        ]);
+    });
+
     test('returns an empty array when every profile is excluded', async () => {
         await createTrophyProfile(undefined, 'user-3', 'Excluded1', false, false, true);
         await createTrophyProfile(undefined, 'user-4', 'Excluded2', true, false, true);

--- a/discord-bot/tests/Integration/Infrastructure/Orm/OrmTrophyProfileRepository.test.ts
+++ b/discord-bot/tests/Integration/Infrastructure/Orm/OrmTrophyProfileRepository.test.ts
@@ -58,7 +58,14 @@ describe('OrmTrophyProfileRepository — findAllNonExcluded', () => {
     });
 
     test('markSynced stamps lastSyncedAt and touches nothing else', async () => {
-        const profile = await createTrophyProfile(undefined, 'user-5', 'ToSync', false, true, false);
+        const profile = await createTrophyProfile(
+            undefined,
+            'user-5',
+            'ToSync',
+            false,
+            true,
+            false,
+        );
         expect(profile.lastSyncedAt).toBeNull();
 
         const syncedAt = new Date('2026-08-23T10:00:00.000Z');


### PR DESCRIPTION
## Summary

Add a `lastSyncedAt` timestamp to `TrophyProfile` to track when the trophy sync job last processed each profile on PSNProfiles. This field is distinct from `updatedAt`, which only changes when the profile row itself is modified.

## Changes

- Add `lastSyncedAt: DateTime?` column to TrophyProfile schema
- Update TrophyProfile domain entity with optional lastSyncedAt field
- Add migration to alter TrophyProfile table
- Update ORM repository to persist and query sync timestamps
- Update job and subcommand to work with the new field

## Why

The `trophies:sync` job needs to distinguish between:
- Profiles that have never been synced (pre-existing rows, null lastSyncedAt)
- Profiles recently synced (lastSyncedAt updated on each run)
- Profiles pending sync (lastSyncedAt older than some threshold)

This prevents the job from starving old profiles and allows resuming sync progress across deployments.

## Test plan

- [x] Type check passes
- [x] Integration tests pass for TrophyProfileRepository
- [x] Integration tests pass for TrophiesSyncJob
- [x] Integration tests pass for CheckTrophyProfileSubcommand
- [x] Database schema matches migrations